### PR TITLE
Fix server startup error.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/ZanataInit.java
+++ b/zanata-war/src/main/java/org/zanata/ZanataInit.java
@@ -156,6 +156,17 @@ public class ZanataInit
 
    private void checkLuceneLocks(File indexDir) throws ZanataInitializationException
    {
+      if( !indexDir.exists() )
+      {
+         if(indexDir.mkdirs())
+         {
+            log.info("Created lucene index directory.");
+         }
+         else
+         {
+            log.warn("Could not create lucene index directory");
+         }
+      }
       Collection<File> lockFiles = FileUtils.listFiles(indexDir, new String[]{"lock"}, true);
       Collection<String> lockedDirs = Lists.newArrayList();
       for (File f : lockFiles)


### PR DESCRIPTION
When booting up, the Zanata server performs validation checks on the lucene index directory (if one is provided). When this index is not yet created, this validation will fail. This directory is now being created jsut for validation purposes, and lucene will use it afterwards.
