### PR TITLE
Map exception handler for failed file upload.

### DIFF
--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -345,6 +345,8 @@ jsf.iteration.files.CustomParams=Custom Parsing Parameters
 jsf.iteration.files.CustomParams.description=Custom Parsing Parameters are used to change how the document is processed.
 ! text for a link to a wiki page
 jsf.iteration.files.CustomParams.linkText=Wiki page for Custom Parsing Parameters
+! shown on error page if something goes wrong with upload. A specific error message is shown after.
+jsf.iteration.files.UploadFailed=Upload Failed! Caused by:
 
 jsf.ConfigFileForOfflineTranslation=Offline Translation Config File
 jsf.GenerateProjectConfigSingleLocale=Generate project configuration file (zanata.xml) for this version with locale #{projectIterationFilesAction.localeId}

--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -998,6 +998,14 @@
     <http-error error-code="503" />
   </exception>
 
+  <exception class="org.jboss.seam.web.FileUploadException" log-level="warn">
+    <redirect view-id="/error.xhtml">
+      <message severity="error">
+        #{messages['jsf.iteration.files.UploadFailed']} #{org.jboss.seam.handledException.message}
+      </message>
+    </redirect>
+  </exception>
+
   <exception>
     <redirect view-id="/error.xhtml">
       <message severity="error">#{messages['jsf.UnexpectedError']}</message>


### PR DESCRIPTION
There could be multiple causes for failed upload, so the best I can do for now is to append the exception message to a generic message. This is not ideal for localization, but is better than nothing and appears to be all that Seam will allow.
