### PR TITLE
Refactor and improve comments for custom captcha classes

### DIFF
--- a/zanata-war/src/main/java/org/zanata/validation/PatchedCaptcha.java
+++ b/zanata-war/src/main/java/org/zanata/validation/PatchedCaptcha.java
@@ -25,20 +25,21 @@ import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
 
 /**
- * Like {@link org.jboss.seam.captcha.Captcha} but uses the fixed
- * {@link org.zanata.validation.CaptchaResponse} to avoid a bug in the original.
+ * Like {@link org.jboss.seam.captcha.Captcha} but uses the patched
+ * {@link org.zanata.validation.PatchedCaptchaResponse} to avoid a bug in the
+ * original.
  * 
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  * 
- * @see CaptchaResponse
+ * @see PatchedCaptchaResponse
  */
 @Name("org.jboss.seam.captcha.captcha")
 @Scope(ScopeType.SESSION)
-public class Captcha extends org.jboss.seam.captcha.Captcha
+public class PatchedCaptcha extends org.jboss.seam.captcha.Captcha
 {
    private static final long serialVersionUID = 1L;
 
-   @CaptchaResponse
+   @PatchedCaptchaResponse
    public String getCaptchaResponse()
    {
       return super.getResponse();

--- a/zanata-war/src/main/java/org/zanata/validation/PatchedCaptchaResponse.java
+++ b/zanata-war/src/main/java/org/zanata/validation/PatchedCaptchaResponse.java
@@ -29,18 +29,18 @@ import java.lang.annotation.Target;
 import javax.validation.Constraint;
 
 /**
- * Like {@link org.jboss.seam.captcha.CaptchaResponse} but uses the fixed
- * {@link CaptchaResponseValidator} to avoid a bug in the original.
+ * Like {@link org.jboss.seam.captcha.CaptchaResponse} but uses the patched
+ * {@link PatchedCaptchaResponseValidator} to avoid a bug in the original.
  * 
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  * 
- * @see CaptchaResponseValidator
+ * @see PatchedCaptchaResponseValidator
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Target(ElementType.METHOD)
-@Constraint(validatedBy = CaptchaResponseValidator.class)
-public @interface CaptchaResponse
+@Constraint(validatedBy = PatchedCaptchaResponseValidator.class)
+public @interface PatchedCaptchaResponse
 {
    String message() default "incorrect response";
 

--- a/zanata-war/src/main/java/org/zanata/validation/PatchedCaptchaResponseValidator.java
+++ b/zanata-war/src/main/java/org/zanata/validation/PatchedCaptchaResponseValidator.java
@@ -29,11 +29,11 @@ import javax.validation.ConstraintValidatorContext;
  * 
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  */
-public class CaptchaResponseValidator implements ConstraintValidator<CaptchaResponse, String>
+public class PatchedCaptchaResponseValidator implements ConstraintValidator<PatchedCaptchaResponse, String>
 {
    private static final String WRAPPED_MESSAGE_TEMPLATE_IDENTIFIER = "{org.jboss.seam.captcha.error}";
 
-   public void initialize(CaptchaResponse constraintAnnotation)
+   public void initialize(PatchedCaptchaResponse constraintAnnotation)
    {
    }
 
@@ -49,7 +49,7 @@ public class CaptchaResponseValidator implements ConstraintValidator<CaptchaResp
 
    private boolean isCorrect(String response)
    {
-      return Captcha.instance().validateResponse(response);
+      return PatchedCaptcha.instance().validateResponse(response);
    }
 
    private void addConstraintViolationIn(ConstraintValidatorContext context)


### PR DESCRIPTION
Added doc comments that indicate the purpose of these copied classes.
Removed 'Zanata' from 'ZanataCaptcha' since it is redundant (it is already in a zanata package).
Refactored CaptchaResponseValidator to make isValid(...) more readable.
