### PR TITLE
rhbz1023258 - Copy trans refactor and bug-fix.

### DIFF
--- a/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
@@ -343,10 +343,8 @@ public class HTextFlowTarget extends ModelEntityBase implements HasContents,
         this.setContents(Arrays.asList(contents));
     }
 
-    // TODO use orphanRemoval=true: requires JPA 2.0
     @OneToOne(optional = true, fetch = FetchType.LAZY,
-            cascade = CascadeType.ALL)
-    @Cascade(org.hibernate.annotations.CascadeType.DELETE_ORPHAN)
+            cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "comment_id")
     public HSimpleComment getComment() {
         return comment;

--- a/zanata-war/src/main/webapp/iteration/view.xhtml
+++ b/zanata-war/src/main/webapp/iteration/view.xhtml
@@ -37,11 +37,10 @@
     </ul>
   </a4j:outputPanel>
 
-  <ui:include src="/WEB-INF/layout/loading.xhtml">
-    <ui:param name="regionId" value="langTableRegion"/>
-  </ui:include>
-
   <h:form id="iterationLanguageForm">
+    <ui:include src="/WEB-INF/layout/loading.xhtml">
+      <ui:param name="regionId" value="langTableRegion"/>
+    </ui:include>
     <a4j:region id="langTableRegion">
       <s:token allowMultiplePosts="true"/>
 
@@ -215,7 +214,7 @@
 
       <!-- Using js function due to reRenderAfterComplete not working properly. -->
       <a4j:jsFunction name="reRenderAfterCopyTrans"
-        render="copyTransIndicator,copyTransLink,blah" limitRender="true"/>
+        render="copyTransIndicator,copyTransLink" limitRender="true"/>
       <rich:progressBar id="copyTransProgressBar"
         mode="ajax"
         value="#{viewAllStatusAction.copyTransProgress}"

--- a/zanata-war/src/test/java/org/zanata/dao/TextFlowTargetDAOTest.java
+++ b/zanata-war/src/test/java/org/zanata/dao/TextFlowTargetDAOTest.java
@@ -70,45 +70,4 @@ public class TextFlowTargetDAOTest extends ZanataDbunitJpaTest {
                 new TextFlowTargetDAO((Session) getEm().getDelegate());
     }
 
-    // FIXME broken test
-    @Test(enabled = false)
-    public void findLatestEquivalentTranslation() throws Exception {
-        HDocument doc = (HDocument) getSession().get(HDocument.class, 1L);
-        HLocale hLocale = (HLocale) getSession().get(HLocale.class, 1L);
-
-        ScrollableResults results =
-                this.textFlowTargetDAO.findMatchingTranslations(doc, hLocale,
-                        true, true, true, true);
-
-        int rows = 0;
-
-        // TODO Have more comprehensive results
-        while (results.next()) {
-            final HTextFlowTarget oldTFT = (HTextFlowTarget) results.get(0);
-            final HTextFlow textFlow = (HTextFlow) results.get(1);
-
-            // make sure that each result is valid
-            assertThat(oldTFT.getTextFlow(), equalTo(textFlow));
-            assertThat(oldTFT.getLocale().getId(), equalTo(hLocale.getId()));
-            assertThat(textFlow.getDocument().getDocId(),
-                    is("/my/path/document.txt"));
-            assertThat(oldTFT.getState(), is(ContentState.Approved));
-
-            rows++;
-        }
-
-        // make sure there where results
-        assertThat(rows, greaterThan(0));
-    }
-
-    @Test
-    public void testQuery() {
-        HDocument doc = (HDocument) getSession().get(HDocument.class, 1L);
-        HLocale hLocale = (HLocale) getSession().get(HLocale.class, 1L);
-        @Cleanup
-        ScrollableResults scroll =
-                this.textFlowTargetDAO.findMatchingTranslations(doc, hLocale,
-                        true, true, true, true);
-    }
-
 }

--- a/zanata-war/src/test/java/org/zanata/seam/SeamAutowire.java
+++ b/zanata-war/src/test/java/org/zanata/seam/SeamAutowire.java
@@ -250,6 +250,7 @@ public class SeamAutowire {
                 String compName = accessor.getComponentName();
                 Class<?> compType = accessor.getComponentType();
 
+                // TODO stateless components should not / need not be cached
                 // autowire the component if not done yet
                 if (!namedComponents.containsKey(compName)) {
                     Object newComponent = null;


### PR DESCRIPTION
Correct the bug that prevented copy trans from getting the latest translation when multiple translations were reuse candidates. This was due to the fact that copy trans was not using the right column for ordering the results.
Since it was not trivial or efficient to query all translations for a single document, copy trans is now split to do a very quick an efficient query per text flow. This means copy trans for a document will probably take a longer time, but it will also be more scalable.
Also remove some tests that don't make any sense after the changes.
Correct copy trans time remaining and elapsed messages.
Fix JSF issue causing the stats table to show as reloading with every progress bar update.
Add a test that checks that the latest translation is being used when all things are equal.
