### PR TITLE
Add subtitle files as translatable formats.

### DIFF
--- a/functional-test/src/test/java/org/zanata/feature/document/DocTypeUploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/DocTypeUploadTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.feature.document;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Rule;
+import org.junit.experimental.categories.Category;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.zanata.feature.testharness.TestPlan.BasicAcceptanceTest;
+import org.zanata.feature.testharness.ZanataTestCase;
+import org.zanata.page.projectversion.VersionDocumentsPage;
+import org.zanata.page.projectversion.VersionLanguagesPage;
+import org.zanata.page.webtrans.EditorPage;
+import org.zanata.util.CleanDocumentStorageRule;
+import org.zanata.util.SampleProjectRule;
+import org.zanata.util.TestFileGenerator;
+import org.zanata.workflow.LoginWorkFlow;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Damian Jansen
+ *         <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+@Slf4j
+@RunWith(Theories.class)
+public class DocTypeUploadTest extends ZanataTestCase {
+
+    @Rule
+    public SampleProjectRule sampleProjectRule = new SampleProjectRule();
+
+    @Rule
+    public CleanDocumentStorageRule documentStorageRule =
+            new CleanDocumentStorageRule();
+
+    private static String testString = "Test text 1";
+
+    @DataPoint
+    public static File SRT_FILE = new TestFileGenerator()
+            .generateTestFileWithContent(
+                    "testsrtfile", ".srt",
+                    "1" + sep() + "00:00:01,000 --> 00:00:02,000" +
+                    sep() + testString);
+
+    @DataPoint
+    public static File WEBVTT_FILE = new TestFileGenerator()
+            .generateTestFileWithContent(
+                    "testvttfile", ".vtt",
+                    "00:01.000 --> 00:01.000" +
+                    sep() + testString);
+
+    @DataPoint
+    public static File SBT_FILE = new TestFileGenerator()
+            .generateTestFileWithContent(
+                    "testsbtfile", ".sbt",
+                    "00:04:35.03,00:04:38.82" +
+                    sep() + testString);
+
+    @DataPoint
+    public static File SUB_FILE = new TestFileGenerator()
+            .generateTestFileWithContent(
+                    "testsubfile", ".sub",
+                    "00:04:35.03,00:04:38.82" +
+                    sep() + testString);
+
+    @Theory
+    @Category(BasicAcceptanceTest.class)
+    public void uploadFile(File testFile) throws Exception {
+        String testFileName = testFile.getName();
+        log.info("[uploadFile] "+testFileName);
+        String successfullyUploaded =
+                "Document " + testFileName + " uploaded.";
+
+        VersionLanguagesPage versionLanguagesPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(testFile.getAbsolutePath())
+                .submitUpload();
+
+        versionLanguagesPage.expectNotification(successfullyUploaded);
+
+        assertThat(versionLanguagesPage.getNotificationMessage())
+                .isEqualTo(successfullyUploaded)
+                .as("Document uploaded notification shows");
+
+        VersionDocumentsPage versionDocumentsPage = versionLanguagesPage
+                .gotoDocumentTab();
+
+        assertThat(versionDocumentsPage.sourceDocumentsContains(testFileName))
+                .as("Document shows in table");
+
+        EditorPage editorPage = versionDocumentsPage
+                .gotoLanguageTab()
+                .translate("pl", testFileName);
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo(testString)
+                .as("The translation source is correct");
+    }
+
+    private static String sep() {
+        return System.getProperty("line.separator");
+    }
+
+}

