### PR TITLE
Fix redirect to login page when using single open id provider authentication

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/LoginAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/LoginAction.java
@@ -157,15 +157,13 @@ public class LoginAction implements Serializable {
     }
 
     /**
-     * This method is executed when accessing the login page. Depending on
-     * current session state, it might indicate to redirect to a different
-     * location. For example, if the user is already logged in, it will indicate
-     * to redirect to the dashboard.
+     * Indicates which location a user should be redirected when accessing the
+     * login page.
      *
      * @return A string indicating where the user should be redirected when
      *         trying to access the login page.
      */
-    public String onLoginPageAccessed() {
+    public String getLoginPageRedirect() {
         if (identity.isLoggedIn()) {
             return "dashboard";
         }

--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -108,8 +108,8 @@
       value="no-cache, no-store, max-age=0, must-revalidate" />
     <param name="continue" value="#{userRedirect.encodedUrl}" />
 
-    <action execute="#{loginAction.onLoginPageAccessed()}" />
-    <navigation from-action="#{loginAction.onLoginPageAccessed()}">
+    <action execute="#{loginAction.getLoginPageRedirect()}" />
+    <navigation from-action="#{loginAction.getLoginPageRedirect()}">
       <rule if-outcome="dashboard">
         <redirect view-id="/dashboard/home.xhtml" />
       </rule>

--- a/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/banner.xhtml
@@ -160,7 +160,7 @@
 
       <h:form rendered="#{applicationConfigurationAction.singleOpenId}">
         <h:commandLink id="openid_single_signin_link"
-          action="#{loginAction.goToLoginPage()}"
+          action="#{loginAction.getLoginPageRedirect()}"
           propagation="none" styleClass="l--push-left-half button--primary">
           #{messages['jsf.Login']}
         </h:commandLink>


### PR DESCRIPTION
This pull request ensures that when accessing a link directly (e.g. going to the editor from a bookmarked link) under single open id provider authentication, Zanata will not go to the usual login page, but instead will go directly to the provider.

Things to test:
- [x] Login button works for internal and open id configurations (both single and multiple provider)
- [x] Accessing an unauthenticated protected url on internal auth should redirect to the login page.
- [x] Accessing an unauthenticated protected url on single provider open id auth should redirect to the provider's page.
