### PR TITLE
Fix random test failures

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -93,16 +93,11 @@ public class CorePage extends AbstractPage {
 
         List<String> newError =
                 WebElementUtil.elementsToText(getDriver(),
-                        By.xpath("//div[@class='message--danger']"));
-
-        List<String> topError =
-                WebElementUtil.elementsToText(getDriver(),
                         By.className("message--danger"));
 
         List<String> allErrors = Lists.newArrayList();
         allErrors.addAll(oldError);
         allErrors.addAll(newError);
-        allErrors.addAll(topError);
 
         return allErrors;
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.page.projects.projectsettings;
 
+import com.google.common.base.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -45,13 +46,15 @@ public class ProjectTranslationTab extends ProjectBasePage {
 
     public boolean isValidationLevel(String optionName, String level) {
         log.info("Query is {} validation level {}", optionName, level);
-        String optionElementID = validationNames
+        final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-
-        return getDriver()
-                .findElement(By.id(optionElementID))
-                .getAttribute("checked")
-                .equals("true");
+        WebElement option = waitForAMoment().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver input) {
+                return getDriver().findElement(By.id(optionElementID));
+            }
+        });
+        return option.getAttribute("checked").equals("true");
     }
 
     public ProjectTranslationTab setValidationLevel(String optionName,

--- a/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
@@ -120,6 +120,12 @@ public class CreateVersionPage extends BasePage {
         return new VersionLanguagesPage(getDriver());
     }
 
+    public CreateVersionPage saveExpectingError() {
+        log.info("Click Save");
+        saveButton.click();
+        return new CreateVersionPage(getDriver());
+    }
+
     public CreateVersionPage waitForNumErrors(final int numberOfErrors) {
         log.info("Wait for number of error to be {}", numberOfErrors);
         waitForAMoment().until(new Predicate<WebDriver>() {

--- a/functional-test/src/test/java/org/zanata/feature/account/ChangePasswordTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/ChangePasswordTest.java
@@ -64,8 +64,9 @@ public class ChangePasswordTest extends ZanataTestCase {
                 .typeNewPassword("newpassword")
                 .clickUpdatePasswordButton();
         dashboard.expectNotification(DashboardAccountTab.PASSWORD_UPDATE_SUCCESS);
+        dashboard.logout();
 
-        assertThat(dashboard.logout().goToHomePage().hasLoggedIn()).isFalse()
+        assertThat(new BasicWorkFlow().goToHome().hasLoggedIn()).isFalse()
                 .as("User is logged out");
 
         DashboardBasePage dashboardPage = new LoginWorkFlow()


### PR DESCRIPTION
Remove accidental duplication of error detection.
Place some webelement access in waits.
Sort of deal with an occasional break in WildFly server logout.
