### PR TITLE
Fix the test pages for sign up and log in

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -40,6 +40,10 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 
+/**
+ * The base class for the page driver. Contains functionality not generally of
+ * a user visible nature.
+ */
 @Slf4j
 public class AbstractPage {
     private final WebDriver driver;
@@ -65,56 +69,12 @@ public class AbstractPage {
         return driver;
     }
 
-    public String getTitle() {
-        return driver.getTitle();
-    }
-
     public String getUrl() {
         return driver.getCurrentUrl();
     }
 
     public FluentWait<WebDriver> waitForTenSec() {
         return ajaxWaitForTenSec;
-    }
-
-    protected void clickAndCheckErrors(WebElement button) {
-        button.click();
-        List<String> errors = getErrors();
-        if (!errors.isEmpty()) {
-            throw new RuntimeException(Joiner.on(";").join(errors));
-        }
-    }
-
-    protected void clickAndExpectErrors(WebElement button) {
-        button.click();
-        refreshPageUntil(this, new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getErrors().size() > 0;
-            }
-        });
-    }
-
-    public List<String> getErrors() {
-        List<WebElement> errorSpans =
-                getDriver().findElements(By.xpath("//span[@class='errors']"));
-        return WebElementUtil.elementsToText(errorSpans);
-    }
-
-    /**
-     * Wait until expected number of errors presented on page or timeout.
-     * @param expectedNumber
-     *            expected number of errors on page
-     * @return list of error message
-     */
-    public List<String> getErrors(final int expectedNumber) {
-        refreshPageUntil(this, new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getErrors().size() == expectedNumber;
-            }
-        });
-        return getErrors();
     }
 
     /**

--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -50,14 +50,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 /**
+ * A Base Page is an extension of the Core Page, providing the navigation bar
+ * and sidebar links common to most pages outside of the editor.
  * @author Damian Jansen <a
  *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
- *
- *         This is a basic page that contains features all pages of Zanata
- *         share, eg. the main navigation menu.
  */
 @Slf4j
