### PR TITLE
Disable failing Concordion Login test

### DIFF
--- a/functional-test/src/test/java/org/zanata/feature/security/SecurityTestSuite.java
+++ b/functional-test/src/test/java/org/zanata/feature/security/SecurityTestSuite.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright 2013, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
 package org.zanata.feature.security;
 
 import org.junit.runner.RunWith;
@@ -8,7 +28,9 @@ import org.junit.runners.Suite;
  *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ SecurityTest.class, LoginTest.class,
+@Suite.SuiteClasses({
+        SecurityTest.class,
+        /* LoginTest.class, DISABLED (RHBZ-1016937) TODO: FIX */
         SecurityFullTest.class })
 public class SecurityTestSuite {
 }


### PR DESCRIPTION
Will be (likely) fixed in a pending pull request, but needs to
be disabled for now. See RHBZ-1016937.
