### PR TITLE
Fix document access from version page, documents' tab.

### DIFF
--- a/zanata-war/src/main/webapp/WEB-INF/layout/version/documents-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version/documents-tab.xhtml
@@ -100,7 +100,7 @@
         var="document">
         <ui:param name="hasActions"
           value="#{versionHomeAction.isPoDocument(document.docId) or !versionHomeAction.isPoDocument(document.docId) or versionHomeAction.hasOriginal(document.path, document.name) or versionHomeAction.documentUploadAllowed or versionHomeAction.documentRemovalAllowed}"/>
-        <li id="#{versionHomeAction.encodeDocId(document.docId)}"
+        <li id="#{document.docId}"
           class="progress-bar__expander #{hasActions ? 'list__item--actionable' : ''}" >
           <s:div styleClass="list__item__action" rendered="#{hasActions}">
             <div


### PR DESCRIPTION
Corrects an issue on this specific page: when clicking on a file with a path on it, the languages' list does not get updated with the available languages.
