### PR TITLE
Clear document-locale translations stats after a document has been pushed

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/TranslationStateCache.java
+++ b/zanata-war/src/main/java/org/zanata/service/TranslationStateCache.java
@@ -76,6 +76,13 @@ public interface TranslationStateCache {
     WordStatistic getDocumentStatistics(Long documentId,
             LocaleId localeId);
 
+    /*
+     * Clears the stats for a document in all present locales.
+     *
+     * @param documentId
+     */
+    void clearDocumentStatistics(Long documentId);
+
     /**
      * Clears the stats for a document and locale.
      *

--- a/zanata-war/src/main/java/org/zanata/service/impl/DocumentServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/DocumentServiceImpl.java
@@ -45,6 +45,7 @@ import org.zanata.service.CopyTransService;
 import org.zanata.service.DocumentService;
 import org.zanata.service.LocaleService;
 import org.zanata.service.LockManagerService;
+import org.zanata.service.TranslationStateCache;
 import org.zanata.service.VersionStateCache;
 
 /**
@@ -77,6 +78,9 @@ public class DocumentServiceImpl implements DocumentService {
 
     @In
     private VersionStateCache versionStateCacheImpl;
+
+    @In
+    private TranslationStateCache translationStateCacheImpl;
 
     @In
     private ResourceUtils resourceUtils;
@@ -201,5 +205,6 @@ public class DocumentServiceImpl implements DocumentService {
     private void clearStatsCacheForUpdatedDocument(HDocument document) {
         versionStateCacheImpl.clearVersionStatsCache(document.getProjectIteration()
                 .getId());
+        translationStateCacheImpl.clearDocumentStatistics(document.getId());
     }
 }

--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationStateCacheImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationStateCacheImpl.java
@@ -43,10 +43,12 @@ import org.zanata.cache.CacheWrapper;
 import org.zanata.cache.EhcacheWrapper;
 import org.zanata.common.LocaleId;
 import org.zanata.dao.DocumentDAO;
+import org.zanata.dao.LocaleDAO;
 import org.zanata.dao.TextFlowDAO;
 import org.zanata.dao.TextFlowTargetDAO;
 import org.zanata.events.TextFlowTargetStateEvent;
 import org.zanata.model.HDocument;
+import org.zanata.model.HLocale;
 import org.zanata.model.HTextFlow;
 import org.zanata.model.HTextFlowTarget;
 import org.zanata.service.TranslationStateCache;
@@ -140,12 +142,21 @@ public class TranslationStateCacheImpl implements TranslationStateCache {
     }
 
     @Override
+    public void clearDocumentStatistics(Long documentId) {
+        LocaleDAO localeDAO = serviceLocator.getInstance(LocaleDAO.class);
+        for (HLocale locale : localeDAO.findAll()) {
+            DocumentLocaleKey key =
+                    new DocumentLocaleKey(documentId, locale.getLocaleId());
+            documentStatisticCache.remove(key);
+        }
+    }
+
+    @Override
     public void clearDocumentStatistics(Long documentId, LocaleId localeId) {
         documentStatisticCache.remove(new DocumentLocaleKey(documentId,
                 localeId));
     }
 
-    @Override
     public DocumentStatus getDocumentStatus(Long documentId, LocaleId localeId) {
         return docStatusCache.getWithLoader(new DocumentLocaleKey(
                 documentId, localeId));

--- a/zanata-war/src/test/java/org/zanata/rest/service/ResourceServiceRestTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/ResourceServiceRestTest.java
@@ -23,6 +23,7 @@ import org.zanata.security.ZanataIdentity;
 import org.zanata.service.impl.CopyTransServiceImpl;
 import org.zanata.service.impl.DocumentServiceImpl;
 import org.zanata.service.impl.LocaleServiceImpl;
+import org.zanata.service.impl.TranslationStateCacheImpl;
 import org.zanata.service.impl.VersionStateCacheImpl;
 
 public class ResourceServiceRestTest extends ResourceTranslationServiceRestTest {
@@ -42,7 +43,8 @@ public class ResourceServiceRestTest extends ResourceTranslationServiceRestTest 
                 .use("identity", mockIdentity).useImpl(LocaleServiceImpl.class)
                 .useImpl(CopyTransServiceImpl.class)
                 .useImpl(DocumentServiceImpl.class)
-                .useImpl(VersionStateCacheImpl.class);
+                .useImpl(VersionStateCacheImpl.class)
+                .useImpl(TranslationStateCacheImpl.class);
 
         SourceDocResourceService sourceDocResourceService =
                 seamAutowire.autowire(SourceDocResourceService.class);

--- a/zanata-war/src/test/java/org/zanata/rest/service/TranslationResourceRestTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/TranslationResourceRestTest.java
@@ -149,7 +149,8 @@ public class TranslationResourceRestTest extends ZanataRestTest {
                 .useImpl(ResourceUtils.class)
                 .useImpl(SecurityServiceImpl.class)
                 .useImpl(ValidationServiceImpl.class)
-                .useImpl(VersionStateCacheImpl.class);
+                .useImpl(VersionStateCacheImpl.class)
+                .useImpl(TranslationStateCacheImpl.class);
 
         TranslatedDocResourceService translatedDocResourceService =
                 seamAutowire.autowire(TranslatedDocResourceService.class);

--- a/zanata-war/src/test/java/org/zanata/rest/service/TranslationServiceRestTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/TranslationServiceRestTest.java
@@ -61,7 +61,8 @@ public class TranslationServiceRestTest extends
                 .useImpl(DocumentServiceImpl.class)
                 .useImpl(TranslationServiceImpl.class)
                 .useImpl(ValidationServiceImpl.class)
-                .useImpl(VersionStateCacheImpl.class);
+                .useImpl(VersionStateCacheImpl.class)
+                .useImpl(TranslationStateCacheImpl.class);
 
         SourceDocResourceService sourceDocResourceService =
                 seamAutowire.autowire(SourceDocResourceService.class);


### PR DESCRIPTION
This allows Zanata to re-calculate those stats if the document has changed its size or translation state.

Testing notes: Just change the size of a source document that is partially translated in Zanata and re-push it. The stats should be updated and accurate after the push.
