### PR TITLE
Fix focus on selected transunit in editor and long string in tu details

### DIFF
--- a/zanata-war/src/main/java/org/zanata/webtrans/client/ui/TransUnitDetailsPanel.ui.xml
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/ui/TransUnitDetailsPanel.ui.xml
@@ -9,7 +9,6 @@
     .headerLabel {
       text-overflow: ellipsis;
       overflow: hidden;
-      white-space: nowrap;
     }
   </ui:style>
 

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/SourceContentsView.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/SourceContentsView.java
@@ -42,6 +42,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Anchor;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.InlineLabel;
@@ -62,7 +63,7 @@ public class SourceContentsView extends Composite implements
     Styles style;
 
     @UiField(provided = true)
-    InlineLabel bookmarkIcon;
+    Anchor bookmarkIcon;
 
     @UiField(provided = true)
     ReferencePanel referencePanel;
@@ -98,8 +99,8 @@ public class SourceContentsView extends Composite implements
         rootPanel = binder.createAndBindUi(this);
     }
 
-    private InlineLabel createBookmarkIcon() {
-        InlineLabel bookmarkIcon = new InlineLabel();
+    private Anchor createBookmarkIcon() {
+        Anchor bookmarkIcon = new Anchor();
         bookmarkIcon.addClickHandler(new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/SourceContentsView.ui.xml
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/SourceContentsView.ui.xml
@@ -20,9 +20,9 @@
       <fui:ReferencePanel ui:field="referencePanel" />
     </li>
     <li>
-      <g:InlineLabel ui:field="bookmarkIcon"
+      <g:Anchor ui:field="bookmarkIcon"
         styleName="{style.bookmark} i i--star l--float-left l--push-top-quarter" />
-      <fui:TransUnitDetailsPanel ui:field="transUnitDetailsPanel"/>
+      <fui:TransUnitDetailsPanel ui:field="transUnitDetailsPanel" styleName="l--push-left-half"/>
     </li>
   </g:HTMLPanel>
 </ui:UiBinder>

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransUnitsTableView.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/TransUnitsTableView.java
@@ -2,10 +2,12 @@ package org.zanata.webtrans.client.view;
 
 import java.util.List;
 
+import com.google.gwt.user.client.Element;
 import org.zanata.webtrans.client.resources.WebTransMessages;
 import org.zanata.webtrans.client.ui.FilterViewConfirmationDisplay;
 import org.zanata.webtrans.client.ui.LoadingPanel;
 
+import com.allen_sauer.gwt.log.client.Log;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -175,19 +177,33 @@ public class TransUnitsTableView extends Composite implements
 
     @Override
     public void ensureVisible(TargetContentsDisplay currentDisplay) {
-        int rootBottom =
-                root.getAbsoluteTop() + root.getElement().getClientHeight();
         Widget transUnitRow = currentDisplay.asWidget();
-        int rowBottom =
-                transUnitRow.getAbsoluteTop()
-                        + transUnitRow.getElement().getClientHeight();
-        if (rowBottom > rootBottom) {
-            root.ensureVisible(transUnitRow);
-        }
-        if (transUnitRow.getAbsoluteTop() < root.getAbsoluteTop()) {
-            root.ensureVisible(transUnitRow);
-        }
+        scrollToElement(root.getElement(), transUnitRow.getElement());
     }
+
+    private native void scrollToElement(Element scroll, Element item) /*-{
+      if (!item || !scroll)  {
+        return;
+      }
+      //need time out due to dom loading
+      setTimeout(function () {
+        var realOffset = 0;
+        var loopItem = item;
+        while (loopItem && (loopItem != scroll)) {
+          realOffset += loopItem.offsetTop;
+          loopItem = loopItem.offsetParent;
+        }
+
+        // handle scrolling when user clicks
+        if((realOffset + item.offsetHeight) > (scroll.scrollTop + scroll.offsetHeight)) {
+          //scroll if text area is partial visible on bottom
+          scroll.scrollTop = realOffset - scroll.offsetHeight / 2;
+        } else if(realOffset < scroll.scrollTop) {
+          //scroll if text area is partial visible on top
+          scroll.scrollTop = realOffset;
+        }
+      }, 100);
+    }-*/;
 
     @Override
     public void setRowSelectionListener(Listener listener) {

--- a/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
+++ b/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
@@ -50,7 +50,7 @@
   <!-- you can leave the body empty if you want  -->
   <!-- to create a completely dynamic UI.        -->
   <!--                                           -->
-  <body class="new-zanata-body">
+  <h:body styleClass="new-zanata-body">
   <script type="text/javascript">
     var zanataSessionId = '#{request.session.id}';
   </script>
@@ -67,7 +67,7 @@
 
   <ui:include src="../WEB-INF/template/scripts.xhtml"/>
 
-  </body>
+  </h:body>
 
   </html>
 </f:view>


### PR DESCRIPTION
- Fix selected transunit in editor not focus properly when loading url
- long string in tu details overflow to right column
