### PR TITLE
HOT-FIX: Replace use of s:link with h:outputLink where a full url is required

### DIFF
--- a/zanata-war/src/main/webapp/account/login.xhtml
+++ b/zanata-war/src/main/webapp/account/login.xhtml
@@ -90,8 +90,9 @@
                   </s:fragment>
                   <s:fragment
                     rendered="#{not applicationConfiguration.internalAuth and not empty applicationConfiguration.registerPath}">
-                    <s:link view="#{applicationConfiguration.registerPath}"
-                      value="#{messages['jsf.Signup']}" />
+                    <h:outputLink value="#{applicationConfiguration.registerPath}">
+                      <h:outputText value="#{messages['jsf.Signup']}"/>
+                    </h:outputLink>
                   </s:fragment>
                 </div>
               </h:form>


### PR DESCRIPTION
Using an s:link tag where full urls are required (as opposed to view ids) causes the component to throw an exception.
