### PR TITLE
rhbz1154555 - Fix process manager screen issue.

### DIFF
--- a/zanata-war/src/main/webapp/admin/processmanager.xhtml
+++ b/zanata-war/src/main/webapp/admin/processmanager.xhtml
@@ -38,7 +38,7 @@
         <rich:column>
           <f:facet
             name="header">#{msgs['jsf.processmanager.Type']}</f:facet>
-          #{handle.getTaskName()}
+          #{handle.toString()}
         </rich:column>
         <rich:column>
           <f:facet name="header">#{msgs['jsf.Status']}</f:facet>


### PR DESCRIPTION
The problem arises when there is a process running and the process manager screen is loaded. With the old async task implementation, the process manager expected a task name. This field is no longer present in the async task handles. For the time being, the process will present a string representation of the task handle. This should be changed in future revisions.
