### PR TITLE
Remove superfluous logging of filter parameters

### DIFF
--- a/zanata-war/src/main/java/org/zanata/adapter/GenericOkapiFilterAdapter.java
+++ b/zanata-war/src/main/java/org/zanata/adapter/GenericOkapiFilterAdapter.java
@@ -408,7 +408,6 @@ public class GenericOkapiFilterAdapter implements FileFormatAdapter
       {
          filter.getParameters().fromString(params.get());
       }
-      log.info("filter parameters: " + filter.getParameters());
    }
 
 }


### PR DESCRIPTION
The removed line was generating several lines of log output any time source document was uploaded and any non-pot translation file was downloaded.
