### PR TITLE
Update group's page markup in languages column

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/layout/version-group/languages-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version-group/languages-tab.xhtml
@@ -80,7 +80,7 @@
         <ui:repeat
           value="#{versionGroupHomeAction.languageTabLanguageFilter.pagedFilteredList}"
           var="hLocale">
-          <li class="progress-bar__expander">
+          <li class="progress-bar__expander panels__panel__item">
             <a4j:commandLink
               oncomplete="zanata.loader.deactivate('#languagesTab-language-label-loader')"
               action="#{versionGroupHomeAction.setSelectedLocale(hLocale)}"
@@ -91,14 +91,15 @@
               styleClass="bx--block #{hLocale.localeId}">
               <div class="list__item">
                 <div class="list__item__info">
-                  <span class="list__title">
+                  <h3 class="list__title">
                     #{hLocale.retrieveDisplayName()}
                     <s:span styleClass="badge--danger"
                       rendered="#{!versionGroupHomeAction.getMissingVersion(hLocale.localeId).isEmpty()}"
                       title="#{versionGroupHomeAction.getMissingVersionTitle(hLocale.localeId)}">
                       #{versionGroupHomeAction.getMissingVersion(hLocale.localeId).size()}
                     </s:span>
-                  </span>
+                  </h3>
+                  <span class="list__item__meta">#{hLocale.localeId}</span>
                 </div>
                 <div class="list__item__stats">
                   <a4j:status name="statistic-loader">

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version-group/projects-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version-group/projects-tab.xhtml
@@ -220,50 +220,68 @@
           <ui:repeat
             value="#{versionGroupHomeAction.projectTabLanguageFilter.pagedFilteredList}"
             var="hLocale">
-            <li class="progress-bar__expander">
-              <div class="list__item">
-                <div class="list__item__info">
-                <span class="list__title">
-                  <h:outputLink
-                    value="#{request.contextPath}/webtrans/Application.seam"
-                    rendered="#{versionGroupHomeAction.isLocaleActivatedInVersion(versionGroupHomeAction.selectedVersion, hLocale.localeId)}">
-                    <f:param name="project"
-                      value="#{versionGroupHomeAction.selectedVersion.project.slug}"/>
-                    <f:param name="iteration"
-                      value="#{versionGroupHomeAction.selectedVersion.slug}"/>
-                    <f:param name="localeId" value="#{hLocale.localeId}"/>
-                    <f:param name="locale" value="#{locale.language}"/>
-                    #{hLocale.retrieveDisplayName()}
-                  </h:outputLink>
+            <li class="progress-bar__expander panels__panel__item">
+              <h:outputLink
+                value="#{request.contextPath}/webtrans/Application.seam"
+                rendered="#{versionGroupHomeAction.isLocaleActivatedInVersion(versionGroupHomeAction.selectedVersion, hLocale.localeId)}">
+                <f:param name="project"
+                  value="#{versionGroupHomeAction.selectedVersion.project.slug}"/>
+                <f:param name="iteration"
+                  value="#{versionGroupHomeAction.selectedVersion.slug}"/>
+                <f:param name="localeId" value="#{hLocale.localeId}"/>
+                <f:param name="locale" value="#{locale.language}"/>
 
