### PR TITLE
set test database to use utf8 encoding

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -381,6 +381,35 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>sql-maven-plugin</artifactId>
+            <version>1.5</version>
+            <dependencies>
+              <dependency>
+                <groupId>${jdbc.groupId}</groupId>
+                <artifactId>${jdbc.artifactId}</artifactId>
+                <version>${jdbc.version}</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <url>${ds.connection.url}</url>
+              <driver>${ds.driver.class}</driver>
+              <username>${ds.username}</username>
+              <password>${ds.password}</password>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <phase>pre-integration-test</phase>
+                <configuration>
+                  <sqlCommand>ALTER DATABASE ${ds.database} CHARACTER SET utf8 COLLATE utf8_general_ci;</sqlCommand>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-maven2-plugin</artifactId>
             <version>1.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -725,7 +725,7 @@
         <plugin>
           <groupId>com.jcabi</groupId>
           <artifactId>jcabi-mysql-maven-plugin</artifactId>
-          <version>0.3</version>
+          <version>0.4</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The default is latin1 therefore some functional test fails.
