### PR TITLE
fix issue - TransUnitUpdated event will cause editor in unsaved style

### DIFF
--- a/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/TargetContentsPresenter.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/TargetContentsPresenter.java
@@ -540,8 +540,8 @@ public class TargetContentsPresenter implements
       if (contentsDisplayOptional.isPresent())
       {
          TargetContentsDisplay contentsDisplay = contentsDisplayOptional.get();
-         contentsDisplay.setState(TargetContentsDisplay.EditingState.SAVED);
          contentsDisplay.setValueAndCreateNewEditors(updatedTransUnit);
+         contentsDisplay.setState(TargetContentsDisplay.EditingState.SAVED);
          contentsDisplay.refresh();
          if (equal(updatedTransUnit.getId(), currentTransUnitId))
          {

--- a/zanata-war/src/test/java/org/zanata/webtrans/client/presenter/TargetContentsPresenterTest.java
+++ b/zanata-war/src/test/java/org/zanata/webtrans/client/presenter/TargetContentsPresenterTest.java
@@ -533,8 +533,10 @@ public class TargetContentsPresenterTest
 
       presenter.updateRow(updatedTransUnit);
 
-      verify(display).setValueAndCreateNewEditors(updatedTransUnit);
-      verify(display).refresh();
+      InOrder inOrder = Mockito.inOrder(display);
+      inOrder.verify(display).setValueAndCreateNewEditors(updatedTransUnit);
+      inOrder.verify(display).setState(TargetContentsDisplay.EditingState.SAVED);
+      inOrder.verify(display).refresh();
    }
 
    @Test


### PR DESCRIPTION
The order is important.
CodeMirror onchange event will fire up and mark editor as unsaved (when TransUnitUpdated event received from server and editor gets udpated). 
So setting state to saved must happen after setting code mirror value.
The test will ensure this.

To test this:
1. Search and replace some text or perform a TM merge.
2. Verify editor is NOT in unsaved style.
