### PR TITLE
Change error page default message and add bug report link to error page.

### DIFF
--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -15,7 +15,8 @@ jsf.DuplicatedRecord=Duplicated record
 jsf.AnotherUserChangedTheSameDataPleaseTryAgain=Another user changed the same data. Please try again.
 jsf.YouDoNotHavePermissionToAccessThisResource=You do not have permission to access this resource.
 jsf.YourSessionHasTimedOutPleaseTryAgain=Your session has timed out. Please try again.
-jsf.UnexpectedErrorPleaseTryAgain=Unexpected error. Please try again.
+jsf.UnexpectedError=An unexpected error has occurred. Please report this problem with details of what you were attempting.
+jsf.ReportProblemInstructions=To report a problem, please use the '#{messages['jsf.ReportAProblem']}' link, available in the '#{messages['jsf.More']}' menu above.
 
 jsf.Actions=Actions
 jsf.Add=Add

--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -976,11 +976,8 @@
 
   <exception>
     <redirect view-id="/error.xhtml">
-      <message severity="error">#{messages['jsf.UnexpectedErrorPleaseTryAgain']}
-      [ Request: #{servletContexts.request.requestURI}?#{servletContexts.request.queryString} ]
-      </message>
+      <message severity="error">#{messages['jsf.UnexpectedError']}</message>
     </redirect>
   </exception>
-
 
 </pages>

--- a/zanata-war/src/main/webapp/error.xhtml
+++ b/zanata-war/src/main/webapp/error.xhtml
@@ -13,8 +13,47 @@
 
         <h1>#{messages['jsf.ErrorTitle']}</h1>
 
-        <h:messages id="errorMessage" styleClass="message" errorClass="errormsg icon-info-circle-2" infoClass="infomsg icon-info-circle-2" warnClass="warnmsg icon-attention" />
-        <h:outputText id="noErrorsMessage" rendered="#{empty org.jboss.seam.international.statusMessages.currentGlobalMessages}">#{messages['jsf.NoErrors']}</h:outputText>
+        <h:outputText id="noErrorsMessage"
+                      rendered="#{empty org.jboss.seam.international.statusMessages.currentGlobalMessages}"
+                      value="#{messages['jsf.NoErrors']}" />
+
+        <h:messages id="errorMessage"
+                    styleClass="message"
+                    infoClass="infomsg icon-info-circle-2"
+                    warnClass="warnmsg icon-attention"
+                    errorClass="errormsg icon-info-circle-2" />
+
+        <div style="padding: 5 10 20;
+                    margin: 35 50;
+                    text-align: center;
+                    border: 1px solid #eee;
+                    box-shadow: 8px 8px 10px #ddd;">
+
+            <p><h:outputText value="#{messages['jsf.ReportProblemInstructions']}" /></p>
+            <a href="https://bugzilla.redhat.com/enter_bug.cgi?format=guided&amp;product=Zanata"
+               target="_blank"
+               style="display: block;
+                      width: 120px;
+                      height: 36px;
+
+                      padding: 0 15;
+                      margin: 0 auto;
+                      border: 1px solid #ccc;
+                      box-shadow: 0px 3px 4px rgba(0, 0, 0, .3);
+
+                      color: #454545;
+                      font-size: 13px;
+                      font-family: helvetica;
+                      font-weight: bold;
+                      line-height: 36px;
+                      text-decoration: none;
+                      text-shadow: none;
+                      text-align: left;
+                      outline: none;">
+                <img src="#{request.contextPath}/images/crystal_project/_16x16/apps/bug.png"
+                     style="margin-right: 4px; vertical-align: middle;" />#{messages['jsf.ReportAProblem']}
+            </a>
+        </div>
 
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
Note that styles on the 'Report problem' link are purposely inline to simplify merging with the new CSS - it will continue to look ok, and the inline styles can be removed when adding appropriate new style classes.
