### PR TITLE
Fix and improve search autocomplete tests

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -232,13 +232,14 @@ public class BasePage extends CorePage {
         return new ProjectsPage(getDriver());
     }
 
-    public void waitForSearchListContains(final String expected) {
+    public BasePage waitForSearchListContains(final String expected) {
         waitForTenSec().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 return getProjectSearchAutocompleteItems().contains(expected);
             }
         });
+        return new BasePage(getDriver());
     }
 
     public List<String> getProjectSearchAutocompleteItems() {

--- a/functional-test/src/main/java/org/zanata/util/WebElementUtil.java
+++ b/functional-test/src/main/java/org/zanata/util/WebElementUtil.java
@@ -31,6 +31,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
@@ -41,6 +42,7 @@ import org.openqa.selenium.support.ui.FluentWait;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+@Slf4j
 public class WebElementUtil {
     private WebElementUtil() {
     }
@@ -290,16 +292,20 @@ public class WebElementUtil {
 
     public static List<WebElement> getSearchAutocompleteResults(
             WebDriver driver, String formId, String id) {
-        return driver.findElement(
-                By.id(formId + ":" + id + ":" + id + "-result")).findElements(
-                By.xpath(".//ul[@class='autocomplete__results']/li"));
+        try {
+            String locator = formId + ":" + id + ":" + id + "-result";
+            return driver.findElement(By.id(locator)).findElements(
+                    By.className("js-autocomplete__result"));
+        } catch (StaleElementReferenceException sere) {
+            log.warn("Stale reference encountered, returning empty list");
+            return Collections.emptyList();
+        }
     }
 
     public static List<String> getSearchAutocompleteItems(WebDriver driver,
             final String formId, final String id) {
         List<WebElement> results =
                 getSearchAutocompleteResults(driver, formId, id);
-
         List<String> resultsText =
                 Lists.transform(results, new Function<WebElement, String>() {
                     @Override

--- a/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
@@ -25,10 +25,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.zanata.feature.DetailedTest;
+import org.zanata.page.BasePage;
 import org.zanata.page.projects.ProjectBasePage;
 import org.zanata.page.projects.ProjectsPage;
-import org.zanata.page.utility.DashboardPage;
 import org.zanata.util.SampleProjectRule;
+import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,17 +47,17 @@ public class ProjectSearchTest {
 
     @Test
     public void successfulProjectSearchAndDisplay() {
-        DashboardPage dashboardPage =
-                new LoginWorkFlow().signIn("translator", "translator");
-        dashboardPage.enterSearch("about").waitForSearchListContains(
-                "about fedora");
+        BasePage basePage = new BasicWorkFlow()
+                .goToHome()
+                .enterSearch("about")
+                .waitForSearchListContains("about fedora");
 
         assertThat("Normal user can see the project",
-                dashboardPage.getProjectSearchAutocompleteItems(),
+                basePage.getProjectSearchAutocompleteItems(),
                 hasItem("about fedora"));
 
         ProjectBasePage projectPage =
-                dashboardPage.clickSearchEntry("about fedora");
+                basePage.clickSearchEntry("about fedora");
 
         assertThat("The project page is the correct one", projectPage
                 .getProjectName().trim(), // UI adds a space
@@ -65,11 +66,11 @@ public class ProjectSearchTest {
 
     @Test
     public void unsuccessfulProjectSearch() {
-        DashboardPage dashboardPage =
-                new LoginWorkFlow().signIn("translator", "translator");
-        dashboardPage.enterSearch("arodef").waitForSearchListContains(
-                "Search Zanata for 'arodef'");
-        ProjectsPage projectsPage = dashboardPage.submitSearch();
+        ProjectsPage projectsPage = new BasicWorkFlow()
+                .goToHome()
+                .enterSearch("arodef")
+                .waitForSearchListContains("Search Zanata for 'arodef'")
+                .submitSearch();
 
         assertThat("No projects are displayed", projectsPage
                 .getProjectNamesOnCurrentPage().isEmpty());
@@ -81,13 +82,13 @@ public class ProjectSearchTest {
                 .goToProject("about fedora").gotoSettingsTab()
                 .gotoSettingsGeneral().archiveProject().logout();
 
-        DashboardPage dashboardPage =
-                new LoginWorkFlow().signIn("translator", "translator");
-        dashboardPage.enterSearch("about").waitForSearchListContains(
-                "Search Zanata for 'about'");
+        BasePage basePage = new BasicWorkFlow()
+                .goToHome()
+                .enterSearch("about")
+                .waitForSearchListContains("Search Zanata for 'about'");
 
         assertThat("User cannot see the obsolete project",
-                dashboardPage.getProjectSearchAutocompleteItems(),
+                basePage.getProjectSearchAutocompleteItems(),
                 not(hasItem("About Fedora")));
 
     }


### PR DESCRIPTION
The prepending of js- to the classname broke search autocomplete
tests.
Also removed the login for project search, as autocomplete does
not require a logged in user, removing an approximate 10 second
delay per test.
