### PR TITLE
Use rest caller in upload tests, fix breakages

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Predicate;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -14,6 +15,7 @@ import org.zanata.page.projectversion.VersionBasePage;
  * @author Damian Jansen <a
  *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
+@Slf4j
 public class VersionDocumentsTab extends VersionBasePage {
 
     public static final String UNSUPPORTED_FILETYPE =
@@ -144,10 +146,10 @@ public class VersionDocumentsTab extends VersionBasePage {
             @Override
             public boolean apply(WebDriver input) {
                 return getDriver().findElement(By.id("file-upload-component"))
-                        .findElement(By.className("txt--danger")).isDisplayed();
+                        .findElement(By.className("message--danger")).isDisplayed();
             }
         });
         return getDriver().findElement(By.id("file-upload-component"))
-                .findElement(By.className("txt--danger")).getText();
+                .findElement(By.className("message--danger")).getText();
     }
 }

--- a/functional-test/src/test/java/org/zanata/feature/document/MultiFileUploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/MultiFileUploadTest.java
@@ -37,6 +37,7 @@ import org.zanata.page.projectversion.versionsettings.VersionDocumentsTab;
 import org.zanata.util.CleanDocumentStorageRule;
 import org.zanata.util.SampleProjectRule;
 import org.zanata.util.TestFileGenerator;
