### PR TITLE
make functional test more robust

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -82,11 +82,14 @@ public class AbstractPage
    protected void clickAndExpectErrors(WebElement button)
    {
       button.click();
-      List<String> errors = getErrors();
-      if (errors.isEmpty())
+      refreshPageUntil(this, new Predicate<WebDriver>()
       {
-         throw new RuntimeException("Errors expected, none found.");
-      }
+         @Override
+         public boolean apply(WebDriver input)
+         {
+            return getErrors().size() > 0;
+         }
+      });
    }
 
    public List<String> getErrors()


### PR DESCRIPTION
error on jsf page is often dynamic and sometimes the build fails for slow ajax response. This should address it.
