### PR TITLE
Make config download maintainable

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/ConfigurationAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/ConfigurationAction.java
@@ -51,48 +51,27 @@ public class ConfigurationAction implements Serializable
    @In
    private ConfigurationService configurationServiceImpl;
 
-   public void getData()
+   public void downloadGeneralConfig()
    {
-      getData(false, null);
+      respondWithFile(configurationServiceImpl.getGeneralConfig(projectSlug, iterationSlug));
    }
 
-   public void getData(HLocale locale)
+   public void downloadOfflineTranslationConfig(HLocale locale)
    {
-      getData(false, locale);
+      respondWithFile(configurationServiceImpl.getConfigForOfflineTranslation(projectSlug, iterationSlug, locale));
    }
 
-   public void getOfflinePoConfigData()
-   {
-      getOfflinePoConfigData(null);
-   }
-
-   public void getOfflinePoConfigData(HLocale locale)
-   {
-      getData(true, locale);
-   }
-
-
-   private void getData(boolean useOfflinePo, HLocale locale)
+   private void respondWithFile(String configFileContents)
    {
       HttpServletResponse response = (HttpServletResponse) FacesContext.getCurrentInstance().getExternalContext().getResponse();
       response.setContentType("application/xml");
       response.addHeader("Content-disposition", "attachment; filename=\"" 
-                                    + this.configurationServiceImpl.getConfigurationFileName() + "\"");
+                                    + configurationServiceImpl.getConfigurationFileName() + "\"");
       response.setCharacterEncoding("UTF-8");
       try
       {
          ServletOutputStream os = response.getOutputStream();
-
-         if (locale == null)
-         {
-            os.write(configurationServiceImpl.getConfigurationFileContents(projectSlug,
-                  iterationSlug, useOfflinePo).getBytes());
-         }
-         else
-         {
-            os.write(configurationServiceImpl.getConfigurationFileContents(projectSlug,
-                  iterationSlug, locale, useOfflinePo).getBytes());
-         }
+         os.write(configFileContents.getBytes());
          os.flush();
          os.close();
          FacesContext.getCurrentInstance().responseComplete();

--- a/zanata-war/src/main/java/org/zanata/action/ProjectIterationZipFileAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/ProjectIterationZipFileAction.java
@@ -10,7 +10,6 @@ import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
 import org.jboss.seam.annotations.security.Restrict;
 import org.jboss.seam.security.Identity;
-import org.zanata.ApplicationConfiguration;
 import org.zanata.async.AsyncTaskHandle;
 import org.zanata.async.tasks.ZipFileBuildTask;
 import org.zanata.dao.ProjectIterationDAO;
@@ -29,9 +28,6 @@ public class ProjectIterationZipFileAction implements Serializable
    @In
    AsyncTaskManagerService asyncTaskManagerServiceImpl;
 
-   @In
-   private ApplicationConfiguration applicationConfiguration;
-
    private String projectSlug;
 
    private String iterationSlug;
@@ -42,7 +38,7 @@ public class ProjectIterationZipFileAction implements Serializable
 
    @Begin(join = true)
    @Restrict("#{s:hasPermission(projectIterationZipFileAction.projectIteration, 'download-all')}")
-   public void prepareIterationZipFile(boolean offlinePo)
+   public void prepareIterationZipFile(boolean isPoProject)
    {
       if( this.zipFilePrepHandle != null && !this.zipFilePrepHandle.isDone() )
       {
@@ -51,8 +47,8 @@ public class ProjectIterationZipFileAction implements Serializable
       }
 
       // Start a zip file task
-      ZipFileBuildTask task = new ZipFileBuildTask(this.projectSlug, this.iterationSlug, this.localeId,
-            Identity.instance().getCredentials().getUsername(), offlinePo);
+      ZipFileBuildTask task = new ZipFileBuildTask(projectSlug, iterationSlug, localeId,
+            Identity.instance().getCredentials().getUsername(), isPoProject);
 
       String taskId = asyncTaskManagerServiceImpl.startTask(task);
       zipFilePrepHandle = asyncTaskManagerServiceImpl.getHandle(taskId);

--- a/zanata-war/src/main/java/org/zanata/service/ConfigurationService.java
+++ b/zanata-war/src/main/java/org/zanata/service/ConfigurationService.java
@@ -25,56 +25,26 @@ import org.zanata.model.HLocale;
 public interface ConfigurationService
 {
    /**
-    * Returns the contents of the configuration for a given project.
+    * Get a standard config file for a project-version.
     * 
-    * @param projectSlug
-    * @param iterationSlug
-    * @param useOfflinePo true to use 'offlinepo' instead of the configured project type
-    * @return The configuration file contents for the given project and
-    *         iteration.
+    * @return contents of the config file
     */
-   String getConfigurationFileContents(String projectSlug, String iterationSlug, boolean useOfflinePo);
+   String getGeneralConfig(String projectSlug, String iterationSlug);
 
    /**
-    * Returns the contents of the configuration for a given project. Use this method
-    * when the server path of the zanata server needs to be customized
-    *
-    * @param projectSlug
-    * @param iterationSlug
-    * @param useOfflinePo true to use 'offlinepo' instead of the configured project type
-    * @param serverPath
-    * @return The configuration file contents for the given project and
-    *         iteration.
+    * Get a standard config file for dealing with a single locale for a project-version.
+    * 
+    * @return contents of the config file
     */
-   String getConfigurationFileContents(String projectSlug, String iterationSlug, boolean useOfflinePo, String serverPath);
+   String getSingleLocaleConfig(String projectSlug, String versionSlug, HLocale locale);
 
    /**
-    * Returns the contents of the configuration for a given project with a
-    * single locale.
+    * Get a config file for a single locale, with project type adjusted to be appropriate for
+    * offline translation.
     * 
-    * @param projectSlug
-    * @param iterationSlug
-    * @param locale
-    * @param useOfflinePo
-    * @return The configuration file contents for the given project and
-    *         iteration.
+    * @return contents of the config file
     */
-   String getConfigurationFileContents(String projectSlug, String iterationSlug, HLocale locale, boolean useOfflinePo);
-
-   /**
-    * Returns the contents of the configuration for a given project with a
-    * single locale. Use this method when the server path of the zanata server
-    * needs to be customized.
-    * 
-    * @param projectSlug
-    * @param iterationSlug
-    * @param locale
-    * @param useOfflinePo true to use 'offlinepo' instead of the configured project type
-    * @param serverPath
-    * @return The configuration file contents for the given project and
-    *         iteration.
-    */
-   String getConfigurationFileContents(String projectSlug, String iterationSlug, HLocale locale, boolean useOfflinePo, String serverPath);
+   String getConfigForOfflineTranslation(String projectSlug, String versionSlug, HLocale locale);
 
    /**
     * Returns the default configuration file Name.

--- a/zanata-war/src/main/java/org/zanata/service/impl/ConfigurationServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/ConfigurationServiceImpl.java
@@ -20,10 +20,11 @@
  */
 package org.zanata.service.impl;
 
-import java.util.ArrayList;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.commons.lang.StringUtils.join;
+
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
 import org.jboss.seam.ScopeType;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
@@ -33,7 +34,6 @@ import org.zanata.common.Namespaces;
 import org.zanata.common.ProjectType;
 import org.zanata.dao.ProjectIterationDAO;
 import org.zanata.model.HLocale;
-import org.zanata.model.HProjectIteration;
 import org.zanata.service.ConfigurationService;
 import org.zanata.service.LocaleService;
 
@@ -50,111 +50,166 @@ public class ConfigurationServiceImpl implements ConfigurationService
 
    @In
    private ProjectIterationDAO projectIterationDAO;
-   
+
    @In
    private ApplicationConfiguration applicationConfiguration;
 
    @Override
-   public String getConfigurationFileContents(String projectSlug, String iterationSlug, boolean useOfflinePo)
+   public String getGeneralConfig(String projectSlug, String versionSlug)
    {
-      return getConfigurationFileContents(projectSlug, iterationSlug, useOfflinePo, applicationConfiguration.getServerPath());
+      return new ConfigBuilder(projectSlug, versionSlug).getConfig();
    }
 
    @Override
-   public String getConfigurationFileContents(String projectSlug, String iterationSlug, HLocale locale, boolean useOfflinePo)
-   {
-      return getConfigurationFileContents(projectSlug, iterationSlug, locale, useOfflinePo, applicationConfiguration.getServerPath());
+   public String getSingleLocaleConfig(String projectSlug, String versionSlug, HLocale locale) {
+      return new SingleLocaleConfigBuilder(projectSlug, versionSlug, locale).getConfig();
    }
 
    @Override
-   public String getConfigurationFileContents(String projectSlug, String iterationSlug, boolean useOfflinePo, String serverPath)
-   {
-      return getConfigurationFileContents(projectSlug, iterationSlug, null, useOfflinePo, serverPath);
-   }
-
-   @Override
-   public String getConfigurationFileContents(String projectSlug, String iterationSlug, HLocale locale, boolean useOfflinePo, String serverPath)
-   {
-      HProjectIteration projectIteration = projectIterationDAO.getBySlug(projectSlug, iterationSlug);
-      ProjectType projectType = projectIteration.getProjectType();
-
-      StringBuilder var = new StringBuilder(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-            "<config xmlns=\"" + Namespaces.ZANATA_CONFIG + "\">\n");
-      var.append("  <url>").append(serverPath).append("/</url>\n");
-      var.append("  <project>").append(projectSlug).append("</project>\n");
-      var.append("  <project-version>").append(iterationSlug).append("</project-version>\n");
-      if (useOfflinePo)
-      {
-         // FIXME this comment could be localized
-         var.append("  <!-- NB project-type set to 'offlinepo' to allow offline po translation\n")
-            .append("       from non-po documents, project-type on server is '")
-            .append(String.valueOf(projectType).toLowerCase()).append("' -->\n")
-            .append("  <project-type>").append(PROJECT_TYPE_OFFLINE_PO).append("</project-type>\n");
-      }
-      else if ( projectType != null )
-      {
-         if( projectType == ProjectType.Gettext )
-         {
-            // FIXME this comment could be localized
-            var.append("  <!-- NB project-type set to 'podir' to allow uploads, but original was 'gettext' -->\n");
-            var.append("  <project-type>").append(ProjectType.Podir.toString().toLowerCase()).append("</project-type>\n");
-         }
-         else
-         {
-            var.append("  <project-type>").append(projectType.toString().toLowerCase()).append("</project-type>\n");
-         }
-      }
-      else
-      {
-         var.append("  <!--<project-type>");
-         var.append(StringUtils.join(ProjectType.values(), "|").toLowerCase());
-         var.append("</project-type>-->\n");
-      }
-      var.append("\n");
-
-      List<HLocale> locales;
-      if (locale == null)
-      {
-         locales = localeServiceImpl.getSupportedLangugeByProjectIteration(projectSlug, iterationSlug);
-      }
-      else
-      {
-         locales = new ArrayList<HLocale>();
-         locales.add(locale);
-      }
-      HLocale source = localeServiceImpl.getSourceLocale(projectSlug, iterationSlug);
-
-      if(locales!=null)
-      {
-         boolean first=true;
-         for(HLocale op: locales)
-         {
-            if(!op.equals(source))
-            {
-               if (first)
-               {
-                  var.append("  <locales>\n");
-               }
-               var.append("    <locale>").append(op.getLocaleId().getId()).append("</locale>\n");
-               first = false;
-            }
-         }
-         if (!first)
-         {
-            var.append("  </locales>\n\n");
-         }
-      }
-
-      var.append("</config>\n");
-
-      return var.toString();
+   public String getConfigForOfflineTranslation(String projectSlug, String versionSlug, HLocale locale) {
+      return new OfflineTranslationConfigBuilder(projectSlug, versionSlug, locale).getConfig();
    }
 
    @Override
    public String getConfigurationFileName()
    {
       return FILE_NAME;
+   }
+
+   private class ConfigBuilder {
+
+      private final String projectSlug;
+      private final String versionSlug;
+
+      private StringBuilder doc;
+
+      public ConfigBuilder(String projectSlug, String versionSlug)
+      {
+         this.projectSlug = projectSlug;
+         this.versionSlug = versionSlug;
+      }
+
+      public String getConfig()
+      {
+         doc = new StringBuilder(
+               "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+               "<config xmlns=\"" + Namespaces.ZANATA_CONFIG + "\">")
+            .append(indent(tag("url", applicationConfiguration.getServerPath() + "/"))).append("\n")
+            .append(indent(tag("project", projectSlug))).append("\n")
+            .append(indent(tag("project-version", versionSlug))).append("\n")
+            .append(makeProjectTypeSection(getProjectType())).append("\n");
+         appendLocalesIfPresent();
+         doc.append("\n")
+            .append("</config>\n");
+         return doc.toString();
+      }
+
+      protected String indent(String line) {
+         return "  " + line;
+      }
+
+      protected String tag(String tagName, String content) {
+         return "<" + tagName + ">" + content + "</" + tagName + ">";
+      }
+
+      protected String makeProjectTypeSection(ProjectType projectType)
+      {
+         if ( projectType != null )
+         {
+            return indent(tag("project-type", projectType.toString().toLowerCase()));
+         }
+         else
+         {
+            return indent(comment(tag("project-type", join(ProjectType.values(), "|").toLowerCase())));
+         }
+      }
+
+      private String comment(String content) {
+         return "<!-- " + content + " -->";
+      }
+
+      private ProjectType getProjectType()
+      {
+         return projectIterationDAO.getBySlug(projectSlug, versionSlug).getProjectType();
+      }
+
+      private void appendLocalesIfPresent()
+      {
+         List<HLocale> locales = getLocalesToAppend();
+         if (!locales.isEmpty()) {
+            appendLocales(locales);
+         }
+      }
+
+      private List<HLocale> getLocalesToAppend() {
+         return removeSourceLocale(getAllLocales());
+      }
+
+      private List<HLocale> removeSourceLocale(List<HLocale> locales) {
+         HLocale source = localeServiceImpl.getSourceLocale(projectSlug, versionSlug);
+         locales.remove(source);
+         return locales;
+      }
+
+      protected List<HLocale> getAllLocales() {
+         return localeServiceImpl.getSupportedLangugeByProjectIteration(projectSlug, versionSlug);
+      }
+
+      private void appendLocales(List<HLocale> locales) {
+         doc.append("\n")
+            .append(indent("<locales>\n"));
+         for(HLocale locale: locales)
+         {
+            doc.append(indent(indent(tag("locale", locale.getLocaleId().getId())))).append("\n");
+         }
+         doc.append(indent("</locales>\n"));
+      }
+
+   }
+
+   private class SingleLocaleConfigBuilder extends ConfigBuilder {
+
+      private final HLocale locale;
+
+      public SingleLocaleConfigBuilder(String projectSlug, String versionSlug, HLocale locale)
+      {
+         super(projectSlug, versionSlug);
+         this.locale = locale;
+      }
+
+      @Override
+      protected List<HLocale> getAllLocales()
+      {
+         return newArrayList(locale);
+      }
+   }
+
+   private class OfflineTranslationConfigBuilder extends SingleLocaleConfigBuilder {
+
+      public OfflineTranslationConfigBuilder(String projectSlug, String versionSlug, HLocale locale)
+      {
+         super(projectSlug, versionSlug, locale);
+      }
+
+      @Override
+      protected String makeProjectTypeSection(ProjectType projectType)
+      {
+         if (projectType == ProjectType.Podir) {
+            return super.makeProjectTypeSection(projectType);
+         }
+
+         if (projectType == ProjectType.Gettext) {
+            return "  <!-- NB project-type set to 'podir' to allow offline translations to be\n"
+                 + "       uploaded, but original was 'gettext' -->\n"
+                 + indent(tag("project-type", ProjectType.Podir.toString().toLowerCase()));
+         }
+
+         return "  <!-- NB project-type set to 'offlinepo' to allow offline po translation\n"
+              + "       from non-po documents, project-type on server is '"
+              + String.valueOf(projectType).toLowerCase() + "' -->\n"
+              + indent(tag("project-type", PROJECT_TYPE_OFFLINE_PO));
+      }
+
    }
 
 }

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/DocumentListPresenter.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/DocumentListPresenter.java
@@ -518,7 +518,11 @@ public class DocumentListPresenter extends WidgetPresenter<DocumentListDisplay> 
    public void downloadAllFiles()
    {
       WorkspaceId workspaceId = userWorkspaceContext.getWorkspaceContext().getWorkspaceId();
-      dispatcher.execute(new DownloadAllFilesAction(workspaceId.getProjectIterationId().getProjectSlug(), workspaceId.getProjectIterationId().getIterationSlug(), workspaceId.getLocaleId().getId(), !isPoProject(getProjectType())), new AsyncCallback<DownloadAllFilesResult>()
+      dispatcher.execute(
+            new DownloadAllFilesAction(workspaceId.getProjectIterationId().getProjectSlug(),
+                  workspaceId.getProjectIterationId().getIterationSlug(),
+                  workspaceId.getLocaleId().getId(), isPoProject(getProjectType())),
+                  new AsyncCallback<DownloadAllFilesResult>()
       {
          @Override
          public void onFailure(Throwable caught)

--- a/zanata-war/src/main/java/org/zanata/webtrans/server/rpc/DownloadAllFilesHandler.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/server/rpc/DownloadAllFilesHandler.java
@@ -28,7 +28,6 @@ import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
 import org.jboss.seam.security.Identity;
-import org.zanata.ApplicationConfiguration;
 import org.zanata.async.AsyncTaskHandle;
 import org.zanata.async.tasks.ZipFileBuildTask;
 import org.zanata.dao.ProjectIterationDAO;
@@ -49,8 +48,6 @@ import org.zanata.webtrans.shared.rpc.DownloadAllFilesResult;
 @ActionHandlerFor(DownloadAllFilesAction.class)
 public class DownloadAllFilesHandler extends AbstractActionHandler<DownloadAllFilesAction, DownloadAllFilesResult>
 {
-   @In
-   private ApplicationConfiguration applicationConfiguration;
 
    @In
    private ZanataIdentity identity;
@@ -81,7 +78,7 @@ public class DownloadAllFilesHandler extends AbstractActionHandler<DownloadAllFi
                                                       action.getVersionSlug(),
                                                       action.getLocaleId(),
                                                       Identity.instance().getCredentials().getUsername(),
-                                                      action.isOfflinePo());
+                                                      action.isPoProject());
 
          // Fire the zip file building process and wait until it is ready to
          // return

--- a/zanata-war/src/main/java/org/zanata/webtrans/shared/rpc/DownloadAllFilesAction.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/shared/rpc/DownloadAllFilesAction.java
@@ -31,19 +31,19 @@ public class DownloadAllFilesAction implements DispatchAction<DownloadAllFilesRe
 
    private String projectSlug, versionSlug, localeId;
 
-   private boolean offlinePo;
+   private boolean isPoProject;
 
    @SuppressWarnings("unused")
    private DownloadAllFilesAction()
    {
    }
 
-   public DownloadAllFilesAction(String projectSlug, String versionSlug, String localeId, boolean offlinePo)
+   public DownloadAllFilesAction(String projectSlug, String versionSlug, String localeId, boolean isPoProject)
    {
       this.projectSlug = projectSlug;
       this.versionSlug = versionSlug;
       this.localeId = localeId;
-      this.offlinePo = offlinePo;
+      this.isPoProject = isPoProject;
    }
 
    public String getProjectSlug()
@@ -61,9 +61,9 @@ public class DownloadAllFilesAction implements DispatchAction<DownloadAllFilesRe
       return localeId;
    }
 
-   public boolean isOfflinePo()
+   public boolean isPoProject()
    {
-      return offlinePo;
+      return isPoProject;
    }
 
 }

--- a/zanata-war/src/main/webapp/iteration/files.xhtml
+++ b/zanata-war/src/main/webapp/iteration/files.xhtml
@@ -286,7 +286,7 @@
                         rendered="#{projectIterationFilesAction.poProject}"
                         value="#{messages['jsf.ConfigFileForOfflineTranslation']}"
                         title="#{messages['jsf.GenerateProjectConfigSingleLocale']}"
-                        action="#{configurationAction.getData(projectIterationFilesAction.locale)}">
+                        action="#{configurationAction.downloadOfflineTranslationConfig(projectIterationFilesAction.locale)}">
                     <f:param name="projectSlug" value="#{projectIterationFilesAction.projectSlug}" />
                     <f:param name="iterationSlug" value="#{projectIterationFilesAction.iterationSlug}" />
                 </s:link>
@@ -295,7 +295,7 @@
                         rendered="#{projectIterationFilesAction.knownProjectType and !projectIterationFilesAction.poProject}"
                         value="#{messages['jsf.ConfigFileForOfflineTranslation']}"
                         title="#{messages['jsf.GenerateProjectConfigForOfflineTranslation']}"
-                        action="#{configurationAction.getOfflinePoConfigData(projectIterationFilesAction.locale)}">
+                        action="#{configurationAction.downloadOfflineTranslationConfig(projectIterationFilesAction.locale)}">
                     <f:param name="projectSlug" value="#{projectIterationFilesAction.projectSlug}" />
                     <f:param name="iterationSlug" value="#{projectIterationFilesAction.iterationSlug}" />
                 </s:link>
@@ -308,7 +308,7 @@
                 </s:link>
 
                 <ui:param name="downloadAllAllowed" value="#{projectIterationFilesAction.zipFileDownloadAllowed}" />
-                
+
                 <a4j:commandLink styleClass="action_link #{downloadAllAllowed ? '' : 'disabled'}"
                                  rendered="#{projectIterationFilesAction.poProject or not downloadAllAllowed}"
                                  value="#{messages['jsf.iteration.files.DownloadAllFiles']}"
@@ -317,7 +317,7 @@
                                  render="downloadProgressBar"
                                  disabled="#{not downloadAllAllowed}"
                                  title="#{projectIterationFilesAction.zipFileDownloadTitle}"/>
-                                 
+
                 <a4j:commandLink styleClass="action_link #{downloadAllAllowed ? '' : 'disabled'}"
                                  rendered="#{downloadAllAllowed and !projectIterationFilesAction.poProject}"
                                  value="#{messages['jsf.iteration.files.DownloadAllFilesOfflinePo']}"

--- a/zanata-war/src/main/webapp/iteration/view.xhtml
+++ b/zanata-war/src/main/webapp/iteration/view.xhtml
@@ -138,7 +138,7 @@
 			<s:link styleClass="action_link" 
 				value="#{messages['jsf.ConfigFile']}"
 				title="#{messages['jsf.GenerateProjectConfig']}"
-                action="#{configurationAction.getData()}">
+                action="#{configurationAction.downloadGeneralConfig()}">
 				<f:param name="projectSlug" value="#{viewAllStatusAction.projectSlug}" />
 				<f:param name="iterationSlug" value="#{viewAllStatusAction.iterationSlug}" />
 			</s:link>


### PR DESCRIPTION
Config download was incorrect (See [bug](https://bugzilla.redhat.com/show_bug.cgi?id=959834)) and confusing (pretty sure it ended up incorrect because it was confusing).
- removed incorrect behaviour (was incorrectly using project type 'podir' for gettext projects in all configs).
- changed the API for config generation so it is clear at every stage what type of config is being requested.
- decomposed config generation so the basic structure is easy to follow.
