### PR TITLE
fix: remove reference to drools rules security resolver after the security change

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/AuthenticationEvents.java
+++ b/zanata-war/src/main/java/org/zanata/action/AuthenticationEvents.java
@@ -30,22 +30,13 @@ import org.jboss.seam.annotations.Observer;
 import org.jboss.seam.annotations.Scope;
 import org.jboss.seam.security.Identity;
 import org.jboss.seam.security.management.JpaIdentityStore;
-import org.jboss.seam.security.permission.RuleBasedPermissionResolver;
 import org.zanata.model.HAccount;
-import org.zanata.model.HPerson;
 
 @Name("authenticationEvents")
 @Scope(ScopeType.STATELESS)
 @Slf4j
 public class AuthenticationEvents implements Serializable {
     private static final long serialVersionUID = 1L;
-
-    public void injectAuthenticatedPersonIntoWorkingMemory(HAccount account) {
-        HPerson authenticatedPerson = account.getPerson();
-        // insert authenticatedPerson for use in security.drl rules
-        RuleBasedPermissionResolver.instance().getSecurityContext()
-                .insert(authenticatedPerson);
-    }
 
     @Observer(JpaIdentityStore.EVENT_USER_CREATED)
     public void createSuccessful(HAccount account) {

--- a/zanata-war/src/main/java/org/zanata/async/AsynchronousTaskExecutor.java
+++ b/zanata-war/src/main/java/org/zanata/async/AsynchronousTaskExecutor.java
@@ -120,7 +120,6 @@ public class AsynchronousTaskExecutor {
                     ServiceLocator.instance().getInstance(
                             AuthenticationEvents.class);
             HAccount authenticatedAccount = accountDAO.getByUsername(username);
-            authEvts.injectAuthenticatedPersonIntoWorkingMemory(authenticatedAccount);
             idStore.setAuthenticateUser(authenticatedAccount);
         }
     }

--- a/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
@@ -20,14 +20,10 @@
  */
 package org.zanata.security;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.annotation.Nullable;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
-import org.drools.FactHandle;
-import org.drools.StatefulSession;
 import org.jboss.seam.annotations.Install;
 import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Observer;
@@ -40,7 +36,6 @@ import org.jboss.seam.security.Configuration;
 import org.jboss.seam.security.Identity;
 import org.jboss.seam.security.NotLoggedInException;
 import org.jboss.seam.security.management.JpaIdentityStore;
-import org.jboss.seam.security.permission.RuleBasedPermissionResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;


### PR DESCRIPTION
This causes exception in all asynchronize tasks. i.e. push and pull from client.
