### PR TITLE
Remove banDuplicateClasses enforcer

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -768,23 +768,6 @@
               </excludes>
               <searchTransitive>true</searchTransitive>
             </bannedDependencies>
-            <banDuplicateClasses>
-              <dependencies combine.children="append">
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>org.jboss</groupId>
-                  <artifactId>jboss-remote-naming</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.jboss.naming.remote.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-              </dependencies>
-              <ignoreClasses combine.children="append">
-                <!-- multiple versions of selenium artifacts in the dependency tree -->
-                <ignoreClass>com.thoughtworks.selenium.*</ignoreClass>
-                <ignoreClass>org.openqa.selenium.*</ignoreClass>
-              </ignoreClasses>
-            </banDuplicateClasses>
           </rules>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -733,58 +733,6 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <configuration>
           <rules>
-            <banDuplicateClasses>
-              <dependencies combine.children="append">
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>com.beust</groupId>
-                  <artifactId>jcommander</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>com.beust.jcommander.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-                <dependency>
-                  <groupId>com.google.gwt</groupId>
-                  <artifactId>gwt-dev</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.apache.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>commons-fileupload</groupId>
-                  <artifactId>commons-fileupload</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.apache.commons.fileupload.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>org.apache.maven</groupId>
-                  <artifactId>maven*</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.apache.maven.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>org.picketbox</groupId>
-                  <artifactId>picketbox</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.picketbox.*</ignoreClass>
-                    <ignoreClass>org.jboss.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-                <!-- multiple versions in the dependency tree -->
-                <dependency>
-                  <groupId>net.sf.ehcache</groupId>
-                  <artifactId>ehcache-core</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>net.sf.ehcache.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-              </dependencies>
-            </banDuplicateClasses>
             <requireNoRepositories>
               <allowedRepositories combine.children="append">
                 <allowedRepository>jboss-public-repository-group</allowedRepository>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -207,44 +207,6 @@
             </configuration>
           </execution>
         </executions>
-        <configuration>
-          <rules>
-            <banDuplicateClasses>
-              <dependencies>
-                <dependency>
-                  <groupId>commons-beanutils</groupId>
-                  <artifactId>commons-beanutils</artifactId>
-                  <ignoreClasses>
-                    <ignoreClass>org.apache.commons.beanutils.*</ignoreClass>
-                  </ignoreClasses>
-                </dependency>
-              </dependencies>
-              <ignoreClasses combine.children="append">
-                <!-- Please remove exclusions as offending jars are fixed
-                     or removed -->
-
-                <ignoreClass>org.apache.maven.model.*</ignoreClass>
-                <ignoreClass>org.apache.maven.artifact.repository.metadata.*</ignoreClass>
-                <ignoreClass>javax.annotation.*</ignoreClass>
-                <ignoreClass>com.beust.jcommander.*</ignoreClass>
-                <ignoreClass>net.sf.ehcache.*</ignoreClass>
-
-                <!--  caused by gwt jars -->
-                <ignoreClass>com.google.gwt.*</ignoreClass>
-                <ignoreClass>com.google.web.bindery.*</ignoreClass>
-                <ignoreClass>javax.servlet.*</ignoreClass>
-                <ignoreClass>javax.validation.ConstraintViolationException_CustomFieldSerializer</ignoreClass>
-                <ignoreClass>org.hibernate.validator.*</ignoreClass>
-                <ignoreClass>org.w3c.css.sac.*</ignoreClass>
-
-                <!-- picketbox jar -->
-                <ignoreClass>org.jboss.crypto.*</ignoreClass>
-                <ignoreClass>org.jboss.security.*</ignoreClass>
-                <ignoreClass>org.picketbox.*</ignoreClass>
-              </ignoreClasses>
-            </banDuplicateClasses>
-          </rules>
-        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Replaced by maven-duplicate-finder-plugin.  See
   https://github.com/zanata/zanata-parent/pull/28 and
   https://github.com/zanata/zanata-parent/commit/04a7b8d
