### PR TITLE
rhbz987235 - fix implicit hibernate flush

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
@@ -165,7 +165,8 @@ public class TranslationServiceImpl implements TranslationService
             try
             {
                int nPlurals = getNumPlurals(hLocale, hTextFlow);
-               result.targetChanged = translate(hTextFlowTarget, request.getNewContents(), request.getNewContentState(), nPlurals, projectIteration.getRequireTranslationReview());
+               result.targetChanged = translate(hTextFlowTarget, request.getNewContents(), request.getNewContentState(),
+                     nPlurals, projectIteration.getRequireTranslationReview());
                result.isSuccess = true;
             }
             catch (HibernateException e)

--- a/zanata-war/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
@@ -20,8 +20,10 @@
  */
 package org.zanata.service.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dbunit.operation.DatabaseOperation;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jboss.seam.security.management.JpaIdentityStore;
 import org.mockito.Mock;
@@ -32,7 +34,6 @@ import org.zanata.ZanataDbunitJpaTest;
 import org.zanata.common.ContentState;
 import org.zanata.common.LocaleId;
 import org.zanata.dao.AccountDAO;
-import org.zanata.exception.ConcurrentTranslationException;
 import org.zanata.model.HLocale;
 import org.zanata.model.HProject;
 import org.zanata.seam.SeamAutowire;
@@ -40,17 +41,13 @@ import org.zanata.security.ZanataIdentity;
 import org.zanata.service.TranslationService;
 import org.zanata.webtrans.shared.model.TransUnitId;
 import org.zanata.webtrans.shared.model.TransUnitUpdateRequest;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import com.google.common.collect.Lists;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.zanata.service.TranslationService.TranslationResult;
 
 /**


### PR DESCRIPTION
When translating a text flow, a HTextFlowTarget object gets retrieved from database or created if none exists.
If the target is created, it will be put into text flow. We further merge values such as contents and content state coming from UI request into this created target object. If at any point a hibernate fetch is issued (like the permission check that used to perform projectIteration.getProject()), hibernate will do an implicit flush which result in the created target being saved. After that further modification will trigger another save at the end.

This will fix bug [987235](https://bugzilla.redhat.com/show_bug.cgi?id=987235) and provide a test to guard ourselves from doing the same thing again. 
