### PR TITLE
Fix view obsolete group in groups list 

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/VersionGroupServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/VersionGroupServiceImpl.java
@@ -120,7 +120,7 @@ public class VersionGroupServiceImpl implements VersionGroupService {
 
         List<HIterationGroup> filteredList = Lists.newArrayList();
         for (HIterationGroup obsoleteGroup : obsoleteVersions) {
-            if (person.isMaintainer(obsoleteGroup)) {
+            if (obsoleteGroup.getMaintainers().contains(person)) {
                 filteredList.add(obsoleteGroup);
             }
         }


### PR DESCRIPTION
Currently, if a group is set to obsolete, it will be missing from group list even if "obsolete" option is checked.
