### PR TITLE
Show correct parent checkbox state on page refresh/reload

### DIFF
--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransFilterDisplay.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransFilterDisplay.java
@@ -21,7 +21,7 @@ public interface TransFilterDisplay extends WidgetDisplay, SearchFieldListener
    void setNeedReviewFilter(boolean filterByNeedReview);
 
    void setUntranslatedFilter(boolean filterByUntranslated);
-   
+
    void setApprovedFilter(boolean filterByApproved);
 
    void setRejectedFilter(boolean filterByRejected);

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransFilterView.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransFilterView.java
@@ -116,37 +116,43 @@ public class TransFilterView extends Composite implements TransFilterDisplay
    @Override
    public void setUntranslatedFilter(boolean filterByUntranslated)
    {
-      untranslatedChk.setValue(filterByUntranslated);
+      updateChildCheckbox(untranslatedChk, filterByUntranslated);
    }
 
    @Override
    public void setNeedReviewFilter(boolean filterByNeedReview)
    {
-      fuzzyChk.setValue(filterByNeedReview);
+      updateChildCheckbox(fuzzyChk, filterByNeedReview);
    }
 
    @Override
    public void setTranslatedFilter(boolean filterByTranslated)
    {
-      translatedChk.setValue(filterByTranslated);
+      updateChildCheckbox(translatedChk, filterByTranslated);
    }
 
    @Override
    public void setApprovedFilter(boolean filterByApproved)
    {
-      approvedChk.setValue(filterByApproved);
+      updateChildCheckbox(approvedChk, filterByApproved);
    }
 
    @Override
    public void setRejectedFilter(boolean filterByRejected)
    {
-      rejectedChk.setValue(filterByRejected);
+      updateChildCheckbox(rejectedChk, filterByRejected);
    }
 
    @Override
    public void setHasErrorFilter(boolean filterByHasError)
    {
-      hasErrorChk.setValue(filterByHasError);
+      updateChildCheckbox(hasErrorChk, filterByHasError);
+   }
+
+   private void updateChildCheckbox(CheckBox checkbox, boolean value)
+   {
+      checkbox.setValue(value);
+      updateParentCheckboxes();
    }
 
    @Override


### PR DESCRIPTION
Previously, checkboxes for individual states would update correctly, but the 'complete' and 'incomplete' checkboxes would always be in unchecked state after page refresh. This makes sure that any programmatic update of the checkboxes will trigger the parent checkboxes to re-evaluate their state.
