### PR TITLE
rhbz1060598 - Project search now discards obsolete projects from results for non-admins.

### DIFF
--- a/zanata-model/src/main/java/org/zanata/model/HProject.java
+++ b/zanata-model/src/main/java/org/zanata/model/HProject.java
@@ -148,6 +148,7 @@ public class HProject extends SlugEntityBase implements Serializable,
 
     @Type(type = "entityStatus")
     @NotNull
+    @Field
     private EntityStatus status = EntityStatus.ACTIVE;
 
     public void addIteration(HProjectIteration iteration) {

--- a/zanata-war/src/main/java/org/zanata/dao/ProjectDAO.java
+++ b/zanata-war/src/main/java/org/zanata/dao/ProjectDAO.java
@@ -235,10 +235,8 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
             int maxResult, int firstResult, boolean includeObsolete)
             throws ParseException {
         FullTextQuery query = getTextQuery(searchQuery, includeObsolete);
-        query.setMaxResults(maxResult).setFirstResult(firstResult)
+        return query.setMaxResults(maxResult).setFirstResult(firstResult)
                 .getResultList();
-
-        return query.getResultList();
     }
 
     public int getQueryProjectSize(@Nonnull String searchQuery,
@@ -264,7 +262,7 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
         if (!includeObsolete) {
             TermQuery obsoleteStateQuery =
                     new TermQuery(new Term(IndexFieldLabels.ENTITY_STATUS,
-                            EntityStatus.OBSOLETE.toString()));
+                            EntityStatus.OBSOLETE.toString().toLowerCase()));
             booleanQuery.add(obsoleteStateQuery, BooleanClause.Occur.MUST_NOT);
         }
 


### PR DESCRIPTION
Status field needs to be indexed for HProject in order for search to filter them out.
