### PR TITLE
Update quartz to 1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
         <scope>import</scope>
       </dependency>
 
+      <dependency>
+        <groupId>org.opensymphony.quartz</groupId>
+        <artifactId>quartz</artifactId>
+        <version>1.6.5</version>
+      </dependency>
+
       <!-- zanata api -->
       <dependency>
         <groupId>org.zanata</groupId>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -107,7 +107,7 @@
             <!-- runtime dep for liquibase logging -->
             <usedDependency>com.mattbertolini:liquibase-slf4j</usedDependency>
             <usedDependency>com.google.code.findbugs:annotations</usedDependency>
-            <usedDependency>quartz:quartz</usedDependency>
+            <usedDependency>org.opensymphony.quartz:quartz</usedDependency>
             <!-- Used indirectly by org.zanata.arquillian.Deployments -->
             <usedDependency>org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api</usedDependency>
             <!-- used by REST API interfaces -->
@@ -1401,7 +1401,7 @@
     <!-- Quartz -->
 
     <dependency>
-      <groupId>quartz</groupId>
+      <groupId>org.opensymphony.quartz</groupId>
       <artifactId>quartz</artifactId>
     </dependency>
 


### PR DESCRIPTION
Once this is merged, we should remove quartz:quartz from zanata-parent/pom.xml, and make it a banned dependency.
