### PR TITLE
Clean up dependencies

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -68,26 +68,47 @@
     <dependencies>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
+            <artifactId>selenium-api</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-firefox-driver</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-htmlunit-driver</artifactId>
             <version>${selenium.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-all</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>xml-apis</artifactId>
-                    <groupId>xml-apis</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>xercesImpl</artifactId>
-                    <groupId>xerces</groupId>
-                </exclusion>
+    				<exclusion>
+						<artifactId>commons-logging</artifactId>
+						<groupId>commons-logging</groupId>
+    				</exclusion>
+    				<exclusion>
+    								<artifactId>xml-apis</artifactId>
+    								<groupId>xml-apis</groupId>
+    				</exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-support</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -106,10 +127,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -162,6 +179,11 @@
             <artifactId>hibernate-envers</artifactId>
             <version>${hibernate.version}</version>
             <scope>${hibernate.scope}</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
 
         <dependency>
@@ -415,6 +437,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                   <failOnWarning>true</failOnWarning>
+                   <usedDependencies combine.children="append">
+                     <usedDependency>com.h2database:h2</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-core</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-envers</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-entitymanager</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-infinispan</usedDependency>
+                     <usedDependency>org.projectlombok:lombok</usedDependency>
+                   </usedDependencies>
+                </configuration>
+            </plugin>
+
             <!--we want to run tests in integration phase-->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.zanata</groupId>
     <artifactId>zanata-parent</artifactId>
-    <version>13</version>
+    <version>14-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 
@@ -55,20 +55,76 @@
 
    <dependencyManagement>
       <dependencies>
+
+         <!-- arquillian and shrinkwrap boms must precede other boms -->
+         <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-bom</artifactId>
+            <version>1.1.2</version>
+            <scope>import</scope>
+            <type>pom</type>
+         </dependency>
+
+         <!-- Override dependency resolver with latest version.
+         This must go *BEFORE* the Arquillian BOM. -->
+         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-bom</artifactId>
+            <version>2.0.0</version>
+            <scope>import</scope>
+            <type>pom</type>
+         </dependency>
+
+          <dependency>
+              <groupId>org.jboss.arquillian</groupId>
+              <artifactId>arquillian-bom</artifactId>
+              <version>1.0.3.Final</version>
+              <scope>import</scope>
+              <type>pom</type>
+          </dependency>
+
+         <!-- repeat resteasy version to make sure the seam bom doesn't downgrade it -->
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-bom</artifactId>
+            <version>${resteasy.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+
+            <!-- make sure the richfaces version is not provided by the seam bom -->
+            <dependency>
+                <groupId>org.richfaces</groupId>
+                <artifactId>richfaces-bom</artifactId>
+                <version>${richfaces.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+
+            <dependency>
+            <groupId>org.jboss.seam</groupId>
+            <artifactId>bom</artifactId>
+            <version>${seam.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+
+          <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-parent</artifactId>
+            <version>7.1.3.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+
           <!-- zanata api -->
           <dependency>
              <groupId>org.zanata</groupId>
              <artifactId>zanata-common-api</artifactId>
              <version>${zanata.api.version}</version>
           </dependency>
-          <dependency>
-             <groupId>org.zanata</groupId>
-             <artifactId>zanata-common-api</artifactId>
-             <version>${zanata.api.version}</version>
-             <type>test-jar</type>
-             <scope>test</scope>
-          </dependency>
-    
+
           <!-- zanata common -->
           <dependency>
              <groupId>org.zanata</groupId>
@@ -237,9 +293,20 @@
 
         <dependency>
             <groupId>net.sf.okapi.steps</groupId>
+            <artifactId>okapi-step-tokenization</artifactId>
+            <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sf.okapi.logbind</groupId>
+                    <artifactId>build-log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-wordcount</artifactId>
             <version>${okapi.version}</version>
-            <!-- see latest version at http://repository-okapi.forge.cloudbees.com/snapshot/net/sf/okapi/steps/okapi-step-wordcount/ -->
             <exclusions>
                 <exclusion>
                     <groupId>net.sf.okapi.logbind</groupId>
@@ -326,33 +393,6 @@
 				<version>1.0_02.CR6</version>
 			</dependency>
 
-			<!-- repeat resteasy version to make sure the seam bom doesn't downgrade it -->
-			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-bom</artifactId>
-				<version>${resteasy.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
-            <!-- make sure the richfaces version is not provided by the seam bom -->
-            <dependency>
-                <groupId>org.richfaces</groupId>
-                <artifactId>richfaces-bom</artifactId>
-                <version>${richfaces.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-
-            <dependency>
-				<groupId>org.jboss.seam</groupId>
-				<artifactId>bom</artifactId>
-				<version>${seam.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<dependency>
 				<groupId>org.jboss.seam</groupId>
 				<artifactId>jboss-seam</artifactId>
@@ -425,42 +465,6 @@
 			<scope>compile</scope>
 		</dependency>
 
-          <!-- Arquillian Dependencies -->
-          <!-- Override the Maven resolver to the latest version -->
-          <!-- TODO Use the arquillian Shrinkwrap bom -->
-          <dependency>
-              <groupId>org.jboss.shrinkwrap.resolver</groupId>
-              <artifactId>shrinkwrap-resolver-api</artifactId>
-              <version>2.0.0-beta-3</version>
-              <!-- TODO Overwritten from arquillian BOM 1.0.3.Final to use the MavenImporter -->
-          </dependency>
-          <dependency>
-              <groupId>org.jboss.shrinkwrap.resolver</groupId>
-              <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-              <version>2.0.0-beta-3</version>
-              <!-- TODO Overwritten from arquillian BOM 1.0.3.Final to use the MavenImporter -->
-          </dependency>
-          <dependency>
-              <groupId>org.jboss.shrinkwrap.resolver</groupId>
-              <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-              <version>2.0.0-beta-3</version>
-              <!-- TODO Overwritten from arquillian BOM 1.0.3.Final to use the MavenImporter -->
-          </dependency>
-
-          <dependency>
-              <groupId>org.jboss.arquillian.protocol</groupId>
-              <artifactId>arquillian-protocol-servlet</artifactId>
-              <version>1.0.3.Final</version>
-          </dependency>
-
-          <!-- Arquillian -->
-          <dependency>
-              <groupId>org.jboss.arquillian</groupId>
-              <artifactId>arquillian-bom</artifactId>
-              <version>1.0.3.Final</version>
-              <scope>import</scope>
-              <type>pom</type>
-          </dependency>
           <dependency>
               <groupId>org.concordion</groupId>
               <artifactId>concordion</artifactId>
@@ -516,36 +520,15 @@
 	         </exclusions>
 	       </dependency>
 
+
+         <dependency>
+             <groupId>javax.xml.stream</groupId>
+             <artifactId>stax-api</artifactId>
+             <version>1.0</version>
+         </dependency>
+
       </dependencies>
    </dependencyManagement>    
-
-   <dependencies>
-      <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-      </dependency>
-      <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-      </dependency>
-      <dependency>
-            <groupId>org.zanata</groupId>
-            <artifactId>zanata-common-api</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-      </dependency>
-          <!--
-            In the server, we can use a newer version than Fedora has
-            (and we need it for concordion).
-            This one also has a source jar!
-          -->
-          <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <version>1.2.5</version>
-          </dependency>
-   </dependencies>
 
    <!--
    https://community.jboss.org/wiki/MavenRepository
@@ -626,47 +609,33 @@
           </plugin>
 
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-ban-duplicate-classes</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
+            <configuration>
+                <rules>
                     <banDuplicateClasses>
-                       <ignoreClasses combine.children="append">
-                          <!-- caused by Lombok (but fortunately lombok is "provided") -->
-                          <ignoreClass>com.sun.jna.*</ignoreClass>
-                       </ignoreClasses>
+                       <dependencies combine.children="append">
+                           <!-- lombok is "provided", so these duplicate classes don't get deployed -->
+                           <dependency>
+                              <groupId>org.projectlombok</groupId>
+                              <artifactId>lombok</artifactId>
+                              <ignoreClasses>
+                                <ignoreClass>com.sun.jna.*</ignoreClass>
+                              </ignoreClasses>
+                           </dependency>
+                       </dependencies>
                     </banDuplicateClasses>
-                  </rules>
-                </configuration>
-              </execution>
-
-              <execution>
-                <id>enforce-no-repositories</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <rules>
                     <requireNoRepositories>
                       <allowedRepositories combine.children="append">
                         <allowedRepository>jboss-public-repository-group</allowedRepository>
                         <allowedRepository>okapi-cloudbees-release</allowedRepository>
                       </allowedRepositories>
-                      <allowedPluginRepositories>
+                      <allowedPluginRepositories combine.children="append">
                         <allowedPluginRepository>cobertura-it-maven-plugin-maven2-release</allowedPluginRepository>
                         <allowedPluginRepository>jboss-public-repository-group</allowedPluginRepository>
                       </allowedPluginRepositories>
                     </requireNoRepositories>
-                  </rules>
-                </configuration>
-              </execution>
-            </executions>
+                </rules>
+            </configuration>
          </plugin>
       </plugins>
       <pluginManagement>

--- a/zanata-model/pom.xml
+++ b/zanata-model/pom.xml
@@ -28,6 +28,19 @@
             </resource>
         </resources>
         <plugins>
+
+           <plugin>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <configuration>
+                 <failOnWarning>true</failOnWarning>
+                 <usedDependencies combine.children="append">
+                    <usedDependency>junit:junit</usedDependency>
+                    <usedDependency>org.projectlombok:lombok</usedDependency>
+                    <usedDependency>org.hibernate:hibernate-search</usedDependency>
+                 </usedDependencies>
+              </configuration>
+           </plugin>
+
 <!--
             <plugin>
                <groupId>com.mysema.maven</groupId>
@@ -119,34 +132,22 @@
             <artifactId>hamcrest-library</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.zanata</groupId>
-            <artifactId>zanata-common-api</artifactId>
-            <exclusions>
-            				<exclusion>
-            								<artifactId>
-            												javassist
-            								</artifactId>
-            								<groupId>javassist</groupId>
-            				</exclusion>
-            				<exclusion>
-            								<artifactId>
-            												commons-logging
-            								</artifactId>
-            								<groupId>
-            												commons-logging
-            								</groupId>
-            				</exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -155,9 +156,13 @@
         </dependency>
 
         <dependency>
+            <groupId>net.sf.okapi</groupId>
+            <artifactId>okapi-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>net.sf.okapi.steps</groupId>
-            <artifactId>okapi-step-wordcount</artifactId>
-            <!-- see latest version at http://repository-okapi.forge.cloudbees.com/snapshot/net/sf/okapi/steps/okapi-step-wordcount/ -->
+            <artifactId>okapi-step-tokenization</artifactId>
         </dependency>
 
         <dependency>
@@ -212,6 +217,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+        </dependency>
+
         <!-- Hibernate / JPA -->
         <dependency>
             <groupId>org.jboss.seam</groupId>
@@ -226,6 +236,11 @@
 
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
 
@@ -235,13 +250,23 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
 
 		<dependency>
@@ -258,6 +283,27 @@
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.zanata</groupId>
+			<artifactId>zanata-common-api</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>javassist</artifactId>
+					<groupId>javassist</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+      <dependency>
+         <groupId>xom</groupId>
+         <artifactId>xom</artifactId>
+         <exclusions>
+            <exclusion>
+               <artifactId>xalan</artifactId>
+               <groupId>xalan</groupId>
+            </exclusion>
+         </exclusions>
+      </dependency>
     </dependencies>
 
 </project>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -18,7 +18,6 @@
 	</scm>
 
 	<properties>
-		<jboss.embedded.version>beta3.SP12</jboss.embedded.version>
 		<war.config.dir>${basedir}/src/etc</war.config.dir>
 		<containerId>jboss71x</containerId>
         <allow.deploy.skip>true</allow.deploy.skip>
@@ -57,116 +56,117 @@
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
+                    <!-- This is used to set the property lombok.lib -->
                     <execution>
+                        <id>dependency-properties</id>
                         <phase>initialize</phase>
                         <goals>
                             <goal>properties</goal>
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                   <failOnWarning>true</failOnWarning>
+                   <usedDependencies combine.children="append">
+                     <usedDependency>javax.xml.bind:jaxb-api</usedDependency>
+                     <!-- runtime dep for liquibase logging -->
+                     <usedDependency>com.mattbertolini:liquibase-slf4j</usedDependency>
+                     <usedDependency>com.google.code.findbugs:annotations</usedDependency>
+                     <usedDependency>quartz:quartz</usedDependency>
+                     <!-- Used indirectly by org.zanata.arquillian.Deployments -->
+                     <usedDependency>org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api</usedDependency>
+
+                     <!-- Grandfathered entries: -->
+                     <!-- TODO validate or remove each of these -->
+                     <usedDependency>antlr:antlr</usedDependency>
+                     <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
+                     <usedDependency>com.google.guava:guava-gwt</usedDependency>
+                     <usedDependency>com.ibm.icu:icu4j</usedDependency>
+                     <usedDependency>com.sun.faces:jsf-impl</usedDependency>
+                     <usedDependency>commons-codec:commons-codec</usedDependency>
+                     <usedDependency>commons-collections:commons-collections</usedDependency>
+                     <usedDependency>commons-lang:commons-lang</usedDependency>
+                     <usedDependency>javax.el:el-api</usedDependency>
+                     <usedDependency>javax.servlet.jsp:jsp-api</usedDependency>
+                     <usedDependency>javax.servlet:javax.servlet-api</usedDependency>
+                     <usedDependency>mysql:mysql-connector-java</usedDependency>
+                     <usedDependency>org.apache.solr:solr-core</usedDependency>
+                     <usedDependency>org.apache.solr:solr-solrj</usedDependency>
+                     <usedDependency>org.codehaus.jackson:jackson-xc</usedDependency>
+                     <usedDependency>org.drools:drools-compiler</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-ehcache</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-search-analyzers</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-search</usedDependency>
+                     <usedDependency>org.hibernate:hibernate-testing</usedDependency>
+                     <usedDependency>org.htmlparser:htmlparser</usedDependency>
+                     <usedDependency>org.jboss.arquillian.junit:arquillian-junit-container</usedDependency>
+                     <usedDependency>org.jboss.arquillian.protocol:arquillian-protocol-servlet</usedDependency>
+                     <usedDependency>org.jboss.as:jboss-as-arquillian-container-managed</usedDependency>
+                     <usedDependency>org.jboss.resteasy:resteasy-jackson-provider</usedDependency>
+                     <usedDependency>org.jboss.seam:jboss-seam-debug</usedDependency>
+                     <usedDependency>org.jboss.seam:jboss-seam-mail</usedDependency>
+                     <usedDependency>org.liquibase.ext:modify-column</usedDependency>
+                     <usedDependency>org.openxri:openxri-client</usedDependency>
+                     <usedDependency>org.openxri:openxri-syntax</usedDependency>
+                     <usedDependency>org.richfaces.core:richfaces-core-impl</usedDependency>
+                     <usedDependency>org.tuckey:urlrewritefilter</usedDependency>
+                     <usedDependency>org.zanata:zanata-rest-client</usedDependency>
+                   </usedDependencies>
+                </configuration>
             </plugin>
          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>enforce-ban-duplicate-classes</id>
-                <goals>
-                  <goal>enforce</goal>
-                </goals>
-                <configuration>
-                  <!-- TODO enforce this once we've cleaned up
-                  the remaining duplicates which are caused by
-                  multiple jars for openid4java, drools, gwt
-                  and lucene-analyzers -->
-                  <fail>false</fail>
-                  <rules>
+            <configuration>
+                <rules>
                     <banDuplicateClasses>
                        <ignoreClasses combine.children="append">
-                          <!-- caused by beanutils and jboss-embedded-thirdparty-all -->
-                          <ignoreClass>org.apache.commons.collections.*</ignoreClass>
-
-                          <!-- caused by jboss-embedded-thirdparty-all -->
-                          <ignoreClass>antlr.*</ignoreClass>
-                          <ignoreClass>com.sun.activation.*</ignoreClass>
-                          <ignoreClass>com.sun.xml.*</ignoreClass>
-                          <ignoreClass>com.sun.istack.*</ignoreClass>
-                          <ignoreClass>hsqlServlet</ignoreClass>
-                          <ignoreClass>javassist.*</ignoreClass>
-                          <ignoreClass>javax.activation.*</ignoreClass>
-                          <ignoreClass>javax.annotation.*</ignoreClass>
-                          <ignoreClass>javax.ejb.*</ignoreClass>
-                          <ignoreClass>javax.interceptor.*</ignoreClass>
-                          <ignoreClass>javax.persistence.*</ignoreClass>
-                          <ignoreClass>javax.transaction.*</ignoreClass>
-                          <ignoreClass>javax.xml.XMLConstants</ignoreClass>
-                          <ignoreClass>javax.xml.bind.*</ignoreClass>
-                          <ignoreClass>javax.xml.namespace.*</ignoreClass>
-                          <ignoreClass>javax.xml.stream.*</ignoreClass>
-                          <ignoreClass>org.apache.commons.logging.*</ignoreClass>
-                          <ignoreClass>org.apache.log4j.*</ignoreClass>
-                          <ignoreClass>org.dom4j.*</ignoreClass>
-                          <ignoreClass>org.hsqldb.*</ignoreClass>
-                          <ignoreClass>org.jboss.crypto.*</ignoreClass>
-                          <ignoreClass>org.jboss.deployment.*</ignoreClass>
-                          <ignoreClass>org.jboss.logging.Logger</ignoreClass>
-                          <ignoreClass>org.jboss.Main*</ignoreClass>
-                          <ignoreClass>org.jboss.mx.*</ignoreClass>
-                          <ignoreClass>org.jboss.security.*</ignoreClass>
-                          <ignoreClass>org.jboss.system.*</ignoreClass>
-                          <ignoreClass>org.jboss.Version</ignoreClass>
-                          <ignoreClass>org.quartz.*</ignoreClass>
+                          <!-- TODO remove exclusions as offending jars are fixed or removed -->
 
                           <!--  caused by gwt jars -->
+                           <!-- https://code.google.com/p/google-web-toolkit/issues/detail?id=4484 -->
                           <ignoreClass>com.google.common.*</ignoreClass>
                           <ignoreClass>com.google.gwt.*</ignoreClass>
                           <ignoreClass>com.google.web.bindery.*</ignoreClass>
                           <ignoreClass>com.ibm.icu.*</ignoreClass>
                           <ignoreClass>com.steadystate.css.*</ignoreClass>
+                          <ignoreClass>javax.annotation.*</ignoreClass>
+                          <ignoreClass>javax.servlet.*</ignoreClass>
                           <ignoreClass>javax.servlet.jsp.*</ignoreClass>
                           <ignoreClass>javax.validation.ConstraintViolationException_CustomFieldSerializer</ignoreClass>
+                          <ignoreClass>javax.xml.*</ignoreClass>
                           <ignoreClass>org.apache.commons.beanutils.*</ignoreClass>
                           <ignoreClass>org.apache.commons.codec.*</ignoreClass>
+                          <ignoreClass>org.apache.commons.collections.*</ignoreClass>
                           <ignoreClass>org.apache.commons.io.*</ignoreClass>
                           <ignoreClass>org.apache.commons.lang.*</ignoreClass>
+                          <ignoreClass>org.apache.commons.logging.*</ignoreClass>
+                          <ignoreClass>org.apache.html.*</ignoreClass>
                           <ignoreClass>org.apache.http.*</ignoreClass>
                           <ignoreClass>org.apache.james.mime4j.*</ignoreClass>
                           <ignoreClass>org.apache.regexp.*</ignoreClass>
+                          <ignoreClass>org.apache.wml.*</ignoreClass>
+                          <ignoreClass>org.apache.xerces.*</ignoreClass>
+                          <ignoreClass>org.apache.xml.*</ignoreClass>
+                          <ignoreClass>org.apache.xmlcommons.Version</ignoreClass>
                           <ignoreClass>org.cyberneko.html.*</ignoreClass>
                           <ignoreClass>org.hibernate.validator.*</ignoreClass>
                           <ignoreClass>org.w3c.css.sac.*</ignoreClass>
-
-                          <!-- caused by gwt jars and jboss-embedded-thirdparty-all -->
-                          <ignoreClass>javax.servlet.*</ignoreClass>
-                          <ignoreClass>javax.xml.*</ignoreClass>
-                          <ignoreClass>org.apache.html.*</ignoreClass>
-                          <ignoreClass>org.apache.wml.*</ignoreClass>
-                          <ignoreClass>org.apache.xerces.*</ignoreClass>
-                          <ignoreClass>org.apache.xmlcommons.Version</ignoreClass>
-                          <ignoreClass>org.apache.xml.serialize.*</ignoreClass>
                           <ignoreClass>org.w3c.dom.*</ignoreClass>
                           <ignoreClass>org.xml.sax.*</ignoreClass>
+
+                          <!-- Caused by arquillian -->
+                          <ignoreClass>org.osgi.util.*</ignoreClass>
+                          <!-- Caused by differing IDs for JDK_HOME/tools.jar -->
+                          <ignoreClass>com.sun.tools.*</ignoreClass>
+                          <ignoreClass>sun.*</ignoreClass>
                        </ignoreClasses>
                     </banDuplicateClasses>
-                  </rules>
-                </configuration>
-              </execution>
-              <execution>
-                  <id>enforce-arquillian-jboss-location-present</id>
-                  <goals>
-                      <goal>enforce</goal>
-                  </goals>
-                  <configuration>
-                      <rules>
-                          <requireProperty>
-                              <property>arquillian.jboss.home</property>
-                              <message>You will need to set the arquillian.jboss.home property to run integration tests</message>
-                          </requireProperty>
-                      </rules>
-                      <fail>false</fail>
-                  </configuration>
-              </execution>
-            </executions>
+                    <requireProperty>
+                       <property>arquillian.jboss.home</property>
+                       <message>You must set the arquillian.jboss.home property to run integration tests</message>
+                    </requireProperty>
+                </rules>
+            </configuration>
          </plugin>
 
             <plugin>
@@ -1112,6 +1112,10 @@
                     <groupId>javassist</groupId>
                     <artifactId>javassist</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>jcip-annotations</artifactId>
+                    <groupId>net.jcip</groupId>
+                </exclusion>
             </exclusions>
 		</dependency>
 		<dependency>
@@ -1147,13 +1151,22 @@
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-jaxrs</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-xc</artifactId>
 		</dependency>
 
+      <dependency>
+         <groupId>org.jboss.spec.javax.faces</groupId>
+         <artifactId>jboss-jsf-api_2.1_spec</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.spec.javax.transaction</groupId>
+         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss</groupId>
+         <artifactId>jboss-dmr</artifactId>
+         <scope>test</scope>
+      </dependency>
 
 		<!-- Drools -->
 
@@ -1177,6 +1190,10 @@
 
         <dependency>
             <groupId>org.richfaces.ui</groupId>
+            <artifactId>richfaces-components-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.richfaces.ui</groupId>
             <artifactId>richfaces-components-ui</artifactId>
         </dependency>
 
@@ -1189,7 +1206,6 @@
         <dependency>
             <groupId>com.sun.faces</groupId>
             <artifactId>jsf-impl</artifactId>
-            <version>2.1.13</version>
         </dependency>
 
 		<!-- Hibernate / JPA -->
@@ -1228,13 +1244,13 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-testing</artifactId>
             <scope>test</scope>
+            <exclusions>
+    				<exclusion>
+						<artifactId>tools</artifactId>
+						<groupId>com.sun</groupId>
+    				</exclusion>
+            </exclusions>
         </dependency>
-
-		<dependency>
-			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
-			<scope>provided</scope>
-		</dependency>
 
       <dependency>
          <groupId>net.sf.ehcache</groupId>
@@ -1259,10 +1275,6 @@
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-plaintext</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.okapi.filters</groupId>
-            <artifactId>okapi-filter-tmx</artifactId>
         </dependency>
 
         <dependency>
@@ -1399,11 +1411,18 @@
 			<artifactId>hibernate-search-analyzers</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<scope>provided</scope>
-		</dependency>
+      <dependency>
+         <groupId>org.hibernate.javax.persistence</groupId>
+         <artifactId>hibernate-jpa-2.0-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-search-engine</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-search-orm</artifactId>
+      </dependency>
 
 		<dependency>
 			<groupId>javax.el</groupId>
@@ -1448,28 +1467,6 @@
             <scope>test</scope>
         </dependency>
 
-<!--
-		<dependency>
-			<groupId>javassist</groupId>
-			<artifactId>javassist</artifactId>
-			<scope>provided</scope>
-		</dependency>
--->
-
-<!--
-		<dependency>
-			<groupId>javax.faces</groupId>
-			<artifactId>jsf-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.sun.faces</groupId>
-			<artifactId>jsf-impl</artifactId>
-			<scope>provided</scope>
-		</dependency>
--->
-
 		<dependency>
 			<groupId>javax.annotation</groupId>
 			<artifactId>jsr250-api</artifactId>
@@ -1481,13 +1478,7 @@
 			<artifactId>stax-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
-<!-- 
-		<dependency>
-			<groupId>xpp3</groupId>
-			<artifactId>xpp3_min</artifactId>
-			<scope>provided</scope>
-		</dependency>
- -->
+
 		<!-- Container dependencies - provided by jboss -->
 
 		<dependency>
@@ -1507,50 +1498,33 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Testing dependencies -->
-
-		<!--<dependency>
-			<groupId>org.jboss.embedded</groupId>
-			<artifactId>jboss-embedded-all</artifactId>
-			<version>${jboss.embedded.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jboss.microcontainer</groupId>
-					<artifactId>jboss-deployers-client-spi</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jboss.embedded</groupId>
-					<artifactId>jboss-embedded</artifactId>
-				</exclusion>
-			</exclusions>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
-			<groupId>org.jboss.embedded</groupId>
-			<artifactId>thirdparty-all</artifactId>
-			<version>${jboss.embedded.version}</version>
-			<scope>test</scope>
+			<groupId>org.javassist</groupId>
+			<artifactId>javassist</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.jboss.seam.embedded</groupId>
-			<artifactId>jboss-embedded-api</artifactId>
-			<version>${jboss.embedded.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jboss.microcontainer</groupId>
-					<artifactId>jboss-deployers-client-spi</artifactId>
-				</exclusion>
-			</exclusions>
-			<scope>test</scope>
-		</dependency>-->
 
         <!-- This must appear before arquillian dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Arquillian 1.0.4 should eliminate the need for this dependency.
@@ -1563,8 +1537,53 @@
         </dependency>-->
 
         <dependency>
+            <groupId>org.jboss.arquillian.config</groupId>
+            <artifactId>arquillian-config-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-spi</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -1572,6 +1591,41 @@
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-arquillian-container-managed</artifactId>
             <version>7.1.3.Final</version>
+            <scope>test</scope>
+            <exclusions>
+    				<exclusion>
+						<artifactId>jboss-logmanager</artifactId>
+						<groupId>org.jboss.logmanager</groupId>
+    				</exclusion>
+    				<exclusion>
+						<artifactId>log4j-jboss-logmanager</artifactId>
+						<groupId>org.jboss.logmanager</groupId>
+    				</exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-arquillian-common</artifactId>
+            <scope>test</scope>
+            <exclusions>
+               <exclusion>
+                  <artifactId>
+                     log4j-jboss-logmanager
+                  </artifactId>
+                  <groupId>
+                     org.jboss.logmanager
+                  </groupId>
+               </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-controller-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-controller</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -1740,11 +1794,21 @@
 	       </exclusions>
 	    </dependency>
 
-		<dependency>
-			<groupId>org.openid4java</groupId>
-			<artifactId>openid4java-nodeps</artifactId>
-			<version>0.9.5</version>
-		</dependency>
+      <dependency>
+         <groupId>org.openid4java</groupId>
+         <artifactId>openid4java-nodeps</artifactId>
+         <version>0.9.5</version>
+         <exclusions>
+            <exclusion>
+               <artifactId>
+                  commons-logging
+               </artifactId>
+               <groupId>
+                  commons-logging
+               </groupId>
+            </exclusion>
+         </exclusions>
+      </dependency>
 
 		<dependency>
 			<groupId>org.openxri</groupId>
@@ -1763,6 +1827,10 @@
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-jcl</artifactId>
 				</exclusion>
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -1774,6 +1842,10 @@
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-jcl</artifactId>
+				</exclusion>
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -1804,10 +1876,6 @@
         <dependency>
           <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
           <groupId>com.beust</groupId>
@@ -1841,11 +1909,13 @@
       <dependency>
          <groupId>xom</groupId>
          <artifactId>xom</artifactId>
+         <exclusions>
+            <exclusion>
+               <artifactId>xalan</artifactId>
+               <groupId>xalan</groupId>
+            </exclusion>
+         </exclusions>
       </dependency>
-		<dependency>
-		    <groupId>org.functionaljava</groupId>
-		    <artifactId>functionaljava</artifactId>
-		</dependency>
 	</dependencies>
 
 


### PR DESCRIPTION
- Fail on errors from maven-dependency-plugin and maven-enforcer-plugin
- Update parent version
- Simplify configuration for maven-enforcer-plugin
- Exclude unused or conflicting dependencies
- Declare dependencies which were used but not declared
- Update shrinkwrap-resolver and fix Deployments class
- Put boms at the top of server pom to avoid mismatched dependencies
