### PR TITLE
Fix sign in for OpenID enabled server.

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
@@ -20,27 +20,29 @@
  */
 package org.zanata.page.account;
 
-import java.util.List;
-
+import com.google.common.base.Predicate;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import com.google.common.base.Predicate;
-
-import lombok.extern.slf4j.Slf4j;
 import org.zanata.page.AbstractPage;
 import org.zanata.page.BasePage;
+
+import java.util.List;
 
 @Slf4j
 public class SignInPage extends BasePage
 {
-   @FindBy(id = "login:usernameField:username")
+   @FindBy(id = "login:internal_signin")
+   private WebElement internalSignIn;
+
+   @FindBy(id = "login:providerUsernameField:username")
    private WebElement usernameField;
 
-   @FindBy(id = "login:passwordField:password")
+   @FindBy(id = "login:providerPasswordField:password")
    private WebElement passwordField;
 
    @FindBy(id = "login:Sign_in")
@@ -52,6 +54,12 @@ public class SignInPage extends BasePage
    public SignInPage(final WebDriver driver)
    {
       super(driver);
+   }
+
+   public SignInPage selectInternalSignin()
+   {
+      internalSignIn.click();
+      return new SignInPage(getDriver());
    }
 
    public <P extends AbstractPage> P signInAndGoToPage(String username, String password, Class<P> pageClass)
@@ -106,8 +114,9 @@ public class SignInPage extends BasePage
 
    private void doSignIn(String username, String password)
    {
-      SignInPage.log.info("log in as username: {}", username);
+      SignInPage.log.info("Internal log in as username: {}", username);
       usernameField.clear();
+      passwordField.clear();
       usernameField.sendKeys(username);
       passwordField.sendKeys(password);
       signInButton.click();
@@ -126,4 +135,5 @@ public class SignInPage extends BasePage
          }
       });
    }
+
 }

--- a/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
@@ -44,7 +44,7 @@ public class LoginWorkFlow extends AbstractWebWorkFlow
          dashboardPage.logout();
       }
 
-      SignInPage signInPage = dashboardPage.clickSignInLink();
+      SignInPage signInPage = dashboardPage.clickSignInLink().selectInternalSignin();
       return signInPage.signInAndGoToPage(username, password, DashboardPage.class);
    }
 

--- a/functional-test/src/test/java/org/zanata/feature/administration/EditHomePageTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/administration/EditHomePageTest.java
@@ -58,6 +58,7 @@ public class EditHomePageTest
       editHomeContentPage.cancelUpdate();
    }
 
+   @Test
    public void goToEditPageCode()
    {
       DashboardPage dashboard = new LoginWorkFlow().signIn("admin", "admin");

--- a/functional-test/src/test/java/org/zanata/feature/security/SecurityFullTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/security/SecurityFullTest.java
@@ -67,7 +67,7 @@ public class SecurityFullTest
    @Test
    public void signInFailure()
    {
-      SignInPage signInPage = new BasicWorkFlow().goToHome().clickSignInLink();
+      SignInPage signInPage = new BasicWorkFlow().goToHome().clickSignInLink().selectInternalSignin();
       signInPage = signInPage.signInFailure("nosuchuser", "password");
       assertThat("Error message is shown", signInPage.getNotificationMessage(), Matchers.equalTo("Login failed"));
       assertThat("User has failed to log in", !signInPage.hasLoggedIn());
@@ -77,7 +77,7 @@ public class SecurityFullTest
    @Ignore("RHBZ-987707 | Cannot intercept email yet")
    public void resetPasswordSuccessful()
    {
-      SignInPage signInPage = new BasicWorkFlow().goToHome().clickSignInLink();
+      SignInPage signInPage = new BasicWorkFlow().goToHome().clickSignInLink().selectInternalSignin();
       ResetPasswordPage resetPasswordPage = signInPage.gotToResetPassword();
       resetPasswordPage = resetPasswordPage.enterUserName("nosuchuser").enterEmail("nosuchuser@nosuchdomain.com");
       resetPasswordPage = resetPasswordPage.resetPassword();


### PR DESCRIPTION
The functional test Zanata server has OpenID and internal auth
enabled, which changes the login process. Basic internal
sign in still only available.
TODO: Tests for OpenID login.
(cherry picked from commit d62f98db687c961b6c46e7f03918cfaa0bba1240)

Conflicts:

```
zanata-war/src/main/webapp/account/login.xhtml
```
