### PR TITLE
Avoid hard-coding http for gravatars

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/GravatarServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/GravatarServiceImpl.java
@@ -12,7 +12,7 @@ import org.zanata.util.HashUtil;
 @Name("gravatarServiceImpl")
 @Scope(ScopeType.STATELESS)
 public class GravatarServiceImpl implements GravatarService {
-    private static String GRAVATAR_URL = "http://www.gravatar.com/avatar/";
+    private static String GRAVATAR_URL = "//www.gravatar.com/avatar/";
 
     @In(required = false, value = JpaIdentityStore.AUTHENTICATED_USER)
     HAccount authenticatedAccount;


### PR DESCRIPTION
This should fix the warning: "The page at https://zanata... displayed
insecure content from http://www.gravatar.com/avatar/..."
