### PR TITLE
Prevent unhandled exception when upload file has no extension

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationFileServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationFileServiceImpl.java
@@ -279,6 +279,10 @@ public class TranslationFileServiceImpl implements TranslationFileService
    @Override
    public boolean hasAdapterFor(DocumentType type)
    {
+      if (type == null)
+      {
+         return false;
+      }
       return DOCTYPEMAP.containsKey(type);
    }
 


### PR DESCRIPTION
Was getting a NullPointerException when filename contains no '.' character.
