### PR TITLE
rhbz1065806 - Fix stuck loading image when changing version statistics type.

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/layout/loading.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/loading.xhtml
@@ -7,7 +7,7 @@
   xmlns:rich="http://richfaces.org/rich">
 
   <div class="loading_parent">
-    <a:status for="#{regionId}" startStyleClass="loading_frame">
+    <a:status name="spinning-loader" startStyleClass="loading_frame">
       <f:facet name="start">
         <h:graphicImage value="/images/loading-lg.gif" height="32" width="32"
           styleClass="loading_image"/>

--- a/zanata-war/src/main/webapp/iteration/view.xhtml
+++ b/zanata-war/src/main/webapp/iteration/view.xhtml
@@ -70,7 +70,8 @@
         rendered="#{identity.loggedIn}"/>
       <a4j:commandButton title="#{messages['jsf.RefreshTable']}"
         action="#{viewAllStatusAction.refreshStatistic}" render="data_table"
-        value="#{messages['jsf.Refresh']}" styleClass="float-right">
+        value="#{messages['jsf.Refresh']}" styleClass="float-right"
+        status="spinning-loader">
       </a4j:commandButton>
       <br/><br/>
       <rich:dataTable id="data_table" width="100%"
@@ -135,7 +136,7 @@
                   itemValue="WORD"/>
                 <f:selectItem itemLabel="#{messages['jsf.Message']}"
                   itemValue="MESSAGE"/>
-                <a4j:ajax event="change" render="data_table"
+                <a4j:ajax event="change" render="data_table" status="spinning-loader"
                   listener="#{viewAllStatusAction.refreshStatistic}"/>
               </h:selectOneMenu>
             </h:panelGroup>


### PR DESCRIPTION
With 4.x changes to Richfaces, the behaviour of the a4j:status component changed and was causing problems by not hiding the "loading" status indicator. Refactored the page to use the updated way of using the status component.