-public class BasePage extends AbstractPage {
+public class BasePage extends CorePage {
     private List<WebElement> navMenuItems = Collections.emptyList();
 
     @FindBy(id = "nav-main")
@@ -74,9 +73,6 @@ public class BasePage extends AbstractPage {
 
     @FindBy(id = "user_avatar")
     private WebElement userAvatar;
-
-    @FindBy(id = "home")
-    private WebElement homeLink;
 
     private static final By BY_SIGN_IN = By.id("signin_link");
     private static final By BY_SIGN_OUT = By.id("right_menu_sign_out_link");
@@ -95,11 +91,6 @@ public class BasePage extends AbstractPage {
         clickLinkAfterAnimation(BY_PROFILE_LINK);
 
         return new MyAccountPage(getDriver());
-    }
-
-    public HomePage goToHomePage() {
-        homeLink.click();
-        return new HomePage(getDriver());
     }
 
     public ProjectsPage goToProjects() {
@@ -214,22 +205,6 @@ public class BasePage extends AbstractPage {
         return PageFactory.initElements(getDriver(), pageClass);
     }
 
-    public String getNotificationMessage() {
-        List<WebElement> messages = getDriver().findElements(By.id("messages"));
-        return messages.size() > 0 ? messages.get(0).getText() : "";
-    }
-
-    public List<String> waitForErrors() {
-        waitForTenSec().until(new Function<WebDriver, WebElement>() {
-            @Override
-            public WebElement apply(WebDriver driver) {
-                return getDriver().findElement(
-                        By.xpath("//span[@class='errors']"));
-            }
-        });
-        return getErrors();
-    }
-
     /**
      * This is a workaround for
      * https://code.google.com/p/selenium/issues/detail?id=2766 Elemenet not
@@ -254,26 +229,4 @@ public class BasePage extends AbstractPage {
                 ExpectedConditions.visibilityOfElementLocated(By
                         .className("off-canvas--right-under")));
     }
-
-    public void assertNoCriticalErrors() {
-        List<WebElement> errors =
-                getDriver().findElements(By.id("errorMessage"));
-        if (errors.size() > 0) {
-            throw new RuntimeException("Critical error: \n"
-                    + errors.get(0).getText());
-        }
-    }
-
-    public boolean hasNoCriticalErrors() {
-        return getDriver().findElements(By.id("errorMessage")).size() <= 0;
-    }
-
-    /**
-     * Shift focus to the page, in order to activate some elements that
-     * only exhibit behaviour on losing focus.
-     */
-    public void defocus() {
-        getDriver().findElement(By.tagName("body")).click();
-    }
-
 }

--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2013, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+
+package org.zanata.page;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.FluentWait;
+import org.zanata.page.utility.HomePage;
+import org.zanata.util.WebElementUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Contains the physical elements, such as page title and home link, that
+ * must exist on all Zanata pages.
+ * @author Damian Jansen <a
+ *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+public class CorePage extends AbstractPage {
+
+    @FindBy(id = "home")
+    private WebElement homeLink;
+
+    public CorePage(WebDriver driver) {
+        super(driver);
+    }
+
+    public String getTitle() {
+        return getDriver().getTitle();
+    }
+
+    public HomePage goToHomePage() {
+        homeLink.click();
+        return new HomePage(getDriver());
+    }
+
+    protected void clickAndCheckErrors(WebElement button) {
+        button.click();
+        List<String> errors = getErrors();
+        if (!errors.isEmpty()) {
+            throw new RuntimeException(Joiner.on(";").join(errors));
+        }
+    }
+
+    protected void clickAndExpectErrors(WebElement button) {
+        button.click();
+        refreshPageUntil(this, new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return getErrors().size() > 0;
+            }
+        });
+    }
+
+    public List<String> getErrors() {
+        List<WebElement> errorSpans =
+                getDriver().findElements(By.xpath("//span[@class='errors']"));
+        return WebElementUtil.elementsToText(errorSpans);
+    }
+
+    /**
+     * Wait until expected number of errors presented on page or timeout.
+     * @param expectedNumber
+     *            expected number of errors on page
+     * @return list of error message
+     */
+    public List<String> getErrors(final int expectedNumber) {
+        refreshPageUntil(this, new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return getErrors().size() == expectedNumber;
+            }
+        });
+        return getErrors();
+    }
+
+    public String getNotificationMessage() {
+        List<WebElement> messages = getDriver().findElements(By.id("messages"));
+        return messages.size() > 0 ? messages.get(0).getText() : "";
+    }
+
+    public List<String> waitForErrors() {
+        waitForTenSec().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver driver) {
+                return getDriver().findElement(
+                        By.xpath("//span[@class='errors']"));
+            }
+        });
+        return getErrors();
+    }
+
+    public void assertNoCriticalErrors() {
+        List<WebElement> errors =
+                getDriver().findElements(By.id("errorMessage"));
+        if (errors.size() > 0) {
+            throw new RuntimeException("Critical error: \n"
+                    + errors.get(0).getText());
+        }
+    }
+
+    public boolean hasNoCriticalErrors() {
+        return getDriver().findElements(By.id("errorMessage")).size() <= 0;
+    }
+
+    /**
+     * Shift focus to the page, in order to activate some elements that
+     * only exhibit behaviour on losing focus.
+     */
+    public void defocus() {
+        getDriver().findElement(By.tagName("body")).click();
+    }
+
+    public List<String> waitForFieldErrors() {
+        waitForTenSec().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver driver) {
+                return getDriver().findElement(
+                        By.className("message--danger"));
+            }
+        });
+        return getFieldErrors();
+    }
+
+    public List<String> getFieldErrors() {
+        List<String> errorList = new ArrayList<String>();
+        List<WebElement> errorObjects = getDriver()
+                .findElements(By.className("message--danger"));
+        for (WebElement element : errorObjects) {
+            errorList.add(element.getText().trim());
+        }
+        return errorList;
+    }
+
+}