-                  <s:fragment
-                    rendered="#{!versionGroupHomeAction.isLocaleActivatedInVersion(versionGroupHomeAction.selectedVersion, hLocale.localeId)}">
-                    #{hLocale.retrieveDisplayName()}
-                  </s:fragment>
-
-                  <s:link view="/iteration/view.xhtml"
-                    rendered="#{!versionGroupHomeAction.isLocaleActivatedInVersion(versionGroupHomeAction.selectedVersion, hLocale.localeId)}">
-                    <f:param name="projectSlug"
-                      value="#{versionGroupHomeAction.selectedVersion.project.slug}"/>
-                    <f:param name="iterationSlug"
-                      value="#{versionGroupHomeAction.selectedVersion.slug}"/>
-                    <span
-                      class="label--danger">#{messages['jsf.Missing']}</span>
-                  </s:link>
-
-                </span>
-                </div>
-                <div class="list__item__stats">
-                  <ui:param name="displayUnit"
-                    value="#{versionGroupHomeAction.getStatisticFigureForProjectWithLocale(versionGroupHomeAction.languageSortingList.selectedSortOption, hLocale.localeId, versionGroupHomeAction.selectedVersion.id)}"/>
+                <div class="list__item">
+                  <div class="list__item__info">
+                    <h3 class="list__title">
+                      #{hLocale.retrieveDisplayName()}
+                    </h3>
+                    <span class="list__item__meta">#{hLocale.localeId}</span>
+                  </div>
+                  <div class="list__item__stats">
+                    <ui:param name="displayUnit"
+                      value="#{versionGroupHomeAction.getStatisticFigureForProjectWithLocale(versionGroupHomeAction.languageSortingList.selectedSortOption, hLocale.localeId, versionGroupHomeAction.selectedVersion.id)}"/>
                   <span class="stats--small #{displayUnit.cssClass}">
                     <span class="stats__figure">#{displayUnit.figure}</span>
                     <span class="stats__unit">#{displayUnit.unit}</span>
                   </span>
+                  </div>
                 </div>
-              </div>
-              <zanata:statistic
-                value="#{versionGroupHomeAction.getSelectedVersionStatistic(hLocale.localeId)}"/>
+                <zanata:statistic
+                  value="#{versionGroupHomeAction.getSelectedVersionStatistic(hLocale.localeId)}"/>
+              </h:outputLink>
+
+              <s:fragment
+                rendered="#{!versionGroupHomeAction.isLocaleActivatedInVersion(versionGroupHomeAction.selectedVersion, hLocale.localeId)}">
+                <div class="list__item">
+                  <div class="list__item__info">
+                    <h3 class="list__title">
+                      #{hLocale.retrieveDisplayName()}
+
+                      <s:link view="/iteration/view.xhtml">
+                        <f:param name="projectSlug"
+                          value="#{versionGroupHomeAction.selectedVersion.project.slug}"/>
+                        <f:param name="iterationSlug"
+                          value="#{versionGroupHomeAction.selectedVersion.slug}"/>
+                        <span
+                          class="label--danger">#{messages['jsf.Missing']}</span>
+                      </s:link>
+
+                    </h3>
+                    <span class="list__item__meta">#{hLocale.localeId}</span>
+                  </div>
+                  <div class="list__item__stats">
+                    <ui:param name="displayUnit"
+                      value="#{versionGroupHomeAction.getStatisticFigureForProjectWithLocale(versionGroupHomeAction.languageSortingList.selectedSortOption, hLocale.localeId, versionGroupHomeAction.selectedVersion.id)}"/>
+                    <span class="stats--small #{displayUnit.cssClass}">
+                      <span class="stats__figure">#{displayUnit.figure}</span>
+                      <span class="stats__unit">#{displayUnit.unit}</span>
+                    </span>
+                  </div>
+                </div>
+                <zanata:statistic
+                  value="#{versionGroupHomeAction.getSelectedVersionStatistic(hLocale.localeId)}"/>
+              </s:fragment>
             </li>
           </ui:repeat>
         </ul>

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version/languages-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version/languages-tab.xhtml
@@ -410,11 +410,11 @@
                     rendered="#{versionHomeAction.pageRendered}">
                     <ui:param name="displayUnit"
                       value="#{versionHomeAction.getStatisticFigureForDocument(versionHomeAction.documentSortingList.selectedSortOption, versionHomeAction.selectedLocale.localeId, document)}"/>
-                 <span class="#{displayUnit.cssClass}"
-                   title="#{displayUnit.title}">
-                    <span class="stats__figure">#{displayUnit.figure}</span>
-                    <span class="stats__unit">#{displayUnit.unit}</span>
-                 </span>
+                     <span class="#{displayUnit.cssClass}"
+                       title="#{displayUnit.title}">
+                        <span class="stats__figure">#{displayUnit.figure}</span>
+                        <span class="stats__unit">#{displayUnit.unit}</span>
+                     </span>
                   </s:div>
                 </div>
                 <zanata:statistic


### PR DESCRIPTION
Update group's language and project tab on languages column to display localeId
