### PR TITLE
Enable manual functional test

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -581,7 +581,6 @@
               <target>
                 <echo>===== Properties that can be set for functional test =====</echo>
                 <echo>-Dfunctional-test : to activate functional test run</echo>
-                <echo>-Dcargo.wait : to ask cargo to start up then wait so that tests can be run manually</echo>
                 <echo>-Dzanata.target.version=version of zanata to deploy. Default is: ${project.parent.version}</echo>
                 <echo>-Dzanata.target.war=location of the war. Default is: ${basedir}/../zanata-war/target/zanata-${zanata.target.version}.war.</echo>
                 <echo>-Dzanata.instance.url=http://${cargo.host}:8080/${context.path}</echo>

--- a/functional-test/src/main/java/org/zanata/page/projects/CreateVersionPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/CreateVersionPage.java
@@ -87,7 +87,7 @@ public class CreateVersionPage extends BasePage {
     }
 
     public CreateVersionPage showLocalesOverride() {
-        getDriver().findElement(By.xpath("//*[@title='overrideLocales']"))
+        getDriver().findElement(By.id("iterationForm:overrideLocales"))
                 .click();
         waitForTenSec().until(new Predicate<WebDriver>() {
             @Override

--- a/zanata-war/src/main/webapp/WEB-INF/layout/iteration_edit_form.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/iteration_edit_form.xhtml
@@ -66,7 +66,7 @@
 
   <s:div>
     <a4j:region>
-      <h:selectBooleanCheckbox title="overrideLocales"
+      <h:selectBooleanCheckbox title="overrideLocales" id="overrideLocales"
         value="#{projectIterationLocaleAction.setting}">
         <a4j:ajax event="change" render="languagelist"/>
       </h:selectBooleanCheckbox>


### PR DESCRIPTION
Old cargo plugin uses a deprecated property -Dcargo.wait to halt cargo container after start. We then able to manually run tests from IDE. With the new version of cargo plugin, we can only run cargo:run to achieve this. Therefore I need to modify some plugin phase. Now pausing cargo is:

``` shell
mvn clean package cargo:run -Dfunctional-test -Dmysql.port=13306
```

Note the mysql.port can be set to any free port.

Also add an id to an element and this should fix recent broken tests due to a css change.
