### PR TITLE
rhbz1007106 - Correct error when signing up with open where the open id username is the same as an existing Zanata user name.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/ProfileAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/ProfileAction.java
@@ -130,11 +130,14 @@ public class ProfileAction implements Serializable
    @Create
    public void onCreate()
    {
-      username = identity.getCredentials().getUsername();
+      if( identity.getCredentials().getAuthType() != AuthenticationType.OPENID )
+      {
+         // Open id user names are url's so they don't make good defaults
+         username = identity.getCredentials().getUsername();
+      }
       newUser = identityStore.isNewUser(username);
       if (newUser)
       {
-         name = identity.getCredentials().getUsername();
          String domain = applicationConfiguration.getDomainName();
          if( domain == null )
          {

--- a/zanata-war/src/main/java/org/zanata/security/ZanataJpaIdentityStore.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataJpaIdentityStore.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.security;
 
+import org.jboss.seam.Component;
 import org.jboss.seam.annotations.Create;
 import org.jboss.seam.annotations.Install;
 import org.jboss.seam.annotations.Name;
@@ -34,6 +35,7 @@ import org.jboss.seam.security.crypto.BinTools;
 import org.jboss.seam.security.management.IdentityManagementException;
 import org.jboss.seam.security.management.JpaIdentityStore;
 import org.jboss.seam.util.AnnotatedBeanProperty;
+import org.zanata.dao.AccountDAO;
 import org.zanata.model.type.UserApiKey;
 
 import static org.jboss.seam.ScopeType.APPLICATION;
@@ -164,6 +166,12 @@ public class ZanataJpaIdentityStore extends JpaIdentityStore
    public boolean isNewUser(String username)
    {
       Object user = lookupUser(username);
+      // also look in the credentials table
+      if(user == null)
+      {
+         AccountDAO accountDAO = (AccountDAO)Component.getInstance(AccountDAO.class);
+         user = accountDAO.getByCredentialsId(username);
+      }
       return user == null;
    }
 

--- a/zanata-war/src/main/java/org/zanata/security/ZanataOpenId.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataOpenId.java
@@ -325,14 +325,17 @@ public class ZanataOpenId implements OpenIdAuthCallback
 
          identity.setPreAuthenticated(true);
 
-         // If the user hasn't been registered, there is no authenticated account
          if( authenticatedAccount != null && authenticatedAccount.isEnabled() )
          {
             credentials.setUsername(authenticatedAccount.getUsername());
             Identity.instance().acceptExternallyAuthenticatedPrincipal((new OpenIdPrincipal(result.getAuthenticatedId())));
             this.loginImmediate();
          }
-
+         // If the user hasn't been registered yet
+         else if( authenticatedAccount == null )
+         {
+            credentials.setUsername(result.getAuthenticatedId()); // this is the full open id
+         }
       }
    }
 


### PR DESCRIPTION
This issue brings up a bigger problem which is that our authentication system has become too complicated and bloated for its own good. We need to streamline and refactor it.
