### PR TITLE
rhbz1120016 - Allow single OpenId authentication.

### DIFF
--- a/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
+++ b/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
 import javax.servlet.http.HttpServletRequest;
 
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +48,7 @@ import org.jboss.seam.annotations.Startup;
 import org.jboss.seam.annotations.Synchronized;
 import org.jboss.seam.web.ServletContexts;
 import org.zanata.config.DatabaseBackedConfig;
+import org.zanata.config.JaasConfig;
 import org.zanata.config.JndiBackedConfig;
 import org.zanata.log4j.ZanataHTMLLayout;
 import org.zanata.log4j.ZanataSMTPAppender;
@@ -56,6 +59,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.zanata.security.OpenIdLoginModule;
 
 @Name("applicationConfiguration")
 @Scope(ScopeType.APPLICATION)
@@ -76,6 +80,8 @@ public class ApplicationConfiguration implements Serializable {
     private DatabaseBackedConfig databaseBackedConfig;
     @In
     private JndiBackedConfig jndiBackedConfig;
+    @In
+    private JaasConfig jaasConfig;
 
     private static final ZanataSMTPAppender smtpAppenderInstance =
             new ZanataSMTPAppender();
@@ -273,6 +279,20 @@ public class ApplicationConfiguration implements Serializable {
 
     public boolean isOpenIdAuth() {
         return this.loginModuleNames.containsKey(AuthenticationType.OPENID);
+    }
+
+    public boolean isSingleOpenIdProvider() {
+        return getOpenIdProviderUrl() != null;
+    }
+
+    public String getOpenIdProviderUrl() {
+        if (loginModuleNames.containsKey(AuthenticationType.OPENID)) {
+            return jaasConfig.getAppConfigurationProperty(
+                    loginModuleNames.get(AuthenticationType.OPENID),
+                    OpenIdLoginModule.class,
+                    OpenIdLoginModule.OPEN_ID_PROVIDER_KEY);
+        }
+        return null;
     }
 
     public boolean isKerberosAuth() {

--- a/zanata-war/src/main/java/org/zanata/action/LoginAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/LoginAction.java
@@ -22,19 +22,19 @@ package org.zanata.action;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.jboss.seam.ScopeType;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
 import org.zanata.ApplicationConfiguration;
-import org.zanata.dao.AccountDAO;
 import org.zanata.security.AuthenticationManager;
 import org.zanata.security.AuthenticationType;
 import org.zanata.security.ZanataCredentials;
 import org.zanata.security.openid.OpenIdProviderType;
-
-import lombok.Getter;
-import lombok.Setter;
+import org.zanata.security.openid.OpenIdUtil;
 
 /**
  * This action takes care of logging a user into the system. It contains logic
@@ -119,5 +119,17 @@ public class LoginAction implements Serializable {
         credentials.setAuthType(AuthenticationType.OPENID);
         credentials.setOpenIdProviderType(providerType);
         return authenticationManager.openIdLogin();
+    }
+
+    /**
+     * Another way of doing open id without knowing the provider first hand.
+     * Tries to match the given open id with a known provider. If it can't find
+     * one it uses a generic provider.
+     */
+    public String genericOpenIdLogin(String openId) {
+        setOpenId(openId);
+        OpenIdProviderType providerType =
+                OpenIdUtil.getBestSuitedProvider(openId);
+        return openIdLogin(providerType.name());
     }
 }

--- a/zanata-war/src/main/java/org/zanata/config/JaasConfig.java
+++ b/zanata-war/src/main/java/org/zanata/config/JaasConfig.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.config;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.spi.LoginModule;
+
+import org.jboss.seam.ScopeType;
+import org.jboss.seam.annotations.AutoCreate;
+import org.jboss.seam.annotations.Name;
+import org.jboss.seam.annotations.Scope;
+import org.jboss.seam.annotations.intercept.BypassInterceptors;
+
+/**
+ * Store for JAAS configuration.
+ *
+ * @author Carlos Munoz <a
+ *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
+ */
+@Name("jaasConfig")
+@AutoCreate
+@BypassInterceptors
+@Scope(ScopeType.APPLICATION)
+public class JaasConfig {
+
+    /**
+     * Retrieves all App configuration entries under a given name. In Jboss's
+     * standalone.xml, these are all the {@code <login-module></login-module>}
+     * entries under @{code <security-domain>}
+     *
+     * @param loginModuleName
+     *            The login module name as configured. In Jboss' standalone.xml
+     *            this the name attribute at
+     *            {@code <security-domain name="NAME">}
+     * @return A collection of configuration entries. May be null if there are
+     *         no configuration entries under that name.
+     */
+    public AppConfigurationEntry[] getAppConfigurationEntries(
+            String loginModuleName) {
+        return Configuration.getConfiguration().getAppConfigurationEntry(
+                loginModuleName);
+    }
+
+    /**
+     * Retrieves a single configuration entry under a given name and using a
+     * specific class. In JBoss' standalone.xml this type is specified under
+     * {@code <login-module code="TYPE"></login-module>}. Since there may be
+     * more than one configuration entry using the same code, this method
+     * returns the first one found.
+     *
+     * @param loginModuleName
+     *            The login module name as configured. In Jboss' standalone.xml
+     *            this the name attribute at
+     *            {@code <security-domain name="NAME">}
+     * @param loginModuleType
+     *            The Login module type used.
+     * @return the first found configuration entry under the given name, and
+     *         using the given login module class. Null if no such configuration
+     *         is found.
+     */
+    public AppConfigurationEntry
+            getAppConfigurationEntry(String loginModuleName,
+                    Class<? extends LoginModule> loginModuleType) {
+        AppConfigurationEntry[] entries =
+                getAppConfigurationEntries(loginModuleName);
+        if(entries != null) {
+            for (AppConfigurationEntry e : entries) {
+                if (e.getLoginModuleName().equals(loginModuleType.getName())) {
+                    return e;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves a configuration property. In Jboss's standalone.xml, these are
+     * configured at {@code
+     * <login-module ...>
+     *     <module-option name="KEY" value="VALUE"/>
+     *     ...
+     * </login-module>
+     * }
+     *
+     * @param loginModuleName
+     *            The login module name as configured. In Jboss' standalone.xml
+     *            this the name attribute at
+     *            {@code <security-domain name="NAME">}
+     * @param loginModuleType
+     *            The Login module type used.
+     * @param key
+     *            The option key.
+     * @return The configuration value for the property ofr null if the property
+     *         cannot be found.
+     */
+    public String getAppConfigurationProperty(String loginModuleName,
+            Class<? extends LoginModule> loginModuleType, String key) {
+        AppConfigurationEntry configEntry =
+                getAppConfigurationEntry(loginModuleName, loginModuleType);
+        if (configEntry == null) {
+            return null;
+        } else if (configEntry.getOptions().containsKey(key)) {
+            return (String) configEntry.getOptions().get(key);
+        } else {
+            return null;
+        }
+    }
+}

--- a/zanata-war/src/main/java/org/zanata/security/AuthenticationType.java
+++ b/zanata-war/src/main/java/org/zanata/security/AuthenticationType.java
@@ -26,5 +26,12 @@ package org.zanata.security;
  * @author camunoz@redhat.com
  */
 public enum AuthenticationType {
-    INTERNAL, KERBEROS, OPENID, JAAS
+    /* Internal authentication (username / password) */
+    INTERNAL,
+    /* Kerberos authentication. Ticket or form based. */
+    KERBEROS,
+    /* Open Id authentication */
+    OPENID,
+    /* Any other custom username & password-based jaas authentication mechanism */
+    JAAS,
 }

--- a/zanata-war/src/main/java/org/zanata/security/OpenIdLoginModule.java
+++ b/zanata-war/src/main/java/org/zanata/security/OpenIdLoginModule.java
@@ -34,6 +34,7 @@ import javax.security.auth.spi.LoginModule;
 import org.zanata.util.ServiceLocator;
 
 public class OpenIdLoginModule implements LoginModule {
+    public static final String OPEN_ID_PROVIDER_KEY = "providerURL";
     protected Set<String> roles = new HashSet<String>();
 
     protected Subject subject;

--- a/zanata-war/src/main/java/org/zanata/security/openid/OpenIdUtil.java
+++ b/zanata-war/src/main/java/org/zanata/security/openid/OpenIdUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.security.openid;
+
+/**
+ * General utilities for Open Id providers.
+ *
+ * @author Carlos Munoz <a
+ *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
+ */
+public class OpenIdUtil {
+
+    /**
+     * Returns the best suited provider for a given Open id.
+     *
+     * @param openId
+     *            An Open id (They are usually in the form of a url).
+     */
+    public static OpenIdProviderType getBestSuitedProvider(String openId) {
+        if (new FedoraOpenIdProvider().accepts(openId)) {
+            return OpenIdProviderType.Fedora;
+        } else if (new GoogleOpenIdProvider().accepts(openId)) {
+            return OpenIdProviderType.Google;
+        } else if (new YahooOpenIdProvider().accepts(openId)) {
+            return OpenIdProviderType.Yahoo;
+        } else {
+            return OpenIdProviderType.Generic;
+        }
+    }
+}

--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -50,6 +50,9 @@
         if="#{!identity.isLoggedIn() and authenticationManager.authenticatedAccountWaitingForActivation}">
         <redirect view-id="/account/inactive_account.xhtml" />
       </rule>
+      <rule if="#{!identity.loggedIn and applicationConfiguration.singleOpenIdProvider}">
+        <redirect view-id="/home.xhtml" />
+      </rule>
       <rule if="#{!identity.loggedIn}">
         <redirect view-id="/account/login.xhtml" />
       </rule>

--- a/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
@@ -154,9 +154,17 @@
       <h:outputLink id="signin_link"
         value="#{request.contextPath}/account/sign_in?continue=#{urlUtil.getEncodedLocalUrl(request)}"
         propagation="none" styleClass="l--push-left-half button--primary"
-        rendered="#{not applicationConfiguration.kerberosAuth}">
+        rendered="#{applicationConfiguration.internalAuth or applicationConfiguration.jaasAuth or (applicationConfiguration.openIdAuth and not applicationConfiguration.singleOpenIdProvider)}">
         #{msgs['jsf.Login']}
       </h:outputLink>
+
+      <h:form rendered="#{applicationConfiguration.openIdAuth and applicationConfiguration.singleOpenIdProvider}">
+        <h:commandLink id="openid_single_signin_link"
+          action="#{loginAction.genericOpenIdLogin(applicationConfiguration.openIdProviderUrl)}"
+          propagation="none" styleClass="l--push-left-half button--primary">
+          #{msgs['jsf.Login']}
+        </h:commandLink>
+      </h:form>
 
       <h:outputLink id="ksignin_link"
         value="#{request.contextPath}/account/klogin.seam?continue=#{urlUtil.getEncodedLocalUrl(request)}"


### PR DESCRIPTION
Offer a configuration setup that allows for just a single open id provider to be configured.
To test this, the standalone.xml security configuration should look like this (for fedora auth):

``` xml
<security-domain name="zanata.openid">
     <authentication>
           <login-module code="org.zanata.security.OpenIdLoginModule" flag="required">
                 <module-option name="providerURL" value="http://id.fedoraproject.org/"/>
           </login-module>
      </authentication>
</security-domain>
```