+import org.zanata.util.ZanataRestCaller;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 import org.zanata.workflow.ProjectWorkFlow;
@@ -51,28 +52,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 public class MultiFileUploadTest extends ZanataTestCase {
 
-    @ClassRule
-    public static SampleProjectRule sampleProjectRule = new SampleProjectRule();
+    @Rule
+    public SampleProjectRule sampleProjectRule = new SampleProjectRule();
 
     @Rule
     public CleanDocumentStorageRule documentStorageRule =
             new CleanDocumentStorageRule();
 
+    private ZanataRestCaller zanataRestCaller;
     private TestFileGenerator testFileGenerator = new TestFileGenerator();
     private String documentStorageDirectory;
-
-
-    @BeforeClass
-    public static void beforeClass() {
-        new LoginWorkFlow().signIn("admin", "admin");
-        new ProjectWorkFlow().createNewProjectVersion(
-                "about fedora", "multi-upload", "File")
-                .logout();
-    }
 
     @Before
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
+        zanataRestCaller = new ZanataRestCaller();
+        zanataRestCaller.createProjectAndVersion("multi-upload", "multi-upload",
+            "file");
         documentStorageDirectory = CleanDocumentStorageRule
                 .getDocumentStoragePath()
                 .concat(File.separator)
@@ -82,6 +78,7 @@ public class MultiFileUploadTest extends ZanataTestCase {
         if (new File(documentStorageDirectory).exists()) {
             log.warn("Document storage directory exists (cleanup incomplete)");
         }
+        new LoginWorkFlow().signIn("admin", "admin");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -95,10 +92,8 @@ public class MultiFileUploadTest extends ZanataTestCase {
                 "This is another test file");
         String testFileName = firstFile.getName();
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("multi-upload")
                 .gotoVersion("multi-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -127,10 +122,8 @@ public class MultiFileUploadTest extends ZanataTestCase {
         File keptUploadFile = testFileGenerator.generateTestFileWithContent(
                 "removeFileFromUploadList", ".txt", "Remove File Upload Test");
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("multi-upload")
                 .gotoVersion("multi-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()

--- a/functional-test/src/test/java/org/zanata/feature/document/SubtitleDocumentTypeTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/SubtitleDocumentTypeTest.java
@@ -35,6 +35,7 @@ import org.zanata.page.webtrans.EditorPage;
 import org.zanata.util.CleanDocumentStorageRule;
 import org.zanata.util.SampleProjectRule;
 import org.zanata.util.TestFileGenerator;
+import org.zanata.util.ZanataRestCaller;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 import org.zanata.workflow.ProjectWorkFlow;
@@ -60,15 +61,15 @@ public class SubtitleDocumentTypeTest extends ZanataTestCase {
     public CleanDocumentStorageRule documentStorageRule =
             new CleanDocumentStorageRule();
 
+    private ZanataRestCaller zanataRestCaller;
     private TestFileGenerator testFileGenerator = new TestFileGenerator();
     private String sep = System.getProperty("line.separator");
 
-    @BeforeClass
-    public static void beforeClass() {
-        new LoginWorkFlow().signIn("admin", "admin");
-        new ProjectWorkFlow().createNewProjectVersion(
-                "about fedora", "subtitle-upload", "File")
-                .logout();
+    @Before
+    public void beforeClass() {
+        zanataRestCaller = new ZanataRestCaller();
+        zanataRestCaller.createProjectAndVersion("subtitle-test", "subtitles",
+                "file");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -243,8 +244,8 @@ public class SubtitleDocumentTypeTest extends ZanataTestCase {
         VersionDocumentsPage versionDocumentsPage = new LoginWorkFlow()
                 .signIn("admin", "admin")
                 .goToProjects()
-                .goToProject("about fedora")
-                .gotoVersion("subtitle-upload")
+                .goToProject("subtitle-test")
+                .gotoVersion("subtitles")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
                 .pressUploadFileButton()

--- a/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
@@ -38,6 +38,7 @@ import org.zanata.page.projectversion.versionsettings.VersionDocumentsTab;
 import org.zanata.util.CleanDocumentStorageRule;
 import org.zanata.util.SampleProjectRule;
 import org.zanata.util.TestFileGenerator;
+import org.zanata.util.ZanataRestCaller;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 import org.zanata.workflow.ProjectWorkFlow;
@@ -53,28 +54,23 @@ import static org.zanata.util.FunctionalTestHelper.assumeTrue;
 @Slf4j
 public class UploadTest extends ZanataTestCase {
 
-    @ClassRule
-    public static SampleProjectRule sampleProjectRule = new SampleProjectRule();
+    @Rule
+    public SampleProjectRule sampleProjectRule = new SampleProjectRule();
 
     @Rule
     public CleanDocumentStorageRule documentStorageRule =
             new CleanDocumentStorageRule();
 
+    private ZanataRestCaller zanataRestCaller;
     private TestFileGenerator testFileGenerator = new TestFileGenerator();
     private String documentStorageDirectory;
-
-
-    @BeforeClass
-    public static void beforeClass() {
-        new LoginWorkFlow().signIn("admin", "admin");
-        new ProjectWorkFlow().createNewProjectVersion(
-                "about fedora", "txt-upload", "File")
-                .logout();
-    }
 
     @Before
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
+        zanataRestCaller = new ZanataRestCaller();
+        zanataRestCaller.createProjectAndVersion("uploadtest",
+                "txt-upload", "file");
         documentStorageDirectory = CleanDocumentStorageRule
                 .getDocumentStoragePath()
                 .concat(File.separator)
@@ -84,6 +80,7 @@ public class UploadTest extends ZanataTestCase {
         if (new File(documentStorageDirectory).exists()) {
             log.warn("Document storage directory exists (cleanup incomplete)");
         }
+        new LoginWorkFlow().signIn("admin", "admin");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -95,10 +92,8 @@ public class UploadTest extends ZanataTestCase {
                         "This is a test file");
         String testFileName = originalFile.getName();
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -133,10 +128,8 @@ public class UploadTest extends ZanataTestCase {
                 testFileGenerator.generateTestFileWithContent(
                         "cancelFileUpload", ".txt", "Cancel File Upload Test");
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -151,10 +144,8 @@ public class UploadTest extends ZanataTestCase {
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void emptyFilenameUpload() {
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -177,10 +168,8 @@ public class UploadTest extends ZanataTestCase {
         assumeTrue("Data file " + bigFile.getName() + " is big",
                 bigFile.length() == fileSizeInMB);
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -202,10 +191,8 @@ public class UploadTest extends ZanataTestCase {
         String successfullyUploaded =
                 "Document " + noFile.getName() + " uploaded.";
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -227,10 +214,8 @@ public class UploadTest extends ZanataTestCase {
         File longFile = testFileGenerator.generateTestFileWithContent(
                 testFileGenerator.longFileName(), ".txt",
                 "This filename is long");
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -254,10 +239,8 @@ public class UploadTest extends ZanataTestCase {
                 .generateTestFileWithContent("emptyFile", ".txt", "");
         assumeTrue("File is empty", emptyFile.length() == 0);
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
@@ -284,16 +267,13 @@ public class UploadTest extends ZanataTestCase {
         File unsupportedFile = testFileGenerator
                 .generateTestFileWithContent("testfodt", ".fodt", "<xml></xml>");
 
-        VersionDocumentsTab versionDocumentsTab = new LoginWorkFlow()
-                .signIn("admin", "admin")
-                .goToProjects()
-                .goToProject("about fedora")
+        VersionDocumentsTab versionDocumentsTab = new ProjectWorkFlow()
+                .goToProjectByName("uploadtest")
                 .gotoVersion("txt-upload")
                 .gotoSettingsTab()
                 .gotoSettingsDocumentsTab()
                 .pressUploadFileButton()
-                .enterFilePath(unsupportedFile.getAbsolutePath())
-                .submitUpload();
+                .enterFilePath(unsupportedFile.getAbsolutePath());
 
         assertThat(versionDocumentsTab.getUploadError())
                 .contains(VersionDocumentsTab.UNSUPPORTED_FILETYPE)

--- a/functional-test/src/test/java/org/zanata/feature/misc/ContactAdminTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/misc/ContactAdminTest.java
@@ -68,18 +68,9 @@ public class ContactAdminTest extends ZanataTestCase {
         String content = HasEmailRule.getEmailContent(wiserMessage);
 
         assertThat(content)
-                .contains("Zanata user ")
-                .contains("translator")
-                .contains(" with id ")
-                .matches(loosely(" has sent the following message:"))
-                .as("The email header is correct");
-        assertThat(content)
-                .contains("I love Zanata")
-                .as("The message content is correct");
-        assertThat(content)
-                .contains("You can reply to translator at " +
-                        "translator@example.com")
-                .as("The email instructions are correct");
+                .contains("You are receiving this mail because:")
+                .contains("You are an administrator")
+                .contains("I love Zanata");
 
         // contains instance url (without last slash)
         String instanceUrl = PropertiesHolder.getProperty(


### PR DESCRIPTION
There were a few errors regarding project and version creation.
Using the ZanataRestCaller removes these and reduces test runtime
by roughly 10 seconds where a project and version needs to be
created.
Also make the contact admin test less strict.
