### PR TITLE
User Registration tests

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/HomePage.java
+++ b/functional-test/src/main/java/org/zanata/page/HomePage.java
@@ -26,6 +26,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.zanata.page.account.RegisterPage;
 import org.zanata.page.administration.AdministrationPage;
 import org.zanata.page.groups.VersionGroupsPage;
 import org.zanata.page.projects.ProjectsPage;
@@ -107,5 +108,13 @@ public class HomePage extends AbstractPage
       WebElement adminLink = getDriver().findElement(By.id("Administration"));
       adminLink.click();
       return new AdministrationPage(getDriver());
+   }
+
+   public RegisterPage goToRegistration()
+   {
+      getDriver().findElement(By.linkText("More")).click();
+      WebElement registerLink = getDriver().findElement(By.id("Register"));
+      registerLink.click();
+      return new RegisterPage(getDriver());
    }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
@@ -1,0 +1,127 @@
+package org.zanata.page.account;
+
+
+import java.util.Map;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.zanata.page.AbstractPage;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Damian Jansen <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+@Slf4j
+public class RegisterPage extends AbstractPage
+{
+
+   @FindBy(id = "registerForm:nameField:name")
+   private WebElement nameField;
+
+   @FindBy(id = "registerForm:emailField:email")
+   private WebElement emailField;
+
+   @FindBy(id = "registerForm:usernameField:username")
+   private WebElement usernameField;
+
+   @FindBy(id = "registerForm:passwordField:password")
+   private WebElement passwordField;
+
+   @FindBy(id = "registerForm:passwordConfirmField:passwordConfirm")
+   private WebElement confirmPasswordField;
+
+   @FindBy(id = "registerForm:captcha:verifyCaptcha")
+   private WebElement captchaField;
+
+   @FindBy(id = "registerForm:agreedToTerms:agreedToTerms")
+   private WebElement termsCheckbox;
+
+   @FindBy(id = "registerForm:registerButton")
+   private WebElement registerButton;
+
+   public RegisterPage(WebDriver driver)
+   {
+      super(driver);
+   }
+
+   public RegisterPage enterName(String name)
+   {
+      nameField.sendKeys(name);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage enterUserName(String userName)
+   {
+      usernameField.sendKeys(userName);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage enterEmail(String email)
+   {
+      emailField.sendKeys(email);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage enterPassword(String password)
+   {
+      passwordField.sendKeys(password);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage enterConfirmPassword(String confirmPassword)
+   {
+      confirmPasswordField.sendKeys(confirmPassword);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage enterCaptcha(String captcha)
+   {
+      captchaField.sendKeys(captcha);
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage clickTerms()
+   {
+      termsCheckbox.click();
+      return new RegisterPage(getDriver());
+   }
+
+   public AbstractPage register()
+   {
+      registerButton.click();
+      return new AbstractPage(getDriver());
+   }
+
+   public RegisterPage registerFailure()
+   {
+      registerButton.click();
+      return new RegisterPage(getDriver());
+   }
+
+   public RegisterPage clearFields()
+   {
+      nameField.clear();
+      emailField.clear();
+      usernameField.clear();
+      passwordField.clear();
+      confirmPasswordField.clear();
+      captchaField.clear();
+      return new RegisterPage(getDriver());
+   }
+
+   /*
+      Pass in a map of strings, to be entered into the registration fields.
+      Fields: name, email, username, password, confirmpassword, captcha
+    */
+   public RegisterPage setFields(Map<String, String> fields)
+   {
+      clearFields();
+      enterName(fields.get("name"));
+      enterEmail(fields.get("email"));
+      enterUserName(fields.get("username"));
+      enterPassword(fields.get("password"));
+      enterConfirmPassword(fields.get("confirmpassword"));
+      enterCaptcha(fields.get("captcha"));
+      return new RegisterPage(getDriver());
+   }
+}

--- a/functional-test/src/main/java/org/zanata/util/RFC2822.java
+++ b/functional-test/src/main/java/org/zanata/util/RFC2822.java
@@ -1,0 +1,277 @@
+package org.zanata.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Damian Jansen <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+public class RFC2822 {
+
+   /*
+    * Definitions
+    * localpart: the section of an address preceding the @ symbol
+    * domain: the section of an address following the @ symbol
+    * label: section of domain between the @ symbol or period and the next period or end e.g example in me@example.com
+    * quote / quoting: a section of the localpart contained within quotation marks
+    *
+    * BUG982048
+    * This defect is an list of all items that, valid or invalid, are not correctly recognised by the email validation
+    * in Zanata.
+    *
+    * Untested:
+    * RFC2822, section 3.4.1
+    * The contents of a bracketed domain can have a \ precede a character to escape it,
+    * and the following character must not be 10 (LF) or 13 (CR).
+    * This allows spaces in the domain as long as they are escaped.
+    *
+    * RFC 2821, section 4.5.3.1
+    * The maximum length of a "useful" email address is 255 characters.
+    *
+    * RFC 3696
+    * The maximum allowable length of an email address is 320 characters.
+    */
+
+   public static Map<String, String> invalidEmailAddresses()
+   {
+      Map<String, String> invalidEmailAddresses = new HashMap<String, String>();
+
+      /*
+       * RFC 2822, section 3.4.1
+       * Email addresses consist of a local part, the "@" symbol, and the domain.
+       */
+      invalidEmailAddresses.put("3.4.1 Plain address", "plainaddress");
+      invalidEmailAddresses.put("3.4.1 Missing @", "email.example.com");
+      invalidEmailAddresses.put("3.4.1 Missing localpart", "@example.com");
+      invalidEmailAddresses.put("3.4.1 Missing domain", "email@");
+      invalidEmailAddresses.put("3.4.1 Two @ sign", "email@example@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * No periods can start or end the local part.
+       * Two periods together is invalid.
+       */
+      invalidEmailAddresses.put("3.4.1 Leading dot", ".email@example.com");
+      invalidEmailAddresses.put("3.4.1 Trailing dot", "email.@example.com");
+      invalidEmailAddresses.put("3.4.1 Multiple dots", "email..email@example.com");
+
+      /*
+       * RFC 2822, section 2.2
+       * All email addresses are in 7-bit US ASCII.
+       */
+      // BUG982048invalidEmailAddresses.put("3.4.1 Non unicode characters", "あいうえお@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * Unquoted local parts can consist of TEXT
+       * TEXT can contain:
+       *    alphabetic
+       *    numeric
+       *    and symbols !#$%'*+-/=?^_`{|}~
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid unquoted character", "test,user@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid unquoted character", "test(user@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid unquoted character", "test)user@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * The quoted local part starts with a quotation mark, ends with a quotation mark.
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid quoting", "test\"user@example.com");
+
+      /*
+       * RFC 2822, section 4.4
+       * If an email is using the obsolete quoting on a per-label basis, then the email address consists of unquoted
+       * or quoted chunks separated by periods
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid quoting", "\"test\"user@example.com");
+      invalidEmailAddresses.put("4.4 Invalid quoting", "\"test\"quote\"user@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * The contents of a quoted local part can not contain characters:
+       *    9 (TAB)
+       *    10 (LF)
+       *    13 (CR)
+       *    32 (space)
+       *    34 (")
+       *    91-94 ([, \, ], ^)
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test,user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test\\user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test[user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test]user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test^user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "\"test\"user\"@example.com");
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "test.\"".concat("\t").concat("\".user@example.com"));
+
+      /*
+       * RFC 2822, section 3.4.1
+       * If the quoted local part has a backslash, the following character is escaped and must not be 10 (LF), 13 (CR).
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "test.\"\\".concat("\r").concat("\".user@example.com"));
+      invalidEmailAddresses.put("3.4.1 Invalid quoted character", "test.\"\\".concat("\n").concat("\".user@example.com"));
+
+      /*
+       * RFC 1035, section 2.3.4
+       * A plain domain consists of labels separated with periods. No period can start or end a domain name.
+       * No two periods in succession can be in a domain name.
+       */
+      invalidEmailAddresses.put("RFC1035-2.3.4 Trailing dot in domain", "email@example.com.");
+      invalidEmailAddresses.put("RFC1035-2.3.4 Leading dot in domain", "email@.example.com");
+      invalidEmailAddresses.put("RFC1035-2.3.4 Multiple dots in domain", "email@example..com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * Bracketed domains must:
+       *    start with [, end with ]
+       *    not contain characters 9 (TAB), 10 (LF), 13 (CR), 32 (space), 91-94 ([, \, ], ^)
+       */
+      invalidEmailAddresses.put("3.4.1 Incorrectly quoted domain", "email@[example].com");
+      invalidEmailAddresses.put("3.4.1 Incorrectly quoted domain", "email@[ex^ample.com]");
+      invalidEmailAddresses.put("3.4.1 Incorrectly quoted domain", "email@[exa\\mple].com");
+
+      /*
+       * RFC 1035, section 2.3.4
+       * The maximum length of a label is 63 characters.
+       */
+      // BUG982048 invalidEmailAddresses.put("RFC1035-2.3.4 Domain label too long",
+      //      "email@IJUr9P6Y7Fx7rFy4sziQDT0qvSC7XKK6jrD0CNC41jorAKgFYIXLTN5ITJLohy58.com");
+
+      /*
+       * RFC 1035, section 2.3.4
+       * A label may contain hyphens, but no two hyphens in a row.
+       * A label must not start nor end with a hyphen.
+       */
+      // BUG982048 invalidEmailAddresses.put("2.3.4 Leading dash in domain", "email@-example.com");
+      // BUG982048 invalidEmailAddresses.put("2.3.4 Trailing dash in domain", "email@example-.com");
+      // BUG982048 invalidEmailAddresses.put("2.3.4 Multiple dashes in domain", "email@exa--mple.com");
+      invalidEmailAddresses.put("2.3.4 Leading dash in bracketed domain", "email@[-example.com]");
+      invalidEmailAddresses.put("2.3.4 Trailing dash in bracketed domain", "email@[example.com-]");
+      invalidEmailAddresses.put("2.3.4 Multiple dashes in bracketed domain", "email@[exa--mple.com]");
+
+      /*
+       * The contents of a bracketed domain can have a \ precede a character to escape it, and the following character
+       * must not be 10 (LF) or 13 (CR).
+       */
+      invalidEmailAddresses.put("3.4.1 Invalid bracketed domain", "test@[\\".concat("\r").concat("example.com]"));
+      invalidEmailAddresses.put("3.4.1 Invalid bracketed domain", "test@[\\".concat("\n").concat("example.com]"));
+
+      /*
+       * RFC 2821, section 4.5.3.1
+       * The maximum length of the local part is 64 characters.
+       */
+      invalidEmailAddresses.put("RFC2821-4.5.3.1 Max localpart length is 64",
+            "emailuhpealgyxntsh5upl5gqn5a4ruqs7mw6wz21j6dn72amzwozqlyua4jx16rd@example.com");
+
+      /*
+       * RFC 3696, section 2
+       * The top level domain must be all alphabetic.
+       */
+      invalidEmailAddresses.put("RFC3696-2 Encoded html", "Joe Smith <email@example.com>");
+      invalidEmailAddresses.put("RFC3696-2 Following text", "email@example.com (Joe Smith)");
+      // BUG982048 invalidEmailAddresses.put("RFC3696-2 Invalid IP", "email@111.222.333.44444");
+
+      /*
+       * RFC 2821, section 4.5.3.1
+       * The maximum length of a "useful" email address is 255 characters.
+       */
+      /*
+       * BUG982048
+      invalidEmailAddresses.put("4.5.3.1 Max email length is 255",
+            "email@"+
+            "Hk3yhCtbBRw3wCT76tL1ryAdfrIaaDszHqvZqnNrZPlNn3Wd7u."+
+            "RfpxrueSghp9dkGTGwT9s0fyJL850Sned72RD3Mm5PpEh6QJwQ."+
+            "3CeXyEHQEhXNOQdWhYVjGBLzlHz1sJfi4lfn7ighLXcxa5cMAK."+
+            "jFXsG8BVsvkODKktTXJ70bQmDWtWQzuh3oz4twumVArDGEbzS1."+
+            "slyaBcQqVgUdqXTBdbMY7YJxZwrzZQBBGjCl4e.com");
+       */
+      return invalidEmailAddresses;
+   }
+
+   /*
+    * An map of valid emails conforming to RFC2822
+    */
+   public static Map<String, String> validEmailAddresses()
+   {
+      Map<String, String> validEmailAddresses = new HashMap<String, String>();
+
+      /*
+       * RFC 2822, section 3.4.1
+       * Email addresses consist of a local part, the "@" symbol, and the domain.
+       */
+      validEmailAddresses.put("3.4.1 Basic email", "email@example.com");
+
+      /*
+       * RFC 2822, sections 3.4.1 and 4.4
+       * The local part can be unquoted, quoted in its entirety, or quoted on a per-label basis.
+       * The quoted local part starts with a quotation mark, ends with a quotation mark.
+       */
+      // BUG982048 validEmailAddresses.put("3.4.1 Basic quoted email", "\"email\"@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * TEXT can contain alphabetic, numeric, and these symbols: !#$%'*+-/=?^_`{|}~
+       */
+      validEmailAddresses.put("3.4.1 Allowed special characters in localpart", "email.!#$%'*+-/=?^_`{|}~.dot@example.com");
+
+      /*
+         RFC 2822, section 4.4
+         If an email is using the obsolete quoting on a per-label basis, then the email address consists of unquoted
+         or quoted chunks separated by periods.
+       */
+      // BUG982048 validEmailAddresses.put("4.4 Quoted label with surrounding labels", "dot.\"email\".dot@example.com");
+      // BUG982048 validEmailAddresses.put("4.4 Localpart with empty quote", "dot.\"\".dot@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * If the quoted local part has a backslash, the following character is escaped and must not be 10 (LF), 13 (CR).
+       * This supersedes the previous rule, allowing spaces and quotation marks in the email address as long as they
+       * are escaped.
+       */
+      // BUG982048 validEmailAddresses.put("3.4.1 Quoted email with escaped special characters", "email.\"(),:;<>\\@\\[\\]\\\\\"@example.com");
+      // BUG982048 validEmailAddresses.put("3.4.1 Quoted email with escaped quotes", "email.\"\\\"\"@example.com");
+      // BUG982048 validEmailAddresses.put("3.4.1 Quoted email with space character", "\"special\\ email\"@example.com");
+
+      /*
+       * RFC 2822, section 3.4.1
+       * The domain can be bracketed or plain.
+       */
+      // BUG982048 validEmailAddresses.put("3.4.1 Email with bracketed domain", "email@[example.com]");
+      // BUG982048 validEmailAddresses.put("3.4.1 Bracketed IPv6 domain", "email@[123.45.67.89]");
+      // BUG982048 validEmailAddresses.put("3.4.1 Bracketed IPv6 domain", "email@[IPv6:2001:2d12:c4fe:5afe::1]");
+
+      /*
+       * RFC 1035, section 2.3.4
+       * A plain domain consists of labels separated with periods. No period can start or end a domain name.
+       */
+      validEmailAddresses.put("RFC1035-2.3.4 Localpart with multiple labels", "another.email@example.com");
+      validEmailAddresses.put("RFC1035-2.3.4 Domain with multiple labels", "email@another.example.com");
+
+      /*
+       * RFC 1035, section 2.3.4
+       * The maximum length of a label is 63 characters.
+       */
+      validEmailAddresses.put("RFC1035-2.3.4 Domain label of 63 characters",
+            "email@B3NQyUsDdzODMoymfDdifn6Wztx2wrivm80LEngHGl182frm6ifCPyv5SntbDg8.com");
+      validEmailAddresses.put("RFC1035-2.3.4 Localpart label of 63 characters",
+            "B3NQyUsDdzODMoymfDdifn6Wztx2wrivm80LEngHGl182frm6ifCPyv5SntbDg8@example.com");
+
+      /*
+       * RFC 1035, section 2.3.4
+       * A label may contain hyphens, but no two hyphens in a row.
+       */
+      validEmailAddresses.put("RFC1035-2.3.4 Hyphenated domain label", "email@another-example.com");
+      validEmailAddresses.put("RFC1035-2.3.4 Hyphenated localpart label", "my-email@example.com");
+
+      /*
+       * RFC 2821, section 4.5.3.1
+       * The maximum length of the local part is 64 characters.
+       */
+      validEmailAddresses.put("RFC1035-2.3.4 Localpart length of 64 characters",
+            "B3NQyUsDdzODMoymfDdifn6Wztx2wrivm.80LEngHGl182frm6ifCPyv5SntbDg8@example.com");
+
+      return validEmailAddresses;
+   }
+}

--- a/functional-test/src/test/java/org/zanata/feature/account/RegisterDetailedTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/RegisterDetailedTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2013, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.feature.account;
+
+import org.hamcrest.Matchers;
+import org.junit.*;
+import org.zanata.page.HomePage;
+import org.zanata.page.account.RegisterPage;
+import org.zanata.util.ResetDatabaseRule;
+import org.zanata.util.RFC2822;
+import org.zanata.workflow.AbstractWebWorkFlow;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Damian Jansen <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+@Slf4j
+public class RegisterDetailedTest
+{
+   @ClassRule
+   public static ResetDatabaseRule resetDatabaseRule = new ResetDatabaseRule(ResetDatabaseRule.Config.WithData, ResetDatabaseRule.Config.NoResetAfter);
+
+   Map<String, String> fields;
+   private HomePage homePage;
+
+   @Before
+   public void before()
+   {
+      // fields contains a set of data that can be successfully registered
+      fields = new HashMap<String, String>();
+
+      // Conflicting fields - must be set for each test function to avoid "not available" errors
+      fields.put("email", "test@test.com");
+      fields.put("username", "testusername");
+
+      fields.put("name", "test");
+      fields.put("password", "testpassword");
+      fields.put("confirmpassword", "testpassword");
+      fields.put("captcha", "555"); // TODO: Expect captcha error, fix
+      homePage = new AbstractWebWorkFlow().goToHome();
+   }
+
+   @Test
+   @Ignore("Captcha prevents test completion")
+   public void registerSuccessful()
+   {
+      RegisterPage registerPage = homePage.goToRegistration();
+      registerPage = registerPage.setFields(fields);
+      assertThat("No errors are shown", registerPage.getErrors().size(), Matchers.equalTo(0));
+      registerPage.register();
+   }
+
+   @Test
+   public void usernameLengthValidation()
+   {
+      String errorMsg = "size must be between 3 and 20";
+      fields.put("email", "length.test@test.com");
+      RegisterPage registerPage = homePage.goToRegistration();
+
+      fields.put("username", "bo");
+      registerPage = registerPage.setFields(fields);
+      assertThat("Size errors are shown for string too short", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+
+      fields.put("username", "testusername");
+      registerPage = registerPage.setFields(fields);
+      assertThat("Size errors are not shown", registerPage.getErrors(), Matchers.not(Matchers.hasItem(errorMsg)));
+
+      fields.put("username", "12345678901234567890a");
+      registerPage = registerPage.setFields(fields);
+      assertThat("Size errors are shown for string too long", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+   }
+
+   @Test
+   public void usernameCharacterValidation()
+   {
+      String errorMsg = "lowercase letters and digits (regex \"^[a-z\\d_]{3,20}$\")";
+      fields.put("email", "character.test@example.com");
+      for (Map.Entry<String, String> entry : usernameCharacterValidationData().entrySet())
+      {
+         log.info("Test " + entry.getKey() + ":" + entry.getValue());
+         fields.put("username", entry.getValue());
+         RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+         assertThat("Validation errors are shown", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+      }
+   }
+
+   @Test
+   @Ignore("Captcha prevents test completion")
+   public void usernamePreExisting()
+   {
+      String errorMsg = "This username is not available";
+      fields.put("email", "exists.test@test.com");
+      fields.put("username", "alreadyexists");
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      registerPage.register();
+
+      fields.put("email", "exists2.test@test.com");
+      registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      assertThat("Username not available message is shown", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+   }
+
+   @Test
+   public void emailValidation()
+   {
+      String errorMsg = "not a well-formed email address";
+      fields.put("username", "emailvalidation");
+      for (Map.Entry<String, String> entry : RFC2822.invalidEmailAddresses().entrySet())
+      {
+         log.info("Test " + entry.getKey() + ":" + entry.getValue());
+         fields.put("email", entry.getValue());
+         RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+         assertThat("Email validation errors are shown", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+      }
+   }
+
+   @Test
+   public void validEmailAcceptance()
+   {
+      String errorMsg = "not a well-formed email address";
+      fields.put("username", "emailvalidation");
+      for (Map.Entry<String, String> entry : RFC2822.validEmailAddresses().entrySet())
+      {
+         log.info("Test " + entry.getKey() + ":" + entry.getValue());
+         fields.put("email", entry.getValue());
+         RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+         assertThat("Email validation errors are not shown", registerPage.getErrors(),
+               Matchers.not(Matchers.hasItem(errorMsg)));
+      }
+   }
+
+   @Test
+   public void rejectIncorrectCaptcha()
+   {
+      String errorMsg = "incorrect response";
+      fields.put("username", "rejectbadcaptcha");
+      fields.put("email", "rejectbadcaptcha@example.com");
+      fields.put("captcha", "9000");
+
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields).registerFailure();
+      assertThat("The Captcha entry is rejected", registerPage.getErrors(), Matchers.contains(errorMsg));
+   }
+
+   @Test
+   public void passwordsMatch()
+   {
+      String errorMsg = "Passwords do not match";
+      fields.put("username", "passwordsmatch");
+      fields.put("email", "passwordsmatchtest@example.com");
+      fields.put("password", "passwordsmatch");
+      fields.put("confirmpassword", "passwordsdonotmatch");
+
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      assertThat("Passwords fail to match error is shown", registerPage.getErrors(), Matchers.contains(errorMsg));
+   }
+
+   @Test
+   public void requiredFields()
+   {
+      String errorMsg = "value is required";
+      fields.put("name", "");
+      fields.put("username", "");
+      fields.put("email", "");
+      fields.put("password", "");
+      fields.put("confirmpassword", "");
+
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      assertThat("Value is required shows for all fields", registerPage.getErrors(),
+            Matchers.contains(errorMsg, errorMsg, errorMsg, errorMsg, errorMsg));
+   }
+
+   /*
+      Bugs
+    */
+   @Test(expected = AssertionError.class)
+   public void bug981082_inaccurateErrorMessage()
+   {
+      String errorMsg = "size must be between 3 and 20";
+      fields.put("email", "bug981082test@test.com");
+      fields.put("username", "mo");
+
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      assertThat("Size errors are shown for string too short", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+
+      fields.put("username", "johndoeusernamevalidation");
+      registerPage = registerPage.setFields(fields);
+      assertThat("Size errors are shown for string too long", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+   }
+
+   @Test(expected = AssertionError.class)
+   public void bug981498_underscoreRules()
+   {
+      String errorMsg = "lowercase letters and digits (regex \"^[a-z\\d_]{3,20}$\")";
+      fields.put("email", "bug981498test@example.com");
+      fields.put("username", "______");
+      RegisterPage registerPage = new AbstractWebWorkFlow().goToHome().goToRegistration().setFields(fields);
+      assertThat("A username of all underscores is not valid", registerPage.getErrors(), Matchers.hasItem(errorMsg));
+   }
+
+   /*
+      Returns a hash of invalid characters for a username
+      Hash is String reason for invalid 'character', String character
+    */
+   private LinkedHashMap<String, String> usernameCharacterValidationData()
+   {
+      LinkedHashMap<String, String> inputData = new LinkedHashMap<String, String>(100);
+      inputData.put("Invalid char |", "user|name");
+      inputData.put("Invalid char /", "user/name");
+      inputData.put("Invalid char ", "user\\name");
+      inputData.put("Invalid char +", "user+name");
+      inputData.put("Invalid char *", "user*name");
+      inputData.put("Invalid char |", "user|name");
+      inputData.put("Invalid char (", "user(name");
+      inputData.put("Invalid char )", "user)name");
+      inputData.put("Invalid char $", "user$name");
+      inputData.put("Invalid char [", "user[name");
+      inputData.put("Invalid char ]", "user]name");
+      inputData.put("Invalid char :", "user:name");
+      inputData.put("Invalid char ;", "user;name");
+      inputData.put("Invalid char '", "user'name");
+      inputData.put("Invalid char ,", "user,name");
+      inputData.put("Invalid char ?", "user?name");
+      inputData.put("Invalid char !", "user!name");
+      inputData.put("Invalid char @", "user@name");
+      inputData.put("Invalid char #", "user#name");
+      inputData.put("Invalid char %", "user%name");
+      inputData.put("Invalid char ^", "user^name");
+      inputData.put("Invalid char =", "user=name");
+      inputData.put("Invalid char .", "user.name");
+      inputData.put("Invalid char {", "user{name");
+      inputData.put("Invalid char }", "user}name");
+      // Capital letters are prohibited
+      for (char c = 'A'; c <= 'Z'; c++) {
+         String letter = String.valueOf(c);
+         inputData.put("Invalid capital char ".concat(letter), "user".concat(letter).concat("name"));
+      }
+      return inputData;
+   }
+}

--- a/zanata-war/src/main/webapp/account/register.xhtml
+++ b/zanata-war/src/main/webapp/account/register.xhtml
@@ -95,7 +95,7 @@
           <h:outputText value="#{messages['jsf.register.LoginUsingOpenId']}" escape="false"/>
         </s:div>
         <div class="actionButtons">
-            <h:commandButton value="#{messages['jsf.Register']}" action="#{register.register}"/>
+            <h:commandButton id="registerButton" value="#{messages['jsf.Register']}" action="#{register.register}"/>
         </div>
       </rich:panel>
     </h:form>


### PR DESCRIPTION
Currently, successful registration testing is blocked by Captcha validation.
Includes register page, and testcases for field validation on usernames and
email RFC2822 compliance.
Basic validation for password matching and Captcha rejection.