--- a/functional-test/src/test/java/org/zanata/feature/document/HTMLDocumentTypeTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/HTMLDocumentTypeTest.java
@@ -22,7 +22,6 @@ package org.zanata.feature.document;
 
 import java.io.File;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,12 +37,12 @@ import org.zanata.util.TestFileGenerator;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.zanata.util.FunctionalTestHelper.assumeTrue;
 
 /**
- * @author Damian Jansen <a
- *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ * @author Damian Jansen
+ * <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
 @Category(DetailedTest.class)
 public class HTMLDocumentTypeTest extends ZanataTestCase {
@@ -60,10 +59,10 @@ public class HTMLDocumentTypeTest extends ZanataTestCase {
     @Before
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
-        String documentStorageDirectory =
-                CleanDocumentStorageRule.getDocumentStoragePath()
-                        .concat(File.separator).concat("documents")
-                        .concat(File.separator);
+        String documentStorageDirectory = CleanDocumentStorageRule
+                .getDocumentStoragePath()
+                .concat(File.separator).concat("documents")
+                .concat(File.separator);
         File docStorage = new File(documentStorageDirectory);
         assumeTrue("The storage folder is empty",
                 docStorage == null ||
@@ -73,42 +72,43 @@ public class HTMLDocumentTypeTest extends ZanataTestCase {
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void uploadHTMLFile() {
-        File htmlfile =
-                testFileGenerator
-                        .generateTestFileWithContent("testhtmlfile", ".html",
-                                "<html><title>Test content</title><br>This is <b>Bold</b> text</html>");
+        File htmlfile = testFileGenerator
+                .generateTestFileWithContent("testhtmlfile", ".html",
+                "<html><title>Test content</title><br>" +
+                "This is <b>Bold</b> text</html>");
         String testFileName = htmlfile.getName();
         String successfullyUploaded = "Document " + testFileName + " uploaded.";
-        VersionLanguagesPage projectVersionPage =
-                new LoginWorkFlow().signIn("admin", "admin")
-                        .goToProjects()
-                        .goToProject("about fedora")
-                        .gotoVersion("master")
-                        .gotoSettingsTab()
-                        .gotoSettingsDocumentsTab()
-                        .pressUploadFileButton()
-                        .enterFilePath(htmlfile.getAbsolutePath())
-                        .submitUpload();
+        VersionLanguagesPage projectVersionPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(htmlfile.getAbsolutePath())
+                .submitUpload();
 
-        assertThat("Document uploaded notification shows",
-                projectVersionPage.expectNotification(successfullyUploaded));
+        assertThat(projectVersionPage.expectNotification(successfullyUploaded))
+                .isTrue()
+                .as("Document uploaded notification shows");
 
         VersionDocumentsPage versionDocumentsPage =
                 projectVersionPage.gotoDocumentTab();
 
-        assertThat("Document shows in table", versionDocumentsPage
-                .sourceDocumentsContains(htmlfile.getName()));
+        assertThat(versionDocumentsPage.sourceDocumentsContains(htmlfile.getName()))
+                .isTrue()
+                .as("Document shows in table");
 
         EditorPage editorPage =
                 projectVersionPage.goToProjects().goToProject("about fedora")
                         .gotoVersion("master").translate("pl", testFileName);
 
-        assertThat("The first translation source is correct",
-                editorPage.getMessageSourceAtRowIndex(0),
-                Matchers.equalTo("Test content"));
-        assertThat("The second translation source is correct",
-                editorPage.getMessageSourceAtRowIndex(1),
-                Matchers.equalTo("This is <g2>Bold</g2> text"));
-
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test content")
+                .as("The first translation source is correct");
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("This is <g2>Bold</g2> text")
+                .as("The second translation source is correct");
     }
 }

--- a/functional-test/src/test/java/org/zanata/feature/document/SubtitleDocumentTypeTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/SubtitleDocumentTypeTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.feature.document;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.zanata.feature.testharness.TestPlan.DetailedTest;
+import org.zanata.feature.testharness.ZanataTestCase;
+import org.zanata.page.projectversion.VersionDocumentsPage;
+import org.zanata.page.projectversion.VersionLanguagesPage;
+import org.zanata.page.webtrans.EditorPage;
+import org.zanata.util.CleanDocumentStorageRule;
+import org.zanata.util.SampleProjectRule;
+import org.zanata.util.TestFileGenerator;
+import org.zanata.workflow.BasicWorkFlow;
+import org.zanata.workflow.LoginWorkFlow;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.zanata.util.FunctionalTestHelper.assumeTrue;
+
+/**
+ * Covers more detailed testing of the subtitle formats
+ * @see DocTypeUploadTest
+ * @author Damian Jansen
+ * <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+@Category(DetailedTest.class)
+public class SubtitleDocumentTypeTest extends ZanataTestCase {
+
+    @Rule
+    public SampleProjectRule sampleProjectRule = new SampleProjectRule();
+
+    @Rule
+    public CleanDocumentStorageRule documentStorageRule =
+            new CleanDocumentStorageRule();
+
+    private TestFileGenerator testFileGenerator = new TestFileGenerator();
+    private String sep = System.getProperty("line.separator");
+
+    @Before
+    public void before() {
+        new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
+        String documentStorageDirectory = CleanDocumentStorageRule
+                .getDocumentStoragePath()
+                .concat(File.separator).concat("documents")
+                .concat(File.separator);
+
+        assumeTrue("The storage directory is empty, or doesn't exist",
+                storageIsClean(documentStorageDirectory));
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void similarSrtEntriesAreIndividual() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("duplicationinsrtfile", ".srt",
+                        "1" + sep +
+                        "00:00:01,000 --> 00:00:02,000" + sep +
+                        "Exactly the same text" + sep + sep +
+                        "2" + sep +
+                        "00:00:02,000 --> 00:00:03,000" + sep +
+                        "Exactly the same text"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Exactly the same text")
+                .as("The first translation source is correct");
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("Exactly the same text")
+                .as("The second translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void webVttLabelsAreNotParsed() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("labelledVttfile", ".vtt",
+                        "Introduction" + sep +
+                        "00:00:01.000 --> 00:00:02.000" + sep +
+                        "Test subtitle 1"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test subtitle 1")
+                .as("The translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void multilineSRTAreParsedCorrectly() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("multilinesrtfile", ".srt",
+                        "1" + sep +
+                        "00:00:01,000 --> 00:00:02,000" + sep +
+                        "Test subtitle 1" + sep +
+                        "Test subtitle 1 line 2" + sep + sep +
+                        "2" + sep +
+                        "00:00:03,000 --> 00:00:04,000" + sep +
+                        "Test subtitle 2"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test subtitle 1" + sep + "Test subtitle 1 line 2")
+                .as("The first translation source is correct");
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("Test subtitle 2")
+                .as("The second translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void multilineVTTAreParsedCorrectly() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("multilinevttfile", ".vtt",
+                        "00:00:01.000 --> 00:00:02.000" + sep +
+                        "Test subtitle 1" + sep +
+                        "Test subtitle 1 line 2" + sep + sep +
+                        "00:00:03.000 --> 00:00:04.000" + sep +
+                        "Test subtitle 2"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test subtitle 1" + sep + "Test subtitle 1 line 2")
+                .as("The first translation source is correct");
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("Test subtitle 2")
+                .as("The second translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void multilineSBTAreParsedCorrectly() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("multilinesbtfile", ".sbt",
+                        "00:04:35.03,00:04:38.82" + sep +
+                        "Test subtitle 1" + sep +
+                        "Test subtitle 1 line 2" + sep + sep +
+                        "2" + sep +
+                        "00:04:39.03,00:04:44.82" + sep +
+                        "Test subtitle 2"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test subtitle 1" + sep + "Test subtitle 1 line 2")
+                .as("The first translation source is correct");
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("Test subtitle 2")
+                .as("The second translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void multilineSubAreParsedCorrectly() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(testFileGenerator
+                .generateTestFileWithContent("multilinesubfile", ".sub",
+                        "00:04:35.03,00:04:38.82" + sep +
+                        "Test subtitle 1" + sep +
+                        "Test subtitle 1 line 2" + sep + sep +
+                        "00:04:39.03,00:04:44.82" + sep +
+                        "Test subtitle 2"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("Test subtitle 1" + sep + "Test subtitle 1 line 2")
+                .as("The first translation source is correct");
+        assertThat(editorPage.getMessageSourceAtRowIndex(1))
+                .isEqualTo("Test subtitle 2")
+                .as("The second translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void formattingInSrtEntries() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(
+                testFileGenerator.generateTestFileWithContent(
+                    "formattedsrtfile",
+                    ".srt",
+                    "1" + sep + "00:00:01,000 --> 00:00:02,000" + sep +
+                    "<b>Exactly the same text</b> {u}and more{/u}"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("<x1/>Exactly the same text<x2/> {u}and more{/u}")
+                .as("The translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void formattingInVttEntries() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(
+                testFileGenerator.generateTestFileWithContent(
+                        "formattedvttfile",
+                        ".vtt",
+                        "00:00:01.000 --> 00:00:02.000" + sep +
+                        "<b>Exactly the same text</b> {u}and more{/u}"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("<x1/>Exactly the same text<x2/> {u}and more{/u}")
+                .as("The translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void formattingInSbtEntries() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(
+                testFileGenerator.generateTestFileWithContent(
+                        "formattedsbtfile",
+                        ".sbt",
+                        "00:04:35.03,00:04:38.82" + sep +
+                        "<b>Exactly the same text</b> {u}and more{/u}"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("<x1/>Exactly the same text<x2/> {u}and more{/u}")
+                .as("The translation source is correct");
+    }
+
+    @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
+    public void formattingInSubEntries() throws Exception {
+        EditorPage editorPage = uploadAndGoToDocument(
+                testFileGenerator.generateTestFileWithContent(
+                        "formattedsubfile",
+                        ".sub",
+                        "00:04:35.03,00:04:38.82" + sep +
+                        "<b>Exactly the same text</b> {u}and more{/u}"));
+
+        assertThat(editorPage.getMessageSourceAtRowIndex(0))
+                .isEqualTo("<x1/>Exactly the same text<x2/> {u}and more{/u}")
+                .as("The translation source is correct");
+    }
+
+    /*
+     * Upload and open the test file in the editor for verification
+     */
+    private EditorPage uploadAndGoToDocument(File testFile) {
+        String successfullyUploaded =
+                "Document " + testFile.getName() + " uploaded.";
+        VersionLanguagesPage versionLanguagesPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(testFile.getAbsolutePath())
+                .submitUpload();
+
+        versionLanguagesPage.expectNotification(successfullyUploaded);
+
+        assertThat(versionLanguagesPage.getNotificationMessage())
+                .isEqualTo(successfullyUploaded)
+                .as("Document uploaded notification shows");
+
+        VersionDocumentsPage versionDocumentsPage = versionLanguagesPage
+                .gotoDocumentTab();
+
+        assertThat(versionDocumentsPage.sourceDocumentsContains(testFile
+                .getName())).as("Document shows in table");
+
+
+        return versionDocumentsPage
+                .gotoLanguageTab()
+                .translate("pl", testFile.getName());
+    }
+
+    private boolean storageIsClean(String documentStorageDirectory) {
+        File testDir;
+        try {
+            testDir = new File(documentStorageDirectory);
+            return  testDir.listFiles().equals(null) ||
+                    testDir.listFiles().length == 0;
+        } catch (NullPointerException npe) {
+            return true;
+        }
+    }
+}

