### PR TITLE
rhbz831479 - REST return 400 bad request for invalid extensions

### DIFF
--- a/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
+++ b/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
@@ -1345,9 +1345,12 @@ public class ResourceUtils {
             @SuppressWarnings("unchecked")
             Collection<String> invalidExtensions =
                     CollectionUtils.subtract(requestedExt, validExtensions);
-            throw new RuntimeException(
-                    "Unsupported Extensions within this context: "
-                            + StringUtils.join(invalidExtensions, ","));
+            Response response =
+                    Response.status(Status.BAD_REQUEST)
+                            .entity("Unsupported Extensions within this context: "
+                                    + StringUtils.join(invalidExtensions, ","))
+                            .build();
+            throw new WebApplicationException(response);
         }
     }
 

--- a/zanata-war/src/test/java/org/zanata/rest/service/TranslationServiceRestTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/TranslationServiceRestTest.java
@@ -3,6 +3,7 @@ package org.zanata.rest.service;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.JAXBException;
 
+import org.hamcrest.Matchers;
 import org.jboss.resteasy.client.ClientResponse;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -18,6 +19,9 @@ import org.zanata.rest.dto.resource.TranslationsResource;
 import org.zanata.seam.SeamAutowire;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.service.impl.*;
+
+
+import com.google.common.collect.Sets;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -169,6 +173,17 @@ public class TranslationServiceRestTest extends
         log.debug("actual:" + get.toString());
         ResourceTestUtil.clearPoTargetHeaders(base, get);
         assertThat(base.toString(), is(get.toString()));
+    }
+
+    @Test
+    public void invalidExtensionWillGetBadRequest() {
+        Resource res = resourceTestFactory.getTextFlowTest();
+        ClientResponse<TranslationsResource> response =
+                translationResource.getTranslations(res.getName(), DE,
+                        Sets.newHashSet("invalidExt"), true, "etag");
+
+        assertThat(response.getStatus(),
+                Matchers.equalTo(Status.BAD_REQUEST.getStatusCode()));
     }
 
     private <T> T cloneDTO(T dto) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=831479

Integration test is written but if you want to manually test it, boot up your local instance and try(replace project/iteration/docId/locale to suit):

curl "http://localhost:8080/zanata/rest/projects/p/about-fedora/iterations/i/master/r/About_Fedora/translations/zh?ext=blah" -H "Cache-Control: no-cache" -H "X-Auth-Token: b6d7044e9ee3b2447c28fb7c50d86d98" -H "X-Auth-User: admin" -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31"
