### PR TITLE
add ids to some gwt elements

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -28,7 +28,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.zanata.page.account.MyAccountPage;
 import org.zanata.page.account.RegisterPage;
 import org.zanata.page.account.SignInPage;
@@ -83,12 +82,28 @@ public class BasePage extends CorePage {
     }
 
     public ProjectsPage goToProjects() {
-        projectsLink.click();
+        clickNavMenuItem(projectsLink);
         return new ProjectsPage(getDriver());
     }
 
+    private void clickNavMenuItem(final WebElement menuItem) {
+        if (!menuItem.isDisplayed()) {
+            // screen is too small the menu become dropdown
+            getDriver().findElement(By.id("nav-main"))
+                    .findElement(By.tagName("a"))
+                    .click();
+        }
+        waitForTenSec().until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return menuItem.isDisplayed();
+            }
+        });
+        menuItem.click();
+    }
+
     public VersionGroupsPage goToGroups() {
-        groupsLink.click();
+        clickNavMenuItem(groupsLink);
         return new VersionGroupsPage(getDriver());
     }
 

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/ui/EditorButtonsWidget.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/ui/EditorButtonsWidget.java
@@ -46,6 +46,17 @@ public class EditorButtonsWidget extends Composite {
             && listener.canEditTranslation());
     }
 
+    @Override
+    protected void onEnsureDebugId(String baseID) {
+        saveIcon.ensureDebugId(baseID + "-save-approve");
+        fuzzyIcon.ensureDebugId(baseID + "-save-fuzzy");
+        cancelIcon.ensureDebugId(baseID + "-cancel");
+        historyIcon.ensureDebugId(baseID + "-history");
+        undoContainer.ensureDebugId(baseID + "-undo");
+        acceptIcon.ensureDebugId(baseID + "-accept");
+        rejectIcon.ensureDebugId(baseID + "-reject");
+    }
+
     private void setDisplayReviewButtons(boolean canReview) {
         acceptIcon.setVisible(canReview);
         rejectIcon.setVisible(canReview);

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/TargetContentsView.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/TargetContentsView.java
@@ -127,6 +127,7 @@ public class TargetContentsView extends Composite implements
 
     @Override
     public void setValueAndCreateNewEditors(TransUnit transUnit) {
+        buttons.ensureDebugId("target-" + transUnit.getRowIndex());
         setCachedTU(transUnit);
         updateCommentIndicator(transUnit.getCommentsCount());
 


### PR DESCRIPTION
- add id to editor buttons.
- navigation menu become invisible when screen is too small. Change BasePage to cater for that.