--- a/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
@@ -23,7 +23,6 @@ package org.zanata.feature.document;
 import java.io.File;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -41,12 +40,12 @@ import org.zanata.util.TestFileGenerator;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.zanata.util.FunctionalTestHelper.assumeTrue;
 
 /**
- * @author Damian Jansen <a
- *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ * @author Damian Jansen
+ * <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
 @Category(DetailedTest.class)
 @Slf4j
@@ -94,22 +93,24 @@ public class UploadTest extends ZanataTestCase {
                         .submitUpload();
 
         // We should be able to assume the new file is the only file
-        assertThat("There is only one uploaded source file", new File(
-                documentStorageDirectory).list().length, Matchers.equalTo(1));
+        assertThat(new File(documentStorageDirectory).list().length)
+                .isEqualTo(1)
+                .as("There is only one uploaded source file");
 
         File newlyCreatedFile = new File(documentStorageDirectory,
                 testFileGenerator
                         .getFirstFileNameInDirectory(documentStorageDirectory));
 
-        assertThat("The contents of the file were also uploaded",
-                testFileGenerator.getTestFileContent(newlyCreatedFile),
-                Matchers.equalTo("This is a test file"));
+        assertThat(testFileGenerator.getTestFileContent(newlyCreatedFile))
+                .isEqualTo("This is a test file")
+                .as("The contents of the file were also uploaded");
         VersionDocumentsPage versionDocumentsPage = projectVersionPage
                 .gotoDocumentTab()
                 .waitForSourceDocsContains(testFileName);
 
-        assertThat("Document shows in table",
-                versionDocumentsPage.sourceDocumentsContains(testFileName));
+        assertThat(versionDocumentsPage.sourceDocumentsContains(testFileName))
+                .isTrue()
+                .as("Document shows in table");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -129,42 +130,48 @@ public class UploadTest extends ZanataTestCase {
                 .enterFilePath(cancelUploadFile.getAbsolutePath())
                 .cancelUpload();
 
-        assertThat("Document does not show in table",
-                !versionDocumentsTab
-                        .sourceDocumentsContains("cancelFileUpload.txt"));
+        assertThat(versionDocumentsTab.sourceDocumentsContains("cancelFileUpload.txt"))
+            .isFalse()
+            .as("Document does not show in table");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void emptyFilenameUpload() {
-        VersionDocumentsTab versionDocumentsTab =
-                new LoginWorkFlow().signIn("admin", "admin").goToProjects()
-                        .goToProject("about fedora").gotoVersion("master")
-                        .gotoSettingsTab().gotoSettingsDocumentsTab()
-                        .pressUploadFileButton();
+        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab().gotoSettingsDocumentsTab()
+                .pressUploadFileButton();
 
-        assertThat("The upload button is not available",
-                !versionDocumentsTab.canSubmitDocument());
+        assertThat(versionDocumentsTab.canSubmitDocument())
+                .isFalse()
+                .as("The upload button is not available");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     @Ignore("RHBZ-990836")
     public void handleReallyBigFile() {
         File bigFile =
-                testFileGenerator.generateTestFileWithContent("bigFile",
-                        ".txt", "Big file content");
+                testFileGenerator.generateTestFileWithContent(
+                        "bigFile", ".txt", "Big file content");
         long fileSizeInMB = (1024 * 1024) * 500;
         testFileGenerator.forceFileSize(bigFile, fileSizeInMB);
 
         assumeTrue("Data file " + bigFile.getName() + " is big",
                 bigFile.length() == fileSizeInMB);
 
-        VersionLanguagesPage projectVersionPage =
-                new LoginWorkFlow().signIn("admin", "admin").goToProjects()
-                        .goToProject("about fedora").gotoVersion("master")
-                        .gotoSettingsTab().gotoSettingsDocumentsTab()
-                        .pressUploadFileButton()
-                        .enterFilePath(bigFile.getAbsolutePath())
-                        .submitUpload();
+        VersionLanguagesPage projectVersionPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(bigFile.getAbsolutePath())
+                .submitUpload();
 
         projectVersionPage.assertNoCriticalErrors();
         // TODO: Verify graceful handling of scenario
@@ -179,86 +186,99 @@ public class UploadTest extends ZanataTestCase {
         String successfullyUploaded =
                 "Document " + noFile.getName() + " uploaded.";
 
-        VersionDocumentsTab versionDocumentsTab =
-                new LoginWorkFlow().signIn("admin", "admin").goToProjects()
-                        .goToProject("about fedora").gotoVersion("master")
-                        .gotoSettingsTab().gotoSettingsDocumentsTab()
-                        .pressUploadFileButton()
-                        .enterFilePath(noFile.getAbsolutePath());
+        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(noFile.getAbsolutePath());
 
-        assertThat("Data file " + noFile.getName() + " does not exist",
-                noFile.delete() && !noFile.exists());
+        assertThat(noFile.delete() && !noFile.exists())
+                .as("Data file " + noFile.getName() + " does not exist");
 
         VersionLanguagesPage versionLanguagesPage = versionDocumentsTab
                 .submitUpload();
         versionLanguagesPage.assertNoCriticalErrors();
-        assertThat("Success message is shown",
-                versionLanguagesPage.expectNotification(successfullyUploaded));
+        assertThat(versionLanguagesPage.expectNotification(successfullyUploaded))
+                .isTrue()
+                .as("Success message is shown");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void handleVeryLongFileNames() {
-        File longFile =
-                testFileGenerator.generateTestFileWithContent(
-                        testFileGenerator.longFileName(), ".txt",
-                        "This filename is long");
+        File longFile = testFileGenerator.generateTestFileWithContent(
+                testFileGenerator.longFileName(), ".txt",
+                "This filename is long");
         String successfullyUploaded =
                 "Document " + longFile.getName() + " uploaded.";
 
-        VersionLanguagesPage projectVersionPage =
-                new LoginWorkFlow().signIn("admin", "admin").goToProjects()
-                        .goToProject("about fedora").gotoVersion("master")
-                        .gotoSettingsTab().gotoSettingsDocumentsTab()
-                        .pressUploadFileButton()
-                        .enterFilePath(longFile.getAbsolutePath())
-                        .submitUpload();
+        VersionLanguagesPage projectVersionPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(longFile.getAbsolutePath())
+                .submitUpload();
 
-        assertThat("Document uploaded notification shows",
-                projectVersionPage.expectNotification(successfullyUploaded));
+        assertThat(projectVersionPage.expectNotification(successfullyUploaded))
+                .isTrue()
+                .as("Document uploaded notification shows");
 
         VersionDocumentsPage versionDocumentsPage = projectVersionPage
                 .gotoDocumentTab()
                 .waitForSourceDocsContains(longFile.getName());
 
-        assertThat("Document shows in table", versionDocumentsPage
-                .sourceDocumentsContains(longFile.getName()));
+        assertThat(versionDocumentsPage.sourceDocumentsContains(longFile.getName()))
+                .isTrue()
+                .as("Document shows in table");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void emptyFile() {
-        File emptyFile =
-                testFileGenerator.generateTestFileWithContent("emptyFile",
-                        ".txt", "");
+        File emptyFile = testFileGenerator
+                .generateTestFileWithContent("emptyFile", ".txt", "");
         String successfullyUploaded =
                 "Document " + emptyFile.getName() + " uploaded.";
 
         assumeTrue("File is empty", emptyFile.length() == 0);
 
-        VersionLanguagesPage projectVersionPage =
-                new LoginWorkFlow().signIn("admin", "admin").goToProjects()
-                        .goToProject("about fedora").gotoVersion("master")
-                        .gotoSettingsTab().gotoSettingsDocumentsTab()
-                        .pressUploadFileButton()
-                        .enterFilePath(emptyFile.getAbsolutePath())
-                        .submitUpload();
+        VersionLanguagesPage projectVersionPage = new LoginWorkFlow()
+                .signIn("admin", "admin")
+                .goToProjects()
+                .goToProject("about fedora")
+                .gotoVersion("master")
+                .gotoSettingsTab()
+                .gotoSettingsDocumentsTab()
+                .pressUploadFileButton()
+                .enterFilePath(emptyFile.getAbsolutePath())
+                .submitUpload();
 
-        assertThat("Data file emptyFile.txt still exists", emptyFile.exists());
-        assertThat("Document uploaded notification shows",
-                projectVersionPage.expectNotification(successfullyUploaded));
+        assertThat(emptyFile.exists())
+                .isTrue()
+                .as("Data file emptyFile.txt still exists");
+        assertThat(projectVersionPage.expectNotification(successfullyUploaded))
+                .isTrue()
+                .as("Document uploaded notification shows");
 
         VersionDocumentsPage versionDocumentsPage = projectVersionPage
                 .gotoDocumentTab()
                 .waitForSourceDocsContains(emptyFile.getName());
 
-        assertThat("Document shows in table", versionDocumentsPage
-                .sourceDocumentsContains(emptyFile.getName()));
+        assertThat(versionDocumentsPage.sourceDocumentsContains(emptyFile.getName()))
+                .isTrue()
+                .as("Document shows in table");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void rejectUnsupportedValidFiletype() {
-        File unsupportedFile =
-                testFileGenerator.generateTestFileWithContent("testfodt",
-                        ".fodt", "<xml></xml>");
+        File unsupportedFile = testFileGenerator
+                .generateTestFileWithContent("testfodt", ".fodt", "<xml></xml>");
         String uploadFailed =
                 "Unrecognized file extension for " + unsupportedFile.getName();
 
@@ -270,8 +290,9 @@ public class UploadTest extends ZanataTestCase {
                         .enterFilePath(unsupportedFile.getAbsolutePath())
                         .submitUpload();
 
-        assertThat("Unrecognized file extension error is shown",
-                projectVersionPage.expectNotification(uploadFailed));
+        assertThat(projectVersionPage.expectNotification(uploadFailed))
+                .isTrue()
+                .as("Unrecognized file extension error is shown");
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,18 @@
       </dependency>
 
       <dependency>
+        <groupId>net.sf.okapi.filters</groupId>
+        <artifactId>okapi-filter-regex</artifactId>
+        <version>${okapi.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>net.sf.okapi.logbind</groupId>
+            <artifactId>build-log4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>net.sf.okapi.steps</groupId>
         <artifactId>okapi-step-tokenization</artifactId>
         <version>${okapi.version}</version>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1389,6 +1389,10 @@
       <groupId>net.sf.okapi.filters</groupId>
       <artifactId>okapi-filter-plaintext</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-regex</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>net.sf.okapi</groupId>

--- a/zanata-war/src/main/java/org/zanata/adapter/SubtitleAdapter.java
+++ b/zanata-war/src/main/java/org/zanata/adapter/SubtitleAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+
+package org.zanata.adapter;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import net.sf.okapi.common.IParameters;
+import net.sf.okapi.filters.regex.RegexFilter;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Adapter to handle Sub-Rip Text (.srt), WebVTT (.vtt) and SubViewer (.sbv/sub)
+ * subtitle files.<br/>
+ * It uses the Okapi's {@link net.sf.okapi.filters.regex.RegexFilter} class
+ * with a regex specific to these formats.<br/>
+ *
+ * @see <a href="http://matroska.org/technical/specs/subtitles/srt.html">
+ *      SubRip Text Specification</a>
+ * @see <a href="http://dev.w3.org/html5/webvtt/">WebVTT Specification</a>
+ *
+ * @author Damian Jansen
+ *         <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ */
+public class SubtitleAdapter extends OkapiFilterAdapter {
+
+    private static final String defaultConfig = loadDefaultConfig();
+
+    private static String loadDefaultConfig() {
+        URL configURL = SubtitleAdapter.class
+                .getResource("SubtitleAdapterDefaultConfiguration.yml");
+        try {
+            return Resources.toString(configURL, Charsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to load default config for SRT adapter.", e);
+        }
+    }
+
+    public SubtitleAdapter() {
+        super(prepareFilter(), IdSource.textUnitName, true);
+    }
+
+    private static RegexFilter prepareFilter() {
+        return new RegexFilter();
+    }
+
+    @Override
+    protected void updateParamsWithDefaults(IParameters params) {
+        params.fromString(defaultConfig);
+    }
+}

--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationFileServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationFileServiceImpl.java
@@ -20,29 +20,9 @@
  */
 package org.zanata.service.impl;
 
-import static org.jboss.seam.ScopeType.STATELESS;
-import static org.zanata.common.DocumentType.GETTEXT_PORTABLE_OBJECT;
-import static org.zanata.common.DocumentType.GETTEXT_PORTABLE_OBJECT_TEMPLATE;
-import static org.zanata.common.DocumentType.HTML;
-import static org.zanata.common.DocumentType.IDML;
-import static org.zanata.common.DocumentType.OPEN_DOCUMENT_GRAPHICS;
-import static org.zanata.common.DocumentType.OPEN_DOCUMENT_PRESENTATION;
-import static org.zanata.common.DocumentType.OPEN_DOCUMENT_SPREADSHEET;
-import static org.zanata.common.DocumentType.OPEN_DOCUMENT_TEXT;
-import static org.zanata.common.DocumentType.PLAIN_TEXT;
-import static org.zanata.common.DocumentType.XML_DOCUMENT_TYPE_DEFINITION;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.MapMaker;
 import lombok.extern.slf4j.Slf4j;
-
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
@@ -54,6 +34,7 @@ import org.zanata.adapter.IDMLAdapter;
 import org.zanata.adapter.OpenOfficeAdapter;
 import org.zanata.adapter.PlainTextAdapter;
 import org.zanata.adapter.po.PoReader2;
+import org.zanata.adapter.SubtitleAdapter;
 import org.zanata.common.DocumentType;
 import org.zanata.common.LocaleId;
 import org.zanata.common.ProjectType;
@@ -67,8 +48,27 @@ import org.zanata.rest.dto.resource.Resource;
 import org.zanata.rest.dto.resource.TranslationsResource;
 import org.zanata.service.TranslationFileService;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.MapMaker;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.jboss.seam.ScopeType.STATELESS;
+import static org.zanata.common.DocumentType.GETTEXT_PORTABLE_OBJECT;
+import static org.zanata.common.DocumentType.GETTEXT_PORTABLE_OBJECT_TEMPLATE;
+import static org.zanata.common.DocumentType.HTML;
+import static org.zanata.common.DocumentType.IDML;
+import static org.zanata.common.DocumentType.OPEN_DOCUMENT_GRAPHICS;
+import static org.zanata.common.DocumentType.OPEN_DOCUMENT_PRESENTATION;
+import static org.zanata.common.DocumentType.OPEN_DOCUMENT_SPREADSHEET;
+import static org.zanata.common.DocumentType.OPEN_DOCUMENT_TEXT;
+import static org.zanata.common.DocumentType.PLAIN_TEXT;
+import static org.zanata.common.DocumentType.SUBTITLE;
+import static org.zanata.common.DocumentType.XML_DOCUMENT_TYPE_DEFINITION;
 
 /**
  * Default implementation of the TranslationFileService interface.
@@ -94,6 +94,7 @@ public class TranslationFileServiceImpl implements TranslationFileService {
         DOCTYPEMAP.put(XML_DOCUMENT_TYPE_DEFINITION, DTDAdapter.class);
         DOCTYPEMAP.put(IDML, IDMLAdapter.class);
         DOCTYPEMAP.put(HTML, HTMLAdapter.class);
+        DOCTYPEMAP.put(SUBTITLE, SubtitleAdapter.class);
     }
 
     private static Set<String> SUPPORTED_EXTENSIONS =

--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -42,7 +42,7 @@ jsf.projectType=Project Type
 jsf.project.projectType.Description=Help: Creating a project and project type
 jsf.iteration.projectType.Description=Help: Creating a version and project type
 jsf.projectType.NotSpecifiedBehaviour=If no project type is specified, the type from containing project is used.
-jsf.projectType.detail.File=For plain text, Libre Office, InDesign etc.
+jsf.projectType.detail.File=For plain text, Libre Office, InDesign, HTML, Subtitles etc.
 jsf.projectType.detail.Gettext=For gettext software strings.
 jsf.projectType.detail.Podir=For publican/docbook strings.
 jsf.projectType.detail.Properties=For Java properties files.
@@ -51,7 +51,6 @@ jsf.projectType.detail.Xliff=For supported XLIFF files.
 jsf.projectType.detail.Xml=For XML from the Zanata REST API.
 jsf.projectType.detail.noSelection=A setting for older projects.
 jsf.projectType.detail.noSelection.message=You will not be able to upload source files from the client with this setting unless you add a project type to your config file.
-
 
 #FIXME extract URL to separate property.
 #      Note that descriptions of project types in different languages could be provided
@@ -520,7 +519,7 @@ jsf.iteration.files.DeleteDocument=Delete this document
 jsf.iteration.files.DownloadDocument=Download this document [{0}]
 jsf.iteration.files.UploadNewSourceDocument=Upload new source document
 jsf.iteration.files.FilenameWithSemicolonNotSupported=Zanata does not support filenames that contain a semicolon.
-jsf.SupportedUploadFormats=Supported types: .pot .dtd .txt .odt .fodt .odp .fodp .ods .fods .odg .fodg .odb .odf
+jsf.SupportedUploadFormats=Supported types: .pot .dtd .txt .html .htm .odt .odp .ods .odg .idml .srt .vtt .sub .sbt
 jsf.SourceLanguage=Source Language
 jsf.iteration.files.DocumentPath=Document Path
 jsf.iteration.files.CustomParams=Custom Parsing Parameters

--- a/zanata-war/src/main/resources/org/zanata/adapter/SubtitleAdapterDefaultConfiguration.yml
+++ b/zanata-war/src/main/resources/org/zanata/adapter/SubtitleAdapterDefaultConfiguration.yml
@@ -1,0 +1,24 @@
+useLD.b=true
+localizeOutside.b=true
+startString="
+endString="
+extractOuterStrings.b=false
+useBSlashEscape.b=true
+oneLevelGroups.b=false
+regexOptions.i=40
+mimeType=text/plain
+ruleCount.i=1
+rule0.ruleName=Rule
+rule0.ruleType.i=1
+rule0.expr=^(\d\d:\d\d:\d\d.*?|\d\d:\d\d\.\d\d\d.*?)\n(.*?)(\n\n|\z)
+rule0.groupSource.i=2
+rule0.groupTarget.i=-1
+rule0.groupName.i=1
+rule0.groupNote.i=-1
+rule0.preserveWS.b=true
+rule0.useCodeFinder.b=true
+rule0.sample=1$0a$00:00:20,000 --> 00:00:24,400 X1:100 X2:600 Y1:050 Y2:100$0a$text line 1$0a$line 2$0a$$0a$2$0a$00:00:24,600 --> 00:00:27,800$0a$Text entry 2$0a$
+rule0.codeFinderRules.count.i=1
+rule0.codeFinderRules.rule0=<\w+.*?>|</\w+.*?>
+rule0.codeFinderRules.sample=test <b>bold</b>, <a href='link' more="&lt;value&gt;"/> test
+rule0.codeFinderRules.useAllRulesWhenTesting.b=false


### PR DESCRIPTION
SubRip Text format is a moderately global format for translating and
displaying subtitles in videos.  Okapi provided a nice interface
via the Regex Filter for upload.
