### PR TITLE
Allow the use of different displays for functional test

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -53,6 +53,7 @@
         <webdriver.chrome.bin>/opt/google/chrome/google-chrome</webdriver.chrome.bin>
         <!-- this decides what web driver type we intended to use-->
         <webdriver.type>chrome</webdriver.type>
+        <webdriver.display>:0</webdriver.display>
         <webdriver.log>${project.build.directory}/webdriver.log</webdriver.log>
 
         <!-- this is the path we store H2 backup script which will be used to reset database state -->
@@ -402,7 +403,11 @@
                                 <!--<echo>-Dzanata.client.version=maven client version to use. Currently: ${zanata.client.version}</echo>-->
                                 <echo>-Dzanata.sample.projects.basedir=${project.build.testOutputDirectory}/sample-projects</echo>
                                 <echo>-Dcargo.debug.jvm.args : If not set by default will listen to port 8787. Need to set to empty on jenkins</echo>
-                                <echo>-Dinclude.test.patterns : by default is **/*TestSuite.java. Can be used to control what test to run.</echo>
+                                <echo>-Dinclude.test.patterns=test filter pattern. Can be used to control what test to run. Default is **/*TestSuite.java.</echo>
+                                <echo>-Dwebdriver.type=run tests in htmlUnit, chrome or firefox. For chrome, see also webdriver.chrome.* Default is htmlUnit.</echo>
+                                <echo>-Dwebdriver.display=display to run test browser in, for Xnest or otherwise. Default is :0.</echo>
+                                <echo>-Dwebdriver.chrome.bin=full path to chrome binary.</echo>
+                                <echo>-Dwebdriver.chrome.driver=full path to chromedriver binary.</echo>
                                 <echo>==========================================================</echo>
                             </target>
                         </configuration>

--- a/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.firefox.FirefoxBinary;
@@ -105,11 +106,11 @@ public enum WebDriverFactory
       driverService = new ChromeDriverService.Builder()
             .usingDriverExecutable(new File(PropertiesHolder.properties.getProperty("webdriver.chrome.driver")))
             .usingAnyFreePort()
+            .withEnvironment(ImmutableMap.of("DISPLAY", PropertiesHolder.properties.getProperty("webdriver.display")))
             .withLogFile(new File(PropertiesHolder.properties.getProperty("webdriver.log")))
             .build();
       DesiredCapabilities capabilities = DesiredCapabilities.chrome();
       capabilities.setCapability("chrome.binary", PropertiesHolder.properties.getProperty("webdriver.chrome.bin"));
-//      System.setProperty("webdriver.chrome.driver", properties.getProperty("webdriver.chrome.driver"));
       try
       {
          driverService.start();
@@ -134,11 +135,13 @@ public enum WebDriverFactory
       {
          firefoxBinary = new FirefoxBinary();
       }
-      //we timeout the connection in 10 seconds
-//      firefoxBinary.setTimeout(SECONDS.toMillis(10));
-
+      /*
+       * TODO: Evaluate current timeout
+       * Timeout the connection in 30 seconds
+       * firefoxBinary.setTimeout(TimeUnit.SECONDS.toMillis(30));
+       */
+      firefoxBinary.setEnvironmentProperty("DISPLAY", PropertiesHolder.properties.getProperty("webdriver.display"));
       return new FirefoxDriver(firefoxBinary, makeFirefoxProfile());
-//      return new FirefoxDriver();
    }
 
    private FirefoxProfile makeFirefoxProfile()
@@ -149,12 +152,16 @@ public enum WebDriverFactory
          // TODO - look at FirefoxDriver.getProfile().
       }
       final FirefoxProfile firefoxProfile = new FirefoxProfile();
-      // firefoxProfile.setPreference("browser.safebrowsing.malware.enabled",
-      // false); // disables connection to sb-ssl.google.com
+
+      /*
+       * TODO: Evaluate need for this
+       * Disable unnecessary connection to sb-ssl.google.com
+       * firefoxProfile.setPreference("browser.safebrowsing.malware.enabled", false);
+       */
+
       firefoxProfile.setAlwaysLoadNoFocusLib(true);
       firefoxProfile.setEnableNativeEvents(true);
       firefoxProfile.setAcceptUntrustedCertificates(true);
-//      firefoxProfile.setPort(8000);
       return firefoxProfile;
    }
 

--- a/functional-test/src/test/resources/setup.properties
+++ b/functional-test/src/test/resources/setup.properties
@@ -6,7 +6,7 @@ webdriver.chrome.driver=${webdriver.chrome.driver}
 #this decides what web driver type we intended to use.
 webdriver.type=${webdriver.type}
 webdriver.log=${webdriver.log}
-
+webdriver.display=${webdriver.display}
 zanata.instance.url=${zanata.instance.url}
 zanata.sample.projects.basedir=${zanata.sample.projects.basedir}
 zanata.apikey=${zanata.apikey}


### PR DESCRIPTION
Using the DISPLAY variable allows a less "obnoxious" running of
tests in an Xserver, preventing popup windows and accidental
interaction with a running test environment.
