### PR TITLE
change problem reporting link on error page to mimic link in footer

### DIFF
--- a/zanata-war/src/main/webapp/error.xhtml
+++ b/zanata-war/src/main/webapp/error.xhtml
@@ -27,11 +27,7 @@
             <p>
               To report a problem, use the
               <a href="https://bugzilla.redhat.com/enter_bug.cgi?format=guided&amp;product=Zanata"
-                 target="_blank"
-                 style="font-size: 12px;
-                        background: #e8eaec;
-                        padding: 5 8;
-                        margin: 0 7;">
+                 target="_blank">
                 #{messages['jsf.ReportAProblem']}
               </a>
               link found in the footer of each page.


### PR DESCRIPTION
This is to show users what the button looks like, but the copy of the
    button is made to work so that users are not confused by trying to click
    an inert button.
