### PR TITLE
Use non-seam instance of JndiBackedConfig when authenticating via kerber...

### DIFF
--- a/zanata-war/src/main/java/org/zanata/config/JndiBackedConfig.java
+++ b/zanata-war/src/main/java/org/zanata/config/JndiBackedConfig.java
@@ -63,7 +63,7 @@ public class JndiBackedConfig implements Serializable
    private static final String KEY_EMAIL_SSL             = "java:global/zanata/smtp/ssl";
    private static final String KEY_WEB_ASSETS_URL_BASE   = "java:global/zanata/webassets/url-base";
 
-   private Map<String, String> configurationValues;
+   private final Map<String, String> configurationValues = new HashMap<String, String>();
 
    private String getConfigValue(String key)
    {
@@ -103,7 +103,7 @@ public class JndiBackedConfig implements Serializable
    @Create
    public void reset()
    {
-      configurationValues = new HashMap<String, String>();
+      configurationValues.clear();
    }
 
    /**

--- a/zanata-war/src/main/java/org/zanata/security/ZanataCentralLoginModule.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataCentralLoginModule.java
@@ -56,7 +56,8 @@ public class ZanataCentralLoginModule implements LoginModule
       this.subject = subject;
       this.callbackHandler = callbackHandler;
 
-      JndiBackedConfig jndiConfig = (JndiBackedConfig) Component.getInstance(JndiBackedConfig.class);
+      // Avoid using Seam components in Login Modules
+      JndiBackedConfig jndiConfig = new JndiBackedConfig();
 
       internalAuthDomain = jndiConfig.getAuthPolicyName(AuthenticationType.INTERNAL.name().toLowerCase());
       kerberosDomain = jndiConfig.getAuthPolicyName(AuthenticationType.KERBEROS.name().toLowerCase());

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-web.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-web.xml
@@ -16,7 +16,7 @@ in case changes are required for production deployment (eg cfengine).
     </resource-ref>
  -->
 
-    <security-domain>zanata.kerberos</security-domain>
+    <security-domain>zanata</security-domain>
     <valve>
         <class-name>org.jboss.security.negotiation.NegotiationAuthenticator</class-name>
     </valve>


### PR DESCRIPTION
...os.

When kerberos authentication happens there is no Seam context available causing the process to fail.
Also revert previous commit which fixed kerberos authentication but broke other authentication mechanisms.
