### PR TITLE
Add iText for PDF/email support in JavaMelody

### DIFF
--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -138,6 +138,8 @@
             <usedDependency>com.google.protobuf:protobuf-java</usedDependency>
             <!-- used for annotations -->
             <usedDependency>com.google.code.findbugs:jsr305</usedDependency>
+            <!-- Used by javamelody for email/pdf support -->
+            <usedDependency>com.lowagie:itext</usedDependency>
             <!-- used for arquillian tests -->
             <usedDependency>org.jboss.as:jboss-as-controller</usedDependency>
             <!-- used for gwt super devmode -->
@@ -1461,6 +1463,19 @@
       <groupId>net.bull.javamelody</groupId>
       <artifactId>javamelody-core</artifactId>
       <version>1.48.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.lowagie</groupId>
+      <artifactId>itext</artifactId>
+      <version>2.1.7</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bctsp-jdk14</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
I haven't had a chance to test this yet, but the documentation is here: https://code.google.com/p/javamelody/wiki/UserGuide#14._Weekly,_daily_or_monthly_reports_by_mail

I think the "Parameters" which live in the tomcat context can also be provided as system properties, eg in standalone.xml.  We would also need to define a suitable mail session with matching name.

We can merge this either into release or integration/master.
