### PR TITLE
rhbz990825 - Admin user list was not being fetched from configuration.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
+++ b/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
@@ -52,6 +52,8 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Sets;
 
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
 @Name("applicationConfiguration")
 @Scope(ScopeType.APPLICATION)
 @Startup


### PR DESCRIPTION
This was caused inadvertently when introducing JNDI configuration.
Now it does a similar fetch as before, only from the JNDI configuration store.