--- a/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
@@ -26,7 +26,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.zanata.page.BasePage;
+import org.zanata.page.CorePage;
 import org.zanata.page.utility.HomePage;
 
 import java.util.List;
@@ -36,45 +36,31 @@ import java.util.Map;
  * @author Damian Jansen <a
  *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
-public class RegisterPage extends BasePage {
+public class RegisterPage extends CorePage {
 
-    @FindBy(id = "registerForm:nameField:name")
+    @FindBy(id = "loginForm:name")
     private WebElement nameField;
 
-    @FindBy(id = "registerForm:emailField:email")
+    @FindBy(id = "loginForm:emailField:email")
     private WebElement emailField;
 
-    @FindBy(id = "registerForm:usernameField:username")
+    @FindBy(id = "loginForm:usernameField:username")
     private WebElement usernameField;
 
-    @FindBy(id = "registerForm:passwordField:password")
+    @FindBy(id = "loginForm:passwordField:password")
     private WebElement passwordField;
 
-    @FindBy(id = "registerForm:passwordConfirmField:passwordConfirm")
-    private WebElement confirmPasswordField;
-
-    @FindBy(id = "registerForm:captcha:verifyCaptcha")
-    private WebElement captchaField;
-
-    @FindBy(id = "registerForm:agreedToTerms:agreedToTerms")
-    private WebElement termsCheckbox;
-
-    @FindBy(id = "registerForm:registerButton")
+    @FindBy(xpath = "//input[@value='Sign Up']")
     private WebElement registerButton;
 
     public RegisterPage(WebDriver driver) {
         super(driver);
-        List<By> elementBys =
-                ImmutableList
-                        .<By> builder()
-                        .add(By.id("registerForm:nameField:name"))
-                        .add(By.id("registerForm:emailField:email"))
-                        .add(By.id("registerForm:usernameField:username"))
-                        .add(By.id("registerForm:passwordField:password"))
-                        .add(By.id("registerForm:passwordConfirmField:passwordConfirm"))
-                        .add(By.id("registerForm:captcha:verifyCaptcha"))
-                        .add(By.id("registerForm:agreedToTerms:agreedToTerms"))
-                        .add(By.id("registerForm:registerButton")).build();
+        List<By> elementBys = ImmutableList.<By> builder()
+                .add(By.id("loginForm:name"))
+                .add(By.id("loginForm:emailField:email"))
+                .add(By.id("loginForm:usernameField:username"))
+                .add(By.id("loginForm:passwordField:password"))
+                .add(By.xpath("//input[@value='Sign Up']")).build();
         waitForPage(elementBys);
     }
 
@@ -98,21 +84,6 @@ public class RegisterPage extends BasePage {
         return new RegisterPage(getDriver());
     }
 
-    public RegisterPage enterConfirmPassword(String confirmPassword) {
-        confirmPasswordField.sendKeys(confirmPassword);
-        return new RegisterPage(getDriver());
-    }
-
-    public RegisterPage enterCaptcha(String captcha) {
-        captchaField.sendKeys(captcha);
-        return new RegisterPage(getDriver());
-    }
-
-    public RegisterPage clickTerms() {
-        termsCheckbox.click();
-        return new RegisterPage(getDriver());
-    }
-
     // TODO: Add a "signup success" page
     public HomePage register() {
         registerButton.click();
@@ -129,8 +100,6 @@ public class RegisterPage extends BasePage {
         emailField.clear();
         usernameField.clear();
         passwordField.clear();
-        confirmPasswordField.clear();
-        captchaField.clear();
         return new RegisterPage(getDriver());
     }
 
@@ -144,8 +113,6 @@ public class RegisterPage extends BasePage {
         enterEmail(fields.get("email"));
         enterUserName(fields.get("username"));
         enterPassword(fields.get("password"));
-        enterConfirmPassword(fields.get("confirmpassword"));
-        enterCaptcha(fields.get("captcha"));
         return new RegisterPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
@@ -26,12 +26,12 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.zanata.page.BasePage;
+import org.zanata.page.CorePage;
 import org.zanata.page.googleaccount.GoogleAccountPage;
 import org.zanata.page.utility.DashboardPage;
 
 @Slf4j
-public class SignInPage extends BasePage {
+public class SignInPage extends CorePage {
     @FindBy(id = "loginForm:username")
     private WebElement usernameField;
 
@@ -61,6 +61,11 @@ public class SignInPage extends BasePage {
     public DashboardPage clickSignIn() {
         signInButton.click();
         return new DashboardPage(getDriver());
+    }
+
+    public SignInPage clickSignInExpectError() {
+        signInButton.click();
+        return new SignInPage(getDriver());
     }
 
     public GoogleAccountPage selectGoogleOpenID() {

--- a/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
@@ -47,7 +47,9 @@ public class LoginWorkFlow extends AbstractWebWorkFlow {
             log.warn("Login failed. May due to some weird issue. Will Try again.");
             doSignIn(username, password);
         } catch (TimeoutException e) {
-            log.error("timeout on login. If you are running tests manually with cargo.wait, you probably forget to create the user admin/admin. See ManualRunHelper.");
+            log.error("timeout on login. If you are running tests manually"+
+                    " with cargo.wait, you probably forget to create the user"+
+                    " admin/admin. See ManualRunHelper.");
             throw e;
         }
         return PageFactory.initElements(driver, pageClass);
@@ -63,16 +65,7 @@ public class LoginWorkFlow extends AbstractWebWorkFlow {
         log.info("log in as username: {}", username);
         signInPage.enterUsername(username);
         signInPage.enterPassword(password);
-        signInPage.clickSignIn();
-        signInPage.waitForTenSec().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver driver) {
-                List<WebElement> messages =
-                        driver.findElements(By.id("messages"));
-                return messages.size() > 0
-                        && messages.get(0).getText().contains("Login failed");
-            }
-        });
+        signInPage.clickSignInExpectError();
         return new SignInPage(driver);
     }
 
@@ -88,9 +81,9 @@ public class LoginWorkFlow extends AbstractWebWorkFlow {
             @Override
             public boolean apply(WebDriver driver) {
                 List<WebElement> messages =
-                        driver.findElements(By.id("messages"));
-                if (messages.size() > 0
-                        && messages.get(0).getText().contains("Login failed")) {
+                        driver.findElements(By.className("message--danger"));
+                if (messages.size() > 0 && messages.get(0)
+                        .getText().contains(" Login failed ")) {
                     throw new IllegalAccessError("Login failed");
                 }
                 List<WebElement> signIn = driver.findElements(By.id("Sign_in"));

--- a/functional-test/src/test/java/org/zanata/feature/account/InvalidEmailAddressTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/InvalidEmailAddressTest.java
@@ -178,10 +178,11 @@ public class InvalidEmailAddressTest {
         String errorMsg = "not a well-formed email address";
         RegisterPage registerPage =
                 new BasicWorkFlow().goToHome().goToRegistration();
-        registerPage =
-                registerPage.enterEmail(emailAddress.toString()).clickTerms();
+        registerPage = registerPage.enterEmail(emailAddress.toString());
+        registerPage.defocus();
+
         assertThat("Email validation errors are not shown",
-                registerPage.waitForErrors(), Matchers.hasItem(errorMsg));
+                registerPage.waitForFieldErrors(), Matchers.hasItem(errorMsg));
     }
 
 }

--- a/functional-test/src/test/java/org/zanata/feature/account/UsernameValidationTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/UsernameValidationTest.java
@@ -109,8 +109,11 @@ public class UsernameValidationTest {
                 "lowercase letters and digits (regex \"^[a-z\\d_]{3,20}$\")";
         RegisterPage registerPage =
                 new BasicWorkFlow().goToHome().goToRegistration();
-        registerPage = registerPage.enterUserName(username).clickTerms();
-        assertThat("Validation errors are shown", registerPage.getErrors(),
+        registerPage = registerPage.enterUserName(username);
+        registerPage.defocus();
+
+        assertThat("Validation errors are shown",
+                registerPage.waitForFieldErrors(),
                 Matchers.hasItem(errorMsg));
     }
 }

--- a/functional-test/src/test/java/org/zanata/feature/account/ValidEmailAddressTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/ValidEmailAddressTest.java
@@ -105,10 +105,11 @@ public class ValidEmailAddressTest {
         String errorMsg = "not a well-formed email address";
         RegisterPage registerPage =
                 new BasicWorkFlow().goToHome().goToRegistration();
-        registerPage =
-                registerPage.enterEmail(emailAddress.toString()).clickTerms();
+        registerPage = registerPage.enterEmail(emailAddress.toString());
+        registerPage.defocus();
+
         assertThat("Email validation errors are not shown",
-                registerPage.getErrors(),
+                registerPage.getFieldErrors(),
                 Matchers.not(Matchers.hasItem(errorMsg)));
 
     }

--- a/functional-test/src/test/java/org/zanata/feature/project/ProjectTestSuite.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/ProjectTestSuite.java
@@ -31,6 +31,6 @@ import org.junit.runners.Suite;
  * @see org.zanata.feature.AggregateTestSuite
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({EditMaintainersTest.class})
+@Suite.SuiteClasses({EditMaintainersTest.class, ProjectVersionTest.class})
 public class ProjectTestSuite {
 }

--- a/functional-test/src/test/java/org/zanata/feature/security/SecurityFullTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/security/SecurityFullTest.java
@@ -23,6 +23,7 @@ package org.zanata.feature.security;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -65,9 +66,10 @@ public class SecurityFullTest {
     public void signInFailure() {
         SignInPage signInPage =
                 new LoginWorkFlow().signInFailure("nosuchuser", "password");
+
         assertThat("Error message is shown",
-                signInPage.getNotificationMessage(), equalTo("Login failed"));
-        assertThat("User has failed to log in", !signInPage.hasLoggedIn());
+                signInPage.waitForFieldErrors(),
+                Matchers.hasItem("Login failed"));
     }
 
     @Test

--- a/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupIDValidationTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupIDValidationTest.java
@@ -96,24 +96,29 @@ public class VersionGroupIDValidationTest {
 
     @BeforeClass
     public static void beforeClass() {
-        groupPage =
-                new LoginWorkFlow().signIn("admin", "admin").goToGroups()
-                        .createNewGroup();
+        groupPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToGroups()
+                .createNewGroup();
     }
 
     @Theory
     public void inputValidationForID(String inputText) {
-        String errorMsg =
-                "must start and end with letter or number, and contain only letters, numbers, underscores and hyphens.";
+        String errorMsg = "must start and end with letter or number, and "+
+                "contain only letters, numbers, underscores and hyphens.";
+
         // Yes reassign groupPage is necessary since JSF re-renders itself after
         // each field input and selenium is not happy with it
-        groupPage =
-                groupPage.clearFields().inputGroupId(inputText)
-                        .inputGroupName(inputText).selectStatus("OBSOLETE")
-                        .selectStatus("ACTIVE") // this is to avoid
-                                                // ConcurrentModificationException
-                                                // thanks to JSF!!
-                        .saveGroupFailure();
+        groupPage = groupPage
+                .clearFields()
+                .inputGroupId(inputText)
+                .inputGroupName(inputText)
+                .selectStatus("OBSOLETE")
+                .selectStatus("ACTIVE") // this is to avoid
+                                        // ConcurrentModificationException
+                                        // thanks to JSF!!
+                .saveGroupFailure();
+
         assertThat("Validation error is displayed for input:" + inputText,
                 groupPage.getErrors(1), Matchers.contains(errorMsg));
     }


### PR DESCRIPTION
The new sign up and log in pages are minimalist, not having the
features that BasePage provides. To remove errors and element
search waits, this adds a core page with globally necessary entities.
