### PR TITLE
rhbz995910 - Change transaction successful event to immediate.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
@@ -636,7 +636,7 @@ public class TranslationServiceImpl implements TranslationService
             
             if(Events.exists())
             {
-               Events.instance().raiseTransactionSuccessEvent(
+               Events.instance().raiseEvent(
                      DocumentUploadedEvent.EVENT_NAME,
                      new DocumentUploadedEvent(document.getId(), false, hLocale.getLocaleId()
                ));


### PR DESCRIPTION
Because transactions are being handled manually, a transaction successful event will fail when raised.
