### PR TITLE
remove dashboard link from top menu - to side menu

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
@@ -48,11 +48,6 @@
 	
 	<nav id="nav-main" class="header__menu is-hidden--s l--push-left-half">
 	  <ul class="list--horizontal">
-	  	<s:fragment rendered="#{identity.loggedIn}">
-		  	<li class="l--push-left-half">
-		    	<s:link id="dashboard_link" view="/dashboard/home.xhtml" propagation="none">#{messages['jsf.Dashboard']}</s:link>
-		    </li>
-	    </s:fragment>
 	    <li class="l--push-left-half">
 	    	<s:link id="projects_link" view="/project/home.xhtml" propagation="none">#{messages['jsf.Projects']}</s:link>
 	    </li>


### PR DESCRIPTION
Remove dashboard link from top, and move to side menu
- top menu are for global url
- side menu are for extras when user logged in
