### PR TITLE
upgrade mysql driver version

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -28,10 +28,6 @@
     <context.path>zanata</context.path>
 
     <!--data source-->
-    <jdbc.groupId>mysql</jdbc.groupId>
-    <jdbc.artifactId>mysql-connector-java</jdbc.artifactId>
-    <jdbc.version>5.1.26</jdbc.version>
-
     <ds.jndi.name>zanataDatasource</ds.jndi.name>
     <!--mysql-maven-plugin will use these setup-->
     <ds.database>root</ds.database>
@@ -186,7 +182,6 @@
     <dependency>
       <groupId>${jdbc.groupId}</groupId>
       <artifactId>${jdbc.artifactId}</artifactId>
-      <version>${jdbc.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
 
     <!-- JBoss version for dependencies (arquillian, jboss-as-parent) -->
     <jboss.as.version>7.2.0.Final</jboss.as.version>
+
+    <jdbc.groupId>mysql</jdbc.groupId>
+    <jdbc.artifactId>mysql-connector-java</jdbc.artifactId>
+    <jdbc.version>5.1.26</jdbc.version>
   </properties>
 
   <dependencyManagement>
@@ -213,6 +217,13 @@
         <artifactId>icu4j</artifactId>
         <classifier>sources</classifier>
         <version>${icu4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${jdbc.groupId}</groupId>
+        <artifactId>${jdbc.artifactId}</artifactId>
+        <version>${jdbc.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1704,9 +1704,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.9</version>
+      <groupId>${jdbc.groupId}</groupId>
+      <artifactId>${jdbc.artifactId}</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
so that it can connect to parallel server running in functional test
see https://github.com/jcabi/jcabi-mysql-maven-plugin/issues/9 for detail

mysql.classifier and mysql.port is provided by the plugin. We don't need to fix it. Now the build is fully portable!
