### PR TITLE
Fix path for test file resources

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -24,6 +24,7 @@ package org.zanata.page;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -40,6 +41,7 @@ import java.util.List;
  * @author Damian Jansen <a
  *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
+@Slf4j
 public class CorePage extends AbstractPage {
 
     @FindBy(id = "home")
@@ -131,7 +133,12 @@ public class CorePage extends AbstractPage {
      * only exhibit behaviour on losing focus.
      */
     public void defocus() {
-        getDriver().findElement(By.tagName("body")).click();
+        List<WebElement> elements = getDriver().findElements(By.id("container"));
+        if (elements.size() > 0) {
+            elements.get(0).click();
+        } else {
+            log.warn("Unable to focus page container");
+        }
     }
 
     public List<String> waitForFieldErrors() {

--- a/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 import org.zanata.page.BasePage;
 import org.zanata.util.Constants;
+import org.zanata.util.WebElementUtil;
 
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public class CreateProjectPage extends BasePage {
             "machineReadableSourceUrlField:machineReadableSourceUrl")
     private WebElement downloadSourceURLField;
 
-    @FindBy(id = "cke_projectForm:homeContentField:homeContent:inp")
+    @FindBy(id = "projectForm:homeContentField:homeContent")
     private WebElement homeContentTextArea;
 
     @FindBy(id = "projectForm:statusField:selectField")
@@ -111,7 +112,8 @@ public class CreateProjectPage extends BasePage {
     }
 
     public CreateProjectPage enterHomepageContent(String content) {
-        homeContentTextArea.sendKeys(content);
+        WebElementUtil.setRichTextEditorContent(getDriver(),
+                homeContentTextArea, content);
         return this;
     }
 

--- a/functional-test/src/main/java/org/zanata/util/TestFileGenerator.java
+++ b/functional-test/src/main/java/org/zanata/util/TestFileGenerator.java
@@ -26,6 +26,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.fedorahosted.openprops.Properties;
 import com.google.common.base.Throwables;
@@ -234,10 +236,10 @@ public class TestFileGenerator {
     }
 
     public File openTestFile(String filename) {
-        String relativePath = "functional-test/target/test-classes/"
-                .concat(filename);
-        File testFile = new File(relativePath);
-        assert testFile.exists();
+        URL url = Thread.currentThread().getContextClassLoader()
+                .getResource(filename);
+        File testFile = new File(url.getPath());
+        Preconditions.checkArgument(testFile.exists(), "%s not found", testFile);
         return testFile;
     }
 }


### PR DESCRIPTION
Tests were using a relative path rather than a process resource path
which had unintended results.
In attempting to fix this, a problem presented with clicks to cke
editors, which this also fixes.
