### PR TITLE
uncaught validation message will display better

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -1119,6 +1119,12 @@
     <http-error error-code="503" />
   </exception>
 
+  <exception class="javax.validation.ConstraintViolationException" log-level="debug">
+    <redirect view-id="/error.xhtml">
+      <message severity="warn">#{messages['jsf.Error']} #{org.jboss.seam.handledException.message}</message>
+    </redirect>
+  </exception>
+
   <exception class="org.jboss.seam.web.FileUploadException" log-level="warn">
     <redirect view-id="/error.xhtml">
       <message severity="error">


### PR DESCRIPTION
When JSF backed bean failed to detect a validation error and let it pass, hibernate will reject the entity and throw ConstraintViolationException. The error page will display as generic server error which isn't helpful. This is not pretty but at least it gives the user a hint they have entered something invalid.

One way to reproduce:
1. login as open id
2. edit profile
3. enter name and username but leave email blank (note email probably should mark as required but that's a separate issue)
4. save

a very generic error page returns with uncooked hibernate validation messages saying email is required.

In general we should not let this happen but if it does, this is better than generic server error.
