### PR TITLE
Fix functional tests by adding document storage JNDI property

### DIFF
--- a/functional-test/src/test/resources/conf/standalone.xml
+++ b/functional-test/src/test/resources/conf/standalone.xml
@@ -220,6 +220,7 @@
                 <simple name="java:global/zanata/security/auth-policy-names/internal" value="zanata.internal"/>
                 <simple name="java:global/zanata/security/admin-users" value="admin"/>
                 <simple name="java:global/zanata/email/default-from-address" value="no-reply@zanata.org" />
+                <simple name="java:global/zanata/files/document-storage-directory" value="/tmp/zanata/documents"/>
             </bindings>
             <remote-naming/>
         </subsystem>

--- a/zanata-war/src/test/resources/arquillian/standalone.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone.xml
@@ -215,6 +215,7 @@
             <bindings>
                 <simple name="java:global/zanata/security/auth-policy-names/internal" value="zanata.internal"/>
                 <simple name="java:global/zanata/security/admin-users" value="user1,user2,user3"/>
+                <simple name="java:global/zanata/files/document-storage-directory" value="./target/zanatadocumentsbase"/>
             </bindings>
             <remote-naming/>
         </subsystem>


### PR DESCRIPTION
Locations used are based on the index directory near the top of each standalone.xml, to be consistent.
