### PR TITLE
Style newline rather than replace it with pilcrow character

### DIFF
--- a/zanata-war/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
@@ -141,7 +141,7 @@ public class Highlighting
          var data = diffs[x][1]; // Text of change.
          var text = data.replace(pattern_amp, '&amp;').replace(pattern_lt,
                '&lt;').replace(pattern_gt, '&gt;').replace(pattern_para,
-               '&para;<br>');
+               '<span class="newline"></span><br>');
          switch (op) {
             case $wnd['DIFF_INSERT']:
                html[x] = text;

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/ui/HighlightingLabel.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/ui/HighlightingLabel.java
@@ -58,9 +58,10 @@ public class HighlightingLabel extends HTML implements SourceContentWrapper
    private void highlight()
    {
       Element preElement = getElement().getFirstChildElement();
-      String text = plainText == null ? "" : plainText.replaceAll("\n", "¶\n");
-      Highlighting.syntaxHighlight(text, preElement);
+      Highlighting.syntaxHighlight(Strings.nullToEmpty(plainText), preElement);
       preElement.addClassName("cm-s-default");
+      String styled = preElement.getInnerHTML().replaceAll("<br>", "<span class='newline'></span><br>");
+      preElement.setInnerHTML(styled);
    }
 
    @Override

--- a/zanata-war/src/main/java/org/zanata/webtrans/shared/validation/AbstractValidationAction.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/shared/validation/AbstractValidationAction.java
@@ -27,6 +27,7 @@ import org.zanata.webtrans.client.resources.ValidationMessages;
 import org.zanata.webtrans.shared.model.ValidationAction;
 import org.zanata.webtrans.shared.model.ValidationId;
 import org.zanata.webtrans.shared.model.ValidationInfo;
+import org.zanata.webtrans.shared.validation.action.HtmlXmlTagValidation;
 import org.zanata.webtrans.shared.validation.action.JavaVariablesValidation;
 import org.zanata.webtrans.shared.validation.action.NewlineLeadTrailValidation;
 import org.zanata.webtrans.shared.validation.action.PrintfVariablesValidation;
@@ -41,7 +42,7 @@ import com.google.common.collect.Lists;
  *
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  *
- * @see HtmlXMlTagValidation
+ * @see HtmlXmlTagValidation
  * @see JavaVariablesValidation
  * @see NewlineLeadTrailValidation
  * @see PrintfVariablesValidation

--- a/zanata-war/src/main/java/org/zanata/webtrans/shared/validation/ValidationFactory.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/shared/validation/ValidationFactory.java
@@ -58,7 +58,6 @@ public class ValidationFactory
     * 
     * Used in client side (ValidationAction)
     * 
-    * @param messages
     * @return Map<ValidationId, ValidationAction>
     */
    public Map<ValidationId, ValidationAction> getAllValidationActions()

--- a/zanata-war/src/main/resources/org/zanata/webtrans/public/codemirror.css
+++ b/zanata-war/src/main/resources/org/zanata/webtrans/public/codemirror.css
@@ -206,3 +206,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-lines pre:last-child:after {
     content: '';
 }
+
+/* for highlighting label (runs code mirror runmode) */
+.newline:after {
+    content: '\00b6';
+    color: #aaaaaa;
+}


### PR DESCRIPTION
so that users won't accidentally copy and paste &para; into translation
