### PR TITLE
Remove http from font urls so it loads font over ssl when required.

### DIFF
--- a/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
+++ b/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
@@ -24,7 +24,7 @@
     <link type="text/css" rel="stylesheet"
       href="#{applicationConfiguration.webAssetsUrl}/assets/css/application.css"/>
     <link type="text/css" rel="stylesheet"
-      href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
 
     <script src="codemirror-compressed.js" type="text/javascript"></script>
     <link rel="stylesheet" type="text/css" href="codemirror.css"/>

--- a/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
@@ -43,7 +43,7 @@
     <link type="text/css" rel="stylesheet"
       href="#{request.contextPath}/resources/fontello/css/fontello.css"/>
     <link type="text/css" rel="stylesheet"
-      href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
     <ui:insert name="head"/>
   </h:head>
 

--- a/zanata-war/src/main/webapp/WEB-INF/template/template_2x.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template_2x.xhtml
@@ -23,7 +23,7 @@
     <link type="text/css" rel="stylesheet"
       href="#{applicationConfiguration.webAssetsStyleUrl}"/>
     <link type="text/css" rel="stylesheet"
-      href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
     <ui:insert name="head"/>
   </h:head>
 


### PR DESCRIPTION
We are loading fonts from Google's CDN, but the original url included the http:// which was breaking over a https:// connection.

Simple fix.
