### PR TITLE
Prevent upload and show error message if source upload filename has a semicolon.

### DIFF
--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -316,6 +316,7 @@ jsf.iteration.files.DocumentDeleted=Document succesfully deleted.
 jsf.iteration.files.ProcessDlgTitle=Processing project files...
 
 jsf.iteration.files.UploadDocument=Upload Document
+jsf.iteration.files.FilenameWithSemicolonNotSupported=Zanata does not support filenames that contain a semicolon.
 jsf.SupportedUploadFormats=Supported types: .pot .dtd .txt .odt .fodt .odp .fodp .ods .fods .odg .fodg .odb .odf
 jsf.SourceLanguage=Source Language
 jsf.iteration.files.DocumentPath=Document Path

--- a/zanata-war/src/main/webapp/iteration/source_files.xhtml
+++ b/zanata-war/src/main/webapp/iteration/source_files.xhtml
@@ -313,8 +313,9 @@
                 <div id="invalidFilenameError" style="display: none;
                                                       color: red;
                                                       padding: 5px;
-                                                      margin-bottom: 5px;
-                ">Zanata does not support filenames that contain a semicolon.</div>
+                                                      margin-bottom: 5px;">
+                    #{messages['jsf.iteration.files.FilenameWithSemicolonNotSupported']}
+                </div>
                 <div>
                     <h:outputLabel for="docPath" value="#{messages['jsf.iteration.files.DocumentPath']}"/>
                     <h:inputText id="docPath"


### PR DESCRIPTION
Zanata cannot accept files with a semicolon for upload due to a bug in seam taglib that causes filename truncation. This prevents the upload from the browser to avoid the confusing truncation behaviour.
