### PR TITLE
Use the old Google site when necessary.

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
@@ -79,4 +79,15 @@ public class GoogleAccountPage extends AbstractPage {
         getDriver().findElement(By.linkText("Sign in with a different account")).click();
         return new GoogleAccountPage(getDriver());
     }
+
+    /**
+     * Query if the old google site login is presented to the user.
+     *
+     * The Google account profile image only shows on the new Google site, so
+     * if this element exists return false.
+     * @return true if the profile image is not shown.
+     */
+    public boolean isTheOldGoogleSite() {
+        return getDriver().findElements(By.id("profile-img")).size() < 1;
+    }
 }

--- a/functional-test/src/main/java/org/zanata/workflow/RegisterWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/RegisterWorkFlow.java
@@ -36,10 +36,15 @@ public class RegisterWorkFlow extends AbstractWebWorkFlow {
                 .goToHome()
                 .clickSignInLink()
                 .selectGoogleOpenID();
-
-        // If Google has remembered us, skip entering the email
-        // If Google has remembered someone else, change the user
-        if (googleAccountPage.hasRememberedAuthentication()) {
+        /*
+            There is the chance that Google presents the old page. It seems
+            to be random. Just enter the email in this case.
+            Otherwise, If Google has remembered us, skip entering the email.
+            If Google has remembered someone else, change the user.
+        */
+        if (googleAccountPage.isTheOldGoogleSite()) {
+            googleAccountPage = googleAccountPage.enterGoogleEmail(email);
+        } else if (googleAccountPage.hasRememberedAuthentication()) {
             if (!googleAccountPage.rememberedUser().equals(email)) {
                 googleAccountPage = googleAccountPage.removeSavedAuthentication();
             }


### PR DESCRIPTION
Occasionally the old Google account site presents itself when logging in,
so if this occurs just enter the email as normal.
