### PR TITLE
Show correct username for copy trans.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/CopyTransAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/CopyTransAction.java
@@ -100,8 +100,7 @@ public class CopyTransAction implements Serializable {
     }
 
     @Restrict("#{s:hasPermission(copyTransAction.projectIteration, 'copy-trans')}")
-    public
-            void startCopyTrans() {
+    public void startCopyTrans() {
         if (isCopyTransRunning()) {
             flashScope.setAttribute("message", messages
                     .get("jsf.iteration.CopyTrans.AlreadyStarted.flash"));

--- a/zanata-war/src/main/java/org/zanata/async/tasks/CopyTransTask.java
+++ b/zanata-war/src/main/java/org/zanata/async/tasks/CopyTransTask.java
@@ -20,13 +20,12 @@
  */
 package org.zanata.async.tasks;
 
-import org.jboss.seam.security.Identity;
+import lombok.Getter;
+import lombok.Setter;
 import org.zanata.async.AsyncTask;
 import org.zanata.async.TimedAsyncHandle;
 import org.zanata.model.HCopyTransOptions;
-
-import lombok.Getter;
-import lombok.Setter;
+import org.zanata.security.ZanataIdentity;
 
 /**
  * Asynchronous Task that runs copy trans. Subclasses should allow for running
@@ -63,7 +62,7 @@ public abstract class CopyTransTask implements
     public Void call() throws Exception {
         getHandle().startTiming();
         getHandle()
-                .setTriggeredBy(Identity.instance().getPrincipal().getName());
+                .setTriggeredBy(ZanataIdentity.instance().getAccountUsername());
         getHandle().setMaxProgress(getMaxProgress());
 
         callCopyTrans();

--- a/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
@@ -22,6 +22,7 @@ package org.zanata.security;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
@@ -40,10 +41,12 @@ import org.jboss.seam.core.Events;
 import org.jboss.seam.security.Configuration;
 import org.jboss.seam.security.Identity;
 import org.jboss.seam.security.NotLoggedInException;
+import org.jboss.seam.security.management.JpaIdentityStore;
 import org.jboss.seam.security.permission.RuleBasedPermissionResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
+import org.zanata.model.HAccount;
 
 import static org.jboss.seam.ScopeType.SESSION;
 import static org.jboss.seam.annotations.Install.APPLICATION;
@@ -240,5 +243,25 @@ public class ZanataIdentity extends Identity {
             this.preAuthenticated = true;
         }
         return result;
+    }
+
+    /**
+     * Utility method to get the authenticated account username. This differs
+     * from {@link org.jboss.seam.security.Credentials#getUsername()} in that
+     * this returns the actual account's username, not the user provided one
+     * (which for some authentication systems is non-existent).
+     *
+     * @return The currently authenticated account username, or null if the
+     *         session is not authenticated.
+     */
+    @Nullable
+    public String getAccountUsername() {
+        HAccount authenticatedAccount =
+                (HAccount) Component
+                        .getInstance(JpaIdentityStore.AUTHENTICATED_USER);
+        if (authenticatedAccount != null) {
+            return authenticatedAccount.getUsername();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
For some authentication systems, Zanata will not show the correct username when running copy trans. This fixes this issue as it will always get the currently authenticated account's username.
