### PR TITLE
RHBZ-1013419: Fix link to docs and remove FAQ

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/template/footer.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/footer.xhtml
@@ -13,7 +13,7 @@
         <li><a href="http://zanata.org/"
           target="_blank">#{messages['jsf.AboutZanata']}</a>
         </li>
-        <li><a href="http://zanata.org/documentation.html"
+        <li><a href="http://zanata.org/help"
           target="_blank">#{messages['jsf.Documentation']}</a></li>
         <li><a href="https://github.com/zanata/zanata/wiki"
           target="_blank">#{messages['jsf.Wiki']}</a></li>
@@ -30,13 +30,9 @@
     <div class="content">
       <ul>
         <li><s:link view="/help/view.xhtml"
-          propagation="none">#{messages['jsf.Help']}</s:link>
-        </li>
+          propagation="none">#{messages['jsf.Help']}</s:link></li>
         <li><a href="http://webchat.freenode.net/?channels=zanata"
           target="_blank">#{messages['jsf.IrcHelp']}</a></li>
-        <li><a href="http://zanata.org/faq.html"
-          target="_blank">#{messages['jsf.FAQ']}</a>
-        </li>
         <li><a
           href="https://bugzilla.redhat.com/enter_bug.cgi?format=guided&amp;product=Zanata"
           target="_blank">#{messages['jsf.ReportAProblem']}</a></li>


### PR DESCRIPTION
FAQ no longer needed, fix Documentation link to go to zanata.org/help.
