### PR TITLE
Make sure the session is unauthenticated after signing up.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/ProfileAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/ProfileAction.java
@@ -235,6 +235,7 @@ public class ProfileAction implements Serializable {
             }
             setActivationKey(key);
             renderer.render("/WEB-INF/facelets/email/email_activation.xhtml");
+            identity.unAuthenticate();
             FacesMessages
                     .instance()
                     .add("You will soon receive an email with a link to activate your account.");


### PR DESCRIPTION
Keeping the authenticated credentials (although not fully signed in) was causing some UI elements and other logic to incorrectly assume the user is signed in.
