### PR TITLE
rhbz1031468 - Fix NonUniqueObject exception when saving project's copy trans options.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/ProjectCopyTransOptionsAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/ProjectCopyTransOptionsAction.java
@@ -44,8 +44,6 @@ public class ProjectCopyTransOptionsAction implements Serializable {
 
     private String projectSlug;
 
-    private HProject project;
-
     @In
     private ProjectDAO projectDAO;
 
@@ -68,10 +66,7 @@ public class ProjectCopyTransOptionsAction implements Serializable {
     }
 
     public HProject getProject() {
-        if (project == null) {
-            project = projectDAO.getBySlug(this.projectSlug);
-        }
-        return project;
+        return projectDAO.getBySlug(this.projectSlug);
     }
 
     @Transactional
@@ -79,9 +74,10 @@ public class ProjectCopyTransOptionsAction implements Serializable {
     public
             void saveOptions() {
         copyTransOptionsModel.save();
-        getProject().setDefaultCopyTransOpts(
-                copyTransOptionsModel.getInstance());
-        projectDAO.makePersistent(getProject());
+        HProject project = getProject();
+        project.setDefaultCopyTransOpts(
+            copyTransOptionsModel.getInstance());
+        projectDAO.makePersistent(project);
 
         FacesMessages.instance().add(StatusMessage.Severity.INFO,
                 "jsf.project.CopyTransOpts.saved", null, null, null);

--- a/zanata-war/src/main/webapp/WEB-INF/urlrewrite.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/urlrewrite.xml
@@ -398,7 +398,7 @@
     <to>$1/project/view/$2</to>
   </outbound-rule>
   <outbound-rule>
-    <from>^(/.+)?/project/copy_trans_options.seam\?projectSlug=(.+)$</from>
+    <from>^(/.+)?/project/copy_trans_options.seam\?projectSlug=([^&amp;]+)(&amp;.+)?$</from>
     <to>$1/project/view/$2/copy_trans_opts</to>
   </outbound-rule>
   <outbound-rule>


### PR DESCRIPTION
Let hibernate handle the caching of the project object (probably second level), instead of keeping a view-level cached version.
Also fix the re-written url for copy trans options as it was inserting extra parameters (i.e. cid) in the middle of the url.
