### PR TITLE
Canonicalize TM locales before storing them.

### DIFF
--- a/zanata-model/src/main/java/org/zanata/model/tm/TMXMetadataHelper.java
+++ b/zanata-model/src/main/java/org/zanata/model/tm/TMXMetadataHelper.java
@@ -280,13 +280,7 @@ public class TMXMetadataHelper
     */
    private static String getValidLang(final String lang)
    {
-      String canonicalLang = ULocale.canonicalize(lang);
-      if (canonicalLang.contains("_"))
-      {
-         log.debug("Converting invalid locale to BCP47: {}", canonicalLang);
-         canonicalLang = canonicalLang.replace('_', '-');
-      }
-      return new LocaleId(canonicalLang).getId();
+      return ULocale.canonicalize(lang).replace('_', '-');
    }
 
    private static void setSharedMetadata(HasTMMetadata toEntity, Map<String, Object> fromMetadata)


### PR DESCRIPTION
This makes TM matches available in cases where a TM file has languages in the form "en-us" while Zanata's internal representation has "en-US".
