### PR TITLE
Replace page getDriver.findElement behaviour with search and wait

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -88,12 +88,7 @@ public class AbstractPage {
      */
     public void waitForPage(List<By> elementBys) {
         for (final By by : elementBys) {
-            waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                @Override
-                public WebElement apply(WebDriver driver) {
-                    return getDriver().findElement(by);
-                }
-            });
+            waitForElementExists(by);
         }
     }
 
@@ -199,11 +194,77 @@ public class AbstractPage {
      * @return target WebElement
      */
     public WebElement waitForWebElement(final By elementBy) {
+        waitForPageSilence();
+        return waitForAMoment().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver input) {
+                WebElement targetElement = waitForElementExists(elementBy);
+                if (!elementIsReady(targetElement)) {
+                    throw new NoSuchElementException("Waiting for element");
+                }
+                return targetElement;
+            }
+        });
+    }
+
+    /**
+     * Wait for a child element to be visible, and return it
+     * @param parentElement parent element of target
+     * @param elementBy WebDriver By locator
+     * @return target WebElement
+     */
+    public WebElement waitForWebElement(final WebElement parentElement,
+                                        final By elementBy) {
+        waitForPageSilence();
+        return waitForAMoment().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver input) {
+                WebElement targetElement = waitForElementExists(parentElement,
+                        elementBy);
+                if (!elementIsReady(targetElement)) {
+                    throw new NoSuchElementException("Waiting for element");
+                }
+                return targetElement;
+            }
+        });
+    }
+
+    /**
+     * Wait for an element to exist on the page, and return it.
+     * Generally used for situations where checking on the state of an element,
+     * e.g isVisible, rather than clicking on it or getting its text.
+     * @param elementBy WebDriver By locator
+     * @return target WebElement
+     */
+    public WebElement waitForElementExists(final By elementBy) {
+        waitForPageSilence();
         return waitForAMoment().until(new Function<WebDriver, WebElement>() {
             @Override
             public WebElement apply(WebDriver input) {
                 return getDriver().findElement(elementBy);
             }
         });
+    }
+
+    /**
+     * Wait for a child element to exist on the page, and return it.
+     * Generally used for situations where checking on the state of an element,
+     * e.g isVisible, rather than clicking on it or getting its text.
+     * @param elementBy WebDriver By locator
+     * @return target WebElement
+     */
+    public WebElement waitForElementExists(final WebElement parentElement,
+                                           final By elementBy) {
+        waitForPageSilence();
+        return waitForAMoment().until(new Function<WebDriver, WebElement>() {
+            @Override
+            public WebElement apply(WebDriver input) {
+                return parentElement.findElement(elementBy);
+            }
+        });
+    }
+
+    private boolean elementIsReady(WebElement targetElement) {
+        return targetElement.isDisplayed() && targetElement.isEnabled();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -328,7 +328,7 @@ public class BasePage extends CorePage {
     }
 
     public void clickElement(By findby) {
-        scrollIntoView(getDriver().findElement(findby));
-        getDriver().findElement(findby).click();
+        scrollIntoView(waitForWebElement(findby));
+        waitForWebElement(findby).click();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -49,8 +49,7 @@ import com.google.common.collect.Lists;
 @Slf4j
 public class CorePage extends AbstractPage {
 
-    @FindBy(id = "home")
-    private WebElement homeLink;
+    private By homeLink = By.id("home");
 
     public CorePage(WebDriver driver) {
         super(driver);
@@ -63,7 +62,7 @@ public class CorePage extends AbstractPage {
     public HomePage goToHomePage() {
         log.info("Click Zanata home icon");
         scrollToTop();
-        homeLink.click();
+        waitForWebElement(homeLink).click();
         return new HomePage(getDriver());
     }
 
@@ -139,8 +138,7 @@ public class CorePage extends AbstractPage {
 
     public String getNotificationMessage() {
         log.info("Query notification message");
-        List<WebElement> messages =
-                getDriver().findElement(By.id("messages"))
+        List<WebElement> messages = waitForElementExists(By.id("messages"))
                         .findElements(By.tagName("li"));
         return messages.size() > 0 ? messages.get(0).getText() : "";
     }

--- a/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
@@ -21,9 +21,8 @@
 package org.zanata.page.account;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.utility.HomePage;
 
@@ -33,20 +32,12 @@ import org.zanata.page.utility.HomePage;
  */
 @Slf4j
 public class EditProfilePage extends BasePage {
-    @FindBy(id = "profile-form:nameField:name")
-    private WebElement nameField;
 
-    @FindBy(id = "profile-form:usernameField:username")
-    private WebElement usernameField;
-
-    @FindBy(id = "profile-form:emailField:email")
-    private WebElement emailField;
-
-    @FindBy(id = "profile-form:user-create-new")
-    private WebElement saveButton;
-
-    @FindBy(id = "profile-form:user-create-cancel")
-    private WebElement cancelButton;
+    private By nameField = By.id("profile-form:nameField:name");
+    private By usernameField = By.id("profile-form:usernameField:username");
+    private By emailField = By.id("profile-form:emailField:email");
+    private By saveButton =  By.id("profile-form:user-create-new");
+    private By cancelButton = By.id("profile-form:user-create-cancel");
 
     public EditProfilePage(WebDriver driver) {
         super(driver);
@@ -54,35 +45,36 @@ public class EditProfilePage extends BasePage {
 
     public EditProfilePage enterName(String name) {
         log.info("Enter name {}", name);
-        nameField.clear();
-        nameField.sendKeys(name);
+        waitForWebElement(nameField).clear();
+        waitForWebElement(nameField).sendKeys(name);
         defocus();
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        usernameField.sendKeys(userName);
+        waitForWebElement(usernameField).clear();
+        waitForWebElement(usernameField).sendKeys(userName);
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterEmail(String email) {
         log.info("Enter email {}", email);
-        emailField.clear();
-        emailField.sendKeys(email);
+        waitForWebElement(emailField).clear();
+        waitForWebElement(emailField).sendKeys(email);
         defocus();
         return new EditProfilePage(getDriver());
     }
 
     public HomePage clickSave() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new HomePage(getDriver());
     }
 
     public EditProfilePage clickSaveAndExpectErrors() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new EditProfilePage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
@@ -20,13 +20,10 @@
  */
 package org.zanata.page.account;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.CorePage;
 import org.zanata.page.utility.HomePage;
 
@@ -54,75 +51,69 @@ public class RegisterPage extends CorePage {
     public static final String USERNAME_LENGTH_ERROR =
             "size must be between 3 and 20";
 
-    @FindBy(id = "loginForm:name")
-    private WebElement nameField;
-
-    @FindBy(id = "loginForm:emailField:email")
-    private WebElement emailField;
-
-    @FindBy(id = "loginForm:usernameField:username")
-    private WebElement usernameField;
-
-    @FindBy(id = "loginForm:passwordField:password")
-    private WebElement passwordField;
-
-    @FindBy(xpath = "//input[@value='Sign Up']")
-    private WebElement registerButton;
+    private By nameField = By.id("loginForm:name");
+    private By emailField = By.id("loginForm:emailField:email");
+    private By usernameField = By.id("loginForm:usernameField:username");
+    private By passwordField = By.id("loginForm:passwordField:password");
+    private By signUpButton = By.xpath("//input[@value='Sign Up']");
+    private By showHideToggleButton = By.className("js-form-password-toggle");
+    private By loginLink = By.linkText("Log In");
+    private By titleLabel = By.className("heading--sub");
 
     public RegisterPage(WebDriver driver) {
         super(driver);
         List<By> elementBys = ImmutableList.<By> builder()
-                .add(By.id("loginForm:name"))
-                .add(By.id("loginForm:emailField:email"))
-                .add(By.id("loginForm:usernameField:username"))
-                .add(By.id("loginForm:passwordField:password"))
-                .add(By.xpath("//input[@value='Sign Up']")).build();
+                .add(nameField)
+                .add(emailField)
+                .add(usernameField)
+                .add(passwordField)
+                .add(signUpButton).build();
         waitForPage(elementBys);
     }
 
     public RegisterPage enterName(String name) {
         log.info("Enter name {}", name);
-        nameField.sendKeys(name);
+        waitForWebElement(nameField).sendKeys(name);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        usernameField.sendKeys(userName);
+        waitForWebElement(usernameField).sendKeys(userName);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        emailField.sendKeys(email);
+        waitForWebElement(emailField).sendKeys(email);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        passwordField.sendKeys(password);
+        waitForWebElement(passwordField).sendKeys(password);
         return new RegisterPage(getDriver());
     }
 
     // TODO: Add a "signup success" page
     public HomePage register() {
         log.info("Click Sign Up");
-        registerButton.click();
+        waitForWebElement(signUpButton).click();
         return new HomePage(getDriver());
     }
 
     public RegisterPage registerFailure() {
         log.info("Click Sign Up");
-        registerButton.click();
+        waitForWebElement(signUpButton).click();
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage clearFields() {
         log.info("Clear fields");
-        nameField.clear();
-        emailField.clear();
-        usernameField.clear();
-        passwordField.clear();
+        waitForWebElement(nameField).clear();
+        waitForWebElement(emailField).clear();
+        waitForWebElement(usernameField).clear();
+        waitForWebElement(passwordField).clear();
         return new RegisterPage(getDriver());
     }
 
@@ -140,29 +131,28 @@ public class RegisterPage extends CorePage {
 
     public String getPageTitle() {
         log.info("Query page title");
-        return getDriver().findElement(By.className("heading--sub"))
-                .getText();
+        return waitForWebElement(titleLabel).getText();
     }
 
     public SignInPage goToSignIn() {
         log.info("Click Log In");
-        getDriver().findElement(By.linkText("Log In")).click();
+        waitForWebElement(loginLink).click();
         return new SignInPage(getDriver());
     }
 
     public RegisterPage clickPasswordShowToggle() {
         log.info("Click Show/Hide");
-        getDriver().findElement(By.className("js-form-password-toggle")).click();
+        waitForWebElement(showHideToggleButton).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPassword() {
         log.info("Query password");
-        return passwordField.getAttribute("value");
+        return waitForWebElement(passwordField).getAttribute("value");
     }
 
     public String getPasswordFieldType() {
         log.info("Query password field type");
-        return passwordField.getAttribute("type");
+        return waitForWebElement(passwordField).getAttribute("type");
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
@@ -21,9 +21,8 @@
 package org.zanata.page.account;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 /**
@@ -33,14 +32,9 @@ import org.zanata.page.BasePage;
 @Slf4j
 public class ResetPasswordPage extends BasePage {
 
-    @FindBy(id = "passwordResetRequestForm:usernameField:username")
-    private WebElement usernameField;
-
-    @FindBy(id = "passwordResetRequestForm:emailField:email")
-    private WebElement emailField;
-
-    @FindBy(id = "passwordResetRequestForm:submitRequest")
-    private WebElement submitButton;
+    private By usernameField = By.id("passwordResetRequestForm:usernameField:username");
+    private By emailField = By.id("passwordResetRequestForm:emailField:email");
+    private By submitButton = By.id("passwordResetRequestForm:submitRequest");
 
     public ResetPasswordPage(WebDriver driver) {
         super(driver);
@@ -48,32 +42,32 @@ public class ResetPasswordPage extends BasePage {
 
     public ResetPasswordPage enterUserName(String username) {
         log.info("Enter username {}", username);
-        usernameField.sendKeys(username);
+        waitForWebElement(usernameField).sendKeys(username);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        emailField.sendKeys(email);
+        waitForWebElement(emailField).sendKeys(email);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage clearFields() {
         log.info("Clear fields");
-        emailField.clear();
-        usernameField.clear();
+        waitForWebElement(usernameField).clear();
+        waitForWebElement(emailField).clear();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetPassword() {
         log.info("Click Submit");
-        submitButton.click();
+        waitForWebElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetFailure() {
         log.info("Click Submit");
-        submitButton.click();
+        waitForWebElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
@@ -24,8 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.CorePage;
 import org.zanata.page.dashboard.DashboardBasePage;
 import org.zanata.page.googleaccount.GoogleAccountPage;
@@ -35,17 +33,13 @@ public class SignInPage extends CorePage {
 
     public static final String LOGIN_FAILED_ERROR = "Login failed";
 
-    @FindBy(id = "loginForm:username")
-    private WebElement usernameField;
-
-    @FindBy(id = "loginForm:password")
-    private WebElement passwordField;
-
-    @FindBy(id = "loginForm:loginButton")
-    private WebElement signInButton;
-
-    @FindBy(linkText = "Forgot your password?")
-    private WebElement forgotPasswordLink;
+    private By usernameField = By.id("loginForm:username");
+    private By passwordField = By.id("loginForm:password");
+    private By signInButton = By.id("loginForm:loginButton");
+    private By forgotPasswordLink = By.linkText("Forgot your password?");
+    private By googleButton = By.linkText("Google");
+    private By signUpLink = By.linkText("Sign Up");
+    private By titleLabel = By.className("heading--sub");
 
     public SignInPage(final WebDriver driver) {
         super(driver);
@@ -53,49 +47,48 @@ public class SignInPage extends CorePage {
 
     public SignInPage enterUsername(String username) {
         log.info("Enter username {}", username);
-        usernameField.sendKeys(username);
+        waitForWebElement(usernameField).sendKeys(username);
         return new SignInPage(getDriver());
     }
 
     public SignInPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        passwordField.sendKeys(password);
+        waitForWebElement(passwordField).sendKeys(password);
         return new SignInPage(getDriver());
     }
 
     public DashboardBasePage clickSignIn() {
         log.info("Click Sign In");
-        signInButton.click();
+        waitForWebElement(signInButton).click();
         return new DashboardBasePage(getDriver());
     }
 
     public SignInPage clickSignInExpectError() {
         log.info("Click Sign In");
-        signInButton.click();
+        waitForWebElement(signInButton).click();
         return new SignInPage(getDriver());
     }
 
     public GoogleAccountPage selectGoogleOpenID() {
         log.info("Click 'Google'");
-        getDriver().findElement(By.linkText("Google")).click();
+        waitForWebElement(googleButton).click();
         return new GoogleAccountPage(getDriver());
     }
 
     public ResetPasswordPage goToResetPassword() {
         log.info("Click Forgot Password");
-        forgotPasswordLink.click();
+        waitForWebElement(forgotPasswordLink).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public RegisterPage goToRegister() {
         log.info("Click Sign Up");
-        getDriver().findElement(By.linkText("Sign Up")).click();
+        waitForWebElement(signUpLink).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPageTitle() {
         log.info("Query page title");
-        return getDriver().findElement(By.className("heading--sub"))
-                .getText();
+        return waitForWebElement(titleLabel).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 import java.util.HashMap;
@@ -39,15 +38,11 @@ public class AddLanguagePage extends BasePage {
     private static final int NAME_COLUMN = 0;
     private static final int VALUE_COLUMN = 1;
 
-    @FindBy(xpath = "//input[@type='text' and contains(@id, 'localeName')]")
-    private WebElement languageInput;
-
-    @FindBy(xpath = "//input[@value='Save']")
-    private WebElement saveButton;
-
-    @FindBy(xpath =
-            "//input[@type='checkbox' and contains(@name, 'enabledByDefault')]")
-    private WebElement enabledByDefaultInput;
+    private By languageInputField = By.xpath(
+            "//input[@type='text' and contains(@id, 'localeName')]");
+    private By saveButton = By.xpath("//input[@value='Save']");
+    private By enabledByDefaultCheckbox = By.xpath(
+            "//input[@type='checkbox' and contains(@name, 'enabledByDefault')]");
 
     public AddLanguagePage(final WebDriver driver) {
         super(driver);
@@ -55,26 +50,26 @@ public class AddLanguagePage extends BasePage {
 
     public AddLanguagePage inputLanguage(String language) {
         log.info("Enter language {}", language);
-        languageInput.sendKeys(language);
+        waitForWebElement(languageInputField).sendKeys(language);
         defocus();
         waitForPageSilence();
-        return this;
+        return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage enableLanguageByDefault() {
         log.info("Click Enable by default");
-        if (!enabledByDefaultInput.isSelected()) {
-            enabledByDefaultInput.click();
+        if (!waitForWebElement(enabledByDefaultCheckbox).isSelected()) {
+            waitForWebElement(enabledByDefaultCheckbox).click();
         }
-        return this;
+        return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage disableLanguageByDefault() {
         log.info("Click Disable by default");
-        if (enabledByDefaultInput.isSelected()) {
-            enabledByDefaultInput.click();
+        if (waitForWebElement(enabledByDefaultCheckbox).isSelected()) {
+            waitForWebElement(enabledByDefaultCheckbox).click();
         }
-        return this;
+        return new AddLanguagePage(getDriver());
     }
 
     public Map<String, String> getLanguageDetails() {
@@ -102,7 +97,7 @@ public class AddLanguagePage extends BasePage {
 
     public ManageLanguagePage saveLanguage() {
         log.info("Click Save");
-        clickAndCheckErrors(saveButton);
+        clickAndCheckErrors(waitForWebElement(saveButton));
         return new ManageLanguagePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
@@ -21,9 +21,8 @@
 package org.zanata.page.administration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.utility.HomePage;
 
@@ -34,14 +33,9 @@ import org.zanata.page.utility.HomePage;
 @Slf4j
 public class EditHomeCodePage extends BasePage {
 
-    @FindBy(id = "homeContentForm:homeContent")
-    private WebElement textEdit;
-
-    @FindBy(id = "homeContentForm:update")
-    private WebElement updateButton;
-
-    @FindBy(id = "homeContentForm:cancel")
-    private WebElement cancelButton;
+    private By textEdit = By.id("homeContentForm:homeContent");
+    private By updateButton = By.id("homeContentForm:update");
+    private By cancelButton = By.id("homeContentForm:cancel");
 
     public EditHomeCodePage(final WebDriver driver) {
         super(driver);
@@ -49,19 +43,19 @@ public class EditHomeCodePage extends BasePage {
 
     public EditHomeCodePage enterText(String text) {
         log.info("Enter homepage text\n{}", text);
-        textEdit.sendKeys(text);
+        waitForWebElement(textEdit).sendKeys(text);
         return new EditHomeCodePage(getDriver());
     }
 
     public HomePage update() {
         log.info("Click Update");
-        updateButton.click();
+        waitForWebElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        cancelButton.click();
+        waitForWebElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
@@ -36,11 +36,8 @@ import org.zanata.page.utility.HomePage;
 @Slf4j
 public class EditHomeContentPage extends BasePage {
 
-    @FindBy(id = "homeContentForm:update")
-    private WebElement updateButton;
-
-    @FindBy(id = "homeContentForm:cancel")
-    private WebElement cancelButton;
+    private By updateButton = By.id("homeContentForm:update");
+    private By cancelButton = By.id("homeContentForm:cancel");
 
     public EditHomeContentPage(final WebDriver driver) {
         super(driver);
@@ -49,23 +46,10 @@ public class EditHomeContentPage extends BasePage {
     public EditHomeContentPage enterText(String text) {
         log.info("Enter homepage code\n{}", text);
         // Switch to the CKEditor frame
-        getDriver().switchTo().frame(waitForAMoment().until(new Function<WebDriver, WebElement>() {
-            @Override
-            public WebElement apply(WebDriver driver) {
-                return getDriver().findElement(
-                        By.id("cke_contents_homeContentForm:homeContent:inp"))
-                        .findElement(By.tagName("iframe"));
-            }
-        }));
-
-        WebElement textEdit = waitForAMoment().until(new Function<WebDriver, WebElement>() {
-            @Override
-            public WebElement apply(WebDriver driver) {
-                System.out.println(getDriver().findElements(By.tagName("body")).size());
-                return getDriver().findElement(By.tagName("body"));
-            }
-        });
-        textEdit.sendKeys(text);
+        getDriver().switchTo().frame(waitForWebElement(By
+                .id("cke_contents_homeContentForm:homeContent:inp"))
+                .findElement(By.tagName("iframe")));
+        waitForWebElement(By.tagName("body")).sendKeys(text);
         // Switch back!
         getDriver().switchTo().defaultContent();
         return new EditHomeContentPage(getDriver());
@@ -73,13 +57,13 @@ public class EditHomeContentPage extends BasePage {
 
     public HomePage update() {
         log.info("Click Update");
-        updateButton.click();
+        waitForWebElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        cancelButton.click();
+        waitForWebElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
@@ -3,7 +3,6 @@ package org.zanata.page.administration;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
 import org.zanata.page.BasePage;
 
@@ -13,44 +12,44 @@ import org.zanata.page.BasePage;
 @Slf4j
 public class EditRoleAssignmentPage extends BasePage {
 
+    private By policySelect = By.id("projectForm:policyNameField:policyName");
+    private By patternField = By.id("projectForm:identityPatternField:identityPattern");
+    private By roleSelect = By.id("projectForm:roleField:roles");
+    private By saveButton = By.id("projectForm:save");
+    private By cancelButton = By.id("projectForm:cancel");
+
     public EditRoleAssignmentPage(WebDriver driver) {
         super(driver);
     }
 
     public EditRoleAssignmentPage selectPolicy(String policy) {
         log.info("Select policy {}", policy);
-        Select policySelect = new Select(getDriver().findElement(
-                By.id("projectForm:policyNameField:policyName")));
-        policySelect.selectByValue(policy);
+        new Select(waitForWebElement(policySelect)).selectByValue(policy);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage enterIdentityPattern(String pattern) {
         log.info("Enter identity pattern {}", pattern);
-        WebElement patternField = getDriver().findElement(
-                By.id("projectForm:identityPatternField:identityPattern"));
-        patternField.clear();
-        patternField.sendKeys(pattern);
+        waitForWebElement(patternField).clear();
+        waitForWebElement(patternField).sendKeys(pattern);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage selectRole(String role) {
         log.info("Select role {}", role);
-        Select roleSelect = new Select(getDriver().findElement(
-                By.id("projectForm:roleField:roles")));
-        roleSelect.selectByValue(role);
+        new Select(waitForWebElement(roleSelect)).selectByValue(role);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage saveRoleAssignment() {
         log.info("Click Save");
-        getDriver().findElement(By.id("projectForm:save")).click();
+        waitForWebElement(saveButton).click();
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public RoleAssignmentsPage cancelEditRoleAssignment() {
         log.info("Click Cancel");
-        getDriver().findElement(By.id("projectForm:cancel")).click();
+        waitForWebElement(cancelButton).click();
         return new RoleAssignmentsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.TableRow;
 import org.zanata.util.WebElementUtil;
@@ -41,17 +40,15 @@ public class ManageLanguagePage extends BasePage {
     public static final int LOCALE_COLUMN = 0;
     public static final int ENABLED_COLUMN = 3;
 
-    @FindBy(id = "languageForm:threads")
-    private WebElement languageTable;
-
-    private By languageTableBy = By.id("languageForm:threads");
+    private By languageTable = By.id("languageForm:threads");
+    private By addLanguageButton = By.linkText("Add New Language");
 
     public ManageLanguagePage(WebDriver driver) {
         super(driver);
     }
 
     public AddLanguagePage addNewLanguage() {
-        getDriver().findElement(By.linkText("Add New Language")).click();
+        waitForWebElement(addLanguageButton).click();
         return new AddLanguagePage(getDriver());
     }
 
@@ -115,7 +112,7 @@ public class ManageLanguagePage extends BasePage {
             getDriver().switchTo().alert().accept();
         }
 
-        return this;
+        return new ManageLanguagePage(getDriver());
     }
 
     public boolean languageIsEnabled(String localeId) {
@@ -126,7 +123,7 @@ public class ManageLanguagePage extends BasePage {
 
     public List<String> getLanguageLocales() {
         log.info("Query list of languages");
-        return WebElementUtil.getColumnContents(getDriver(), languageTableBy,
+        return WebElementUtil.getColumnContents(getDriver(), languageTable,
                 LOCALE_COLUMN);
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.Checkbox;
 import org.zanata.util.TableRow;
@@ -22,8 +20,17 @@ import java.util.List;
  */
 @Slf4j
 public class ManageLanguageTeamMemberPage extends BasePage {
-    @FindBy(id = "memberPanel")
-    private WebElement memberPanel;
+
+    private By memberPanel = By.id("memberPanel");
+    private By memberPanelRows = By.id("memberPanel:threads");
+    private By joinLanguageTeamButton = By.linkText("Join Language Team");
+    private By addTeamMemberButton = By.id("addTeamMemberLink");
+    private By addUserPanel = By.id("userAddPanel_container");
+    private By addUserSearchInput = By.id("searchForm:searchField");
+    private By addUserSearchButton = By.id("searchForm:searchBtn");
+    private By personTable = By.id("resultForm:personTable");
+    private By addSelectedButton = By.id("resultForm:addSelectedBtn");
+    private By closeSearchButton = By.id("searchForm:closeBtn");
 
     public static final int USERNAME_COLUMN = 0;
     public static final int SEARCH_RESULT_PERSON_COLUMN = 0;
@@ -35,8 +42,8 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     private String getMembersInfo() {
         log.info("Query members info");
-        WebElement memberInfo = memberPanel.findElement(By.xpath(".//p"));
-        return memberInfo.getText();
+        return waitForWebElement(memberPanel)
+                .findElement(By.xpath(".//p")).getText();
     }
 
     public List<String> getMemberUsernames() {
@@ -45,33 +52,22 @@ public class ManageLanguageTeamMemberPage extends BasePage {
             log.info("no members yet for this language");
             return Collections.emptyList();
         }
-        By by = By.id("memberPanel:threads");
-        List<String> usernameColumn =
-                WebElementUtil.getColumnContents(getDriver(), by,
-                        USERNAME_COLUMN);
+        List<String> usernameColumn = WebElementUtil.getColumnContents(
+                getDriver(),
+                memberPanelRows,
+                USERNAME_COLUMN);
         log.info("username column: {}", usernameColumn);
         return usernameColumn;
     }
 
     public ManageLanguageTeamMemberPage joinLanguageTeam() {
         log.info("Click Join");
-        // Waiting 10 seconds for an element to be present on the page, checking
-        // for its presence once every 1 second.
-        WebElement joinLanguageTeamLink =
-                waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                    public WebElement apply(WebDriver driver) {
-                        return driver.findElement(By
-                                .linkText("Join Language Team"));
-                    }
-                });
-        joinLanguageTeamLink.click();
+        waitForWebElement(joinLanguageTeamButton).click();
         // we need to wait for this join to finish before returning the page
         waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
             public Boolean apply(WebDriver driver) {
-                List<WebElement> joinLanguageTeam =
-                        driver.findElements(By.linkText("Join Language Team"));
-                return joinLanguageTeam.isEmpty();
+                return driver.findElements(joinLanguageTeamButton).isEmpty();
             }
         });
         return new ManageLanguageTeamMemberPage(getDriver());
@@ -79,74 +75,57 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickAddTeamMember() {
         log.info("Click Add Team Member");
-        WebElement addTeamMemberLink =
-                waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                    public WebElement apply(WebDriver driver) {
-                        return driver.findElement(By.id("addTeamMemberLink"));
-                    }
-                });
-        addTeamMemberLink.click();
+        waitForWebElement(addTeamMemberButton).click();
         return this;
     }
 
     public ManageLanguageTeamMemberPage searchPersonAndAddToTeam(
             final String personName) {
         log.info("Enter username search {}", personName);
-        final WebElement addUserPanel =
-                getDriver().findElement(By.id("userAddPanel_container"));
+        // Wait for the search field under the add user panel
+        waitForWebElement(waitForElementExists(addUserPanel), addUserSearchInput)
+                .sendKeys(personName);
 
-        WebElement searchInput =
-                waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                    public WebElement apply(WebDriver driver) {
-                        return addUserPanel.findElement(By
-                                .id("searchForm:searchField"));
-                    }
-                });
-        searchInput.sendKeys(personName);
-        WebElement searchButton =
-                getDriver().findElement(By.id("searchForm:searchBtn"));
-        searchButton.click();
+        log.info("Click search button");
+        waitForWebElement(addUserSearchButton).click();
 
-        return waitForAMoment().until(
-                new Function<WebDriver, ManageLanguageTeamMemberPage>() {
-                    @Override
-                    public ManageLanguageTeamMemberPage apply(WebDriver driver) {
-                        TableRow firstRow =
-                                tryGetFirstRowInSearchPersonResult(driver,
-                                        personName);
+        TableRow firstRow = tryGetFirstRowInSearchPersonResult(personName);
 
-                        final String personUsername =
-                                firstRow.getCellContents().get(
-                                        SEARCH_RESULT_PERSON_COLUMN);
-                        log.info("username to be added: {}", personUsername);
-                        WebElement isTranslatorCheckBox =
-                                firstRow.getCells().get(ISTRANSLATOR_COLUMN)
-                                        .findElement(By.tagName("input"));
-                        Checkbox.of(isTranslatorCheckBox).check();
-
-                        getDriver().findElement(
-                                By.id("resultForm:addSelectedBtn")).click();
-                        getDriver().findElement(By.id("searchForm:closeBtn"))
-                                .click();
-                        return confirmAdded(personName);
-                    }
-                });
-
+        final String personUsername = firstRow.getCellContents()
+                .get(SEARCH_RESULT_PERSON_COLUMN);
+        log.info("Username to be added: {}", personUsername);
+        log.info("Set checked as translator");
+        Checkbox.of(firstRow.getCells()
+                .get(ISTRANSLATOR_COLUMN)
+                .findElement(By.tagName("input")))
+                .check();
+        log.info("Click Add Selected");
+        waitForWebElement(addSelectedButton).click();
+        log.info("Click Close");
+        waitForWebElement(closeSearchButton).click();
+        return confirmAdded(personName);
     }
 
-    private TableRow tryGetFirstRowInSearchPersonResult(WebDriver driver,
-            String personName) {
-        WebElement table = driver.findElement(By.id("resultForm:personTable"));
-        List<TableRow> tableRows =
-                WebElementUtil.getTableRows(getDriver(), table);
+    private TableRow tryGetFirstRowInSearchPersonResult(final String personName) {
         // we want to wait until search result comes back
-        if (tableRows.isEmpty()
-                || !tableRows.get(0).getCellContents()
+        return waitForAMoment().until(new Function<WebDriver, List<TableRow>>() {
+            @Override
+            public List<TableRow> apply(WebDriver input) {
+                log.debug("waiting for search result refresh...");
+                List<TableRow> tableRows = WebElementUtil
+                        .getTableRows(getDriver(),
+                                waitForWebElement(personTable));
+                if (tableRows.isEmpty()) {
+                    log.debug("waiting for search result refresh...");
+                    throw new NoSuchElementException("");
+                }
+                if (!tableRows.get(0).getCellContents()
                         .get(SEARCH_RESULT_PERSON_COLUMN).contains(personName)) {
-            log.debug("waiting for search result refresh...");
-            throw new NoSuchElementException("result is not shown yet");
-        }
-        return tableRows.get(0);
+                    throw new NoSuchElementException("User not in pos 0");
+                }
+                return tableRows;
+            }
+        }).get(0);
     }
 
     private ManageLanguageTeamMemberPage confirmAdded(
@@ -155,10 +134,10 @@ public class ManageLanguageTeamMemberPage extends BasePage {
         return refreshPageUntil(this, new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver driver) {
-                By byId = By.id("memberPanel:threads");
-                List<String> usernameColumn =
-                        WebElementUtil.getColumnContents(getDriver(), byId,
-                                USERNAME_COLUMN);
+                List<String> usernameColumn = WebElementUtil
+                        .getColumnContents(getDriver(),
+                        memberPanelRows,
+                        USERNAME_COLUMN);
                 log.info("username column: {}", usernameColumn);
                 return usernameColumn.contains(personUsername);
             }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
@@ -19,19 +19,25 @@ import org.zanata.util.WebElementUtil;
  */
 @Slf4j
 public class ManageSearchPage extends BasePage {
-    private static final int SELECT_ALL_COLUMN = 0;
-    private By classesTableBy = By.id("form:classList");
-    private By abortButtonBy = By.id("form:cancel");
 
+    private static final int SELECT_ALL_COLUMN = 0;
+
+    private By classesTable = By.id("form:classList");
+    private By abortButton = By.id("form:cancel");
+    private By selectAllButton = By.id("form:selectAll");
+    private By performButton = By.id("form:reindex");
+    private By cancelButton = By.id("form:cancel");
+    private By noOpsLabel = By.id("noOperationsRunning");
+    private By abortedLabel = By.id("aborted");
+    private By completedLabel = By.id("completed");
 
     public ManageSearchPage(WebDriver driver) {
         super(driver);
     }
 
-
     public ManageSearchPage selectAllActionsFor(String clazz) {
-        List<TableRow> tableRows =
-            WebElementUtil.getTableRows(getDriver(), classesTableBy);
+        List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
+                waitForWebElement(classesTable));
         for (TableRow tableRow : tableRows) {
             if (tableRow.getCellContents().contains(clazz)) {
                 WebElement allActionsChkBox =
@@ -40,12 +46,12 @@ public class ManageSearchPage extends BasePage {
             }
         }
 
-        return this;
+        return new ManageSearchPage(getDriver());
     }
 
     public ManageSearchPage clickSelectAll() {
         log.info("Click Select All");
-        getDriver().findElement(By.id("form:selectAll")).click();
+        waitForWebElement(selectAllButton).click();
         // It seems that if the Select All and Perform buttons are clicked too
         // quickly in succession, the operation will fail
         try {
@@ -59,7 +65,7 @@ public class ManageSearchPage extends BasePage {
     public boolean allActionsSelected() {
         log.info("Query all actions selected");
         List<TableRow> tableRows =
-                WebElementUtil.getTableRows(getDriver(), classesTableBy);
+                WebElementUtil.getTableRows(getDriver(), classesTable);
         for (TableRow tableRow : tableRows) {
             // column 2, 3, 4 are checkboxes for purge, reindex and optimize
             for (int i = 2; i <= 4; i++) {
@@ -74,12 +80,12 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage performSelectedActions() {
         log.info("Click Perform Actions");
-        getDriver().findElement(By.id("form:reindex")).click();
+        waitForWebElement(performButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 // The Abort button will display
-                return input.findElement(By.id("form:cancel")).isDisplayed();
+                return waitForWebElement(cancelButton).isDisplayed();
             }
         });
         return new ManageSearchPage(getDriver());
@@ -91,7 +97,7 @@ public class ManageSearchPage extends BasePage {
             @Override
             public boolean apply(WebDriver input) {
                 // once the button re-appears, it means the reindex is done.
-                return input.findElement(By.id("form:reindex")).isDisplayed();
+                return waitForWebElement(performButton).isDisplayed();
             }
         });
         return new ManageSearchPage(getDriver());
@@ -99,24 +105,24 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage abort() {
         log.info("Click Abort");
-        getDriver().findElement(abortButtonBy).click();
+        waitForWebElement(abortButton).click();
         return new ManageSearchPage(getDriver());
     }
 
 
     public boolean noOperationsRunningIsDisplayed() {
         log.info("Query No Operations");
-        return getDriver().findElement(By.id("noOperationsRunning")).isDisplayed();
+        return waitForWebElement(noOpsLabel).isDisplayed();
     }
 
     public boolean completedIsDisplayed() {
         log.info("Query is action completed");
-        return getDriver().findElement(By.id("completed")).isDisplayed();
+        return waitForWebElement(completedLabel).isDisplayed();
     }
 
     public boolean abortedIsDisplayed() {
         log.info("Query is action aborted");
-        return getDriver().findElement(By.id("aborted")).isDisplayed();
+        return waitForWebElement(abortedLabel).isDisplayed();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
@@ -25,10 +25,7 @@ import java.util.Map;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -41,23 +38,11 @@ public class ManageUserAccountPage extends BasePage {
 
     public static String PASSWORD_ERROR = "Passwords do not match";
 
-    @FindBy(id = "userdetailForm:passwordField:password")
-    private WebElement passwordField;
-
-    @FindBy(id = "userdetailForm:passwordConfirmField:confirm")
-    private WebElement passwordConfirmField;
-
-    @FindBy(id = "userdetailForm:enabledField:enabled")
-    private WebElement enabledField;
-
-    @FindBy(id = "userdetailForm:userdetailSave")
-    private WebElement saveButton;
-
-    @FindBy(id = "userdetailForm:userdetailCancel")
-    private WebElement cancelButton;
-
-    // username field will trigger ajax call and become stale
-    private By usernameBy = By.id("userdetailForm:usernameField:username");
+    private By passwordField = By.id("userdetailForm:passwordField:password");
+    private By passwordConfirmField = By.id("userdetailForm:passwordConfirmField:confirm");
+    private By enabledField = By.id("userdetailForm:enabledField:enabled");
+    private By saveButton = By.id("userdetailForm:userdetailSave");
+    private By cancelButton = By.id("userdetailForm:userdetailCancel");
 
     private Map<String, String> roleMap;
 
@@ -73,54 +58,50 @@ public class ManageUserAccountPage extends BasePage {
 
     public ManageUserAccountPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        passwordField.sendKeys(password);
+        waitForWebElement(passwordField).sendKeys(password);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage enterConfirmPassword(String confirmPassword) {
         log.info("Enter confirm password {}", confirmPassword);
-        passwordConfirmField.sendKeys(confirmPassword);
+        waitForWebElement(passwordConfirmField).sendKeys(confirmPassword);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickEnabled() {
         log.info("Click Enabled");
-        enabledField.click();
+        waitForWebElement(enabledField).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickRole(String role) {
         log.info("Click role {}", role);
-        WebElement roleBox =
-                getDriver().findElement(
-                        By.id("userdetailForm:rolesField:roles:".concat(roleMap
-                                .get(role))));
-        roleBox.click();
+        waitForWebElement(By.id("userdetailForm:rolesField:roles:"
+                .concat(roleMap.get(role)))).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public boolean isRoleChecked(String role) {
         log.info("Query is role {} checked", role);
-        return getDriver().findElement(
-                By.id("userdetailForm:rolesField:roles:".concat(roleMap
-                        .get(role)))).isSelected();
+        return waitForWebElement(By.id("userdetailForm:rolesField:roles:"
+                .concat(roleMap.get(role)))).isSelected();
     }
 
     public ManageUserPage saveUser() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new ManageUserPage(getDriver());
     }
 
     public ManageUserAccountPage saveUserExpectFailure() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserPage cancelEditUser() {
         log.info("Click Cancel");
-        cancelButton.click();
+        waitForWebElement(cancelButton).click();
         return new ManageUserPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
@@ -16,13 +16,16 @@ import java.util.List;
 @Slf4j
 public class RoleAssignmentsPage extends BasePage {
 
+    private By newRuleButton = By.linkText("New Rule");
+    private By roleTable = By.tagName("table");
+
     public RoleAssignmentsPage(WebDriver driver) {
         super(driver);
     }
 
     public EditRoleAssignmentPage clickCreateNew() {
         log.info("Click Create New");
-        getDriver().findElement(By.linkText("New Rule")).click();
+        waitForWebElement(newRuleButton).click();
         return new EditRoleAssignmentPage(getDriver());
     }
 
@@ -30,7 +33,7 @@ public class RoleAssignmentsPage extends BasePage {
         log.info("Query role rules");
         List<String> names = new ArrayList<String>();
         List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
-                By.tagName("table"));
+                roleTable);
         for (TableRow tableRow : tableRows) {
             names.add(tableRow.getCells().get(1).getText());
         }

--- a/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
@@ -14,19 +14,11 @@ import org.zanata.util.WebElementUtil;
  */
 @Slf4j
 public class ServerConfigurationPage extends BasePage {
-    @FindBy(id = "serverConfigForm:urlField")
-    private WebElement urlField;
 
-    @FindBy(
-            id = "serverConfigForm:maxConcurrentPerApiKeyField:maxConcurrentPerApiKeyEml")
-    private WebElement maxConcurrentField;
-
-    @FindBy(
-            id = "serverConfigForm:maxActiveRequestsPerApiKeyField:maxActiveRequestsPerApiKeyEml")
-    private WebElement maxActiveField;
-
-    @FindBy(id = "serverConfigForm:save")
-    private WebElement saveButton;
+    private By urlField = By.id("serverConfigForm:urlField");
+    private By maxConcurrentField = By.id("serverConfigForm:maxConcurrentPerApiKeyField:maxConcurrentPerApiKeyEml");
+    private By maxActiveField = By.id("serverConfigForm:maxActiveRequestsPerApiKeyField:maxActiveRequestsPerApiKeyEml");
+    private By saveButton = By.id("serverConfigForm:save");
 
     public ServerConfigurationPage(WebDriver driver) {
         super(driver);
@@ -34,31 +26,31 @@ public class ServerConfigurationPage extends BasePage {
 
     public ServerConfigurationPage inputMaxConcurrent(int max) {
         log.info("Enter maximum concurrent API requests {}", max);
-        maxConcurrentField.clear();
-        maxConcurrentField.sendKeys(max + "");
-        return this;
+        waitForWebElement(maxConcurrentField).clear();
+        waitForWebElement(maxConcurrentField).sendKeys(max + "");
+        return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxConcurrentRequestsPerApiKey() {
         log.info("Query maximum concurrent API requests");
-        return maxConcurrentField.getAttribute("value");
+        return waitForWebElement(maxConcurrentField).getAttribute("value");
     }
 
     public ServerConfigurationPage inputMaxActive(int max) {
         log.info("Enter maximum active API requests {}", max);
-        maxActiveField.clear();
-        maxActiveField.sendKeys(max + "");
-        return this;
+        waitForWebElement(maxActiveField).clear();
+        waitForWebElement(maxActiveField).sendKeys(max + "");
+        return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxActiveRequestsPerApiKey() {
         log.info("Query maximum active API requests");
-        return maxActiveField.getAttribute("value");
+        return waitForWebElement(maxActiveField).getAttribute("value");
     }
 
     public AdministrationPage save() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new AdministrationPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
@@ -21,9 +21,8 @@
 package org.zanata.page.administration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 /**
@@ -33,17 +32,10 @@ import org.zanata.page.BasePage;
 @Slf4j
 public class TranslationMemoryEditPage extends BasePage {
 
-    @FindBy(id = "tmForm:slugField:slug")
-    private WebElement idField;
-
-    @FindBy(id = "tmForm:descriptionField:description")
-    private WebElement descriptionField;
-
-    @FindBy(id = "tmForm:save")
-    private WebElement saveButton;
-
-    @FindBy(id = "tmForm:cancel")
-    private WebElement cancelButton;
+    private By idField = By.id("tmForm:slugField:slug");
+    private By descriptionField = By.id("tmForm:descriptionField:description");
+    private By saveButton = By.id("tmForm:save");
+    private By cancelButton = By.id("tmForm:cancel");
 
     public TranslationMemoryEditPage(WebDriver driver) {
         super(driver);
@@ -51,31 +43,31 @@ public class TranslationMemoryEditPage extends BasePage {
 
     public TranslationMemoryEditPage enterMemoryID(String id) {
         log.info("Enter TM ID {}", id);
-        idField.sendKeys(id);
+        waitForWebElement(idField).sendKeys(id);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryEditPage enterMemoryDescription(String description) {
         log.info("Enter TM description {}", description);
-        descriptionField.sendKeys(description);
+        waitForWebElement(descriptionField).sendKeys(description);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage saveTM() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryEditPage clickSaveAndExpectFailure() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage cancelTM() {
         log.info("Click Cancel");
-        cancelButton.click();
+        waitForWebElement(cancelButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
@@ -20,15 +20,14 @@
  */
 package org.zanata.page.dashboard;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.zanata.util.WebElementUtil;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,46 +36,35 @@ import java.util.List;
 @Slf4j
 public class DashboardActivityTab extends DashboardBasePage {
 
+    private By activityList = By.id("activity-list");
+    private By moreActivityButton = By.id("moreActivity");
+
     public DashboardActivityTab(WebDriver driver) {
         super(driver);
     }
 
     public List<WebElement> getMyActivityList() {
         log.info("Query activity list");
-        WebElement listWrapper =
-                getDriver().findElement(By.id("activity-list"));
-
-        if (listWrapper != null) {
-            return listWrapper.findElements(By.xpath("./li"));
-        }
-        return new ArrayList<WebElement>();
+        return waitForWebElement(activityList).findElements(By.xpath("./li"));
     }
 
     /**
      * Click on the activity list's "More Activity element".
-     * @return true, if there is more activity available. False otherwise.
+     * @return true, if the list has increased, false otherwise.
      */
     public boolean clickMoreActivity() {
         log.info("Click More Activity button");
-        WebElement moreActivity = getMoreActivityElement();
         final int activityListOrigSize = getMyActivityList().size();
-        if (moreActivity != null) {
-            moreActivity.click();
-            WebElementUtil.waitForAMoment(getDriver()).until(
-                    new ExpectedCondition<Object>() {
-                        @Nullable
-                        @Override
-                        public Object apply(@Nullable WebDriver input) {
-                            return getMyActivityList().size() > activityListOrigSize;
-                        }
-                    });
-            return true;
-        } else {
-            return false;
-        }
+        waitForWebElement(moreActivityButton).click();
+        return waitForAMoment().until(new Function<WebDriver, Boolean>() {
+            @Override
+            public Boolean apply(WebDriver input) {
+                return getMyActivityList().size() > activityListOrigSize;
+            }
+        });
     }
 
-    private WebElement getMoreActivityElement() {
-        return getDriver().findElement(By.id("moreActivity"));
+    public boolean isMoreActivity() {
+        return getDriver().findElements(moreActivityButton).size() > 0;
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
@@ -24,8 +24,6 @@ import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.dashboard.dashboardsettings.DashboardAccountTab;
 import org.zanata.page.dashboard.dashboardsettings.DashboardClientTab;
@@ -34,32 +32,16 @@ import org.zanata.page.dashboard.dashboardsettings.DashboardProfileTab;
 @Slf4j
 public class DashboardBasePage extends BasePage {
 
-    @FindBy(id = "activity_tab")
-    private WebElement activityTab;
-
-    @FindBy(id = "projects_tab")
-    private WebElement projectsTab;
-
-    @FindBy(id = "settings_tab")
-    private WebElement settingsTab;
-
-    @FindBy(id = "account_tab")
-    private WebElement settingsAccountTab;
-
-    @FindBy(id = "profile_tab")
-    private WebElement settingsProfileTab;
-
-    @FindBy(id = "client_tab")
-    private WebElement settingsClientTab;
-
-    @FindBy(id = "activity-today_tab")
-    private WebElement todaysActivityTab;
-
-    @FindBy(id = "activity-week_tab")
-    private WebElement thisWeeksActivityTab;
-
-    @FindBy(id = "activity-month_tab")
-    private WebElement thisMonthsActivityTab;
+    private By activityTab = By.id("activity_tab");
+    private By projectsTab = By.id("projects_tab");
+    private By settingsTab = By.id("settings_tab");
+    private By settingsAccountTab = By.id("account_tab");
+    private By settingsProfileTab = By.id("profile_tab");
+    private By settingsClientTab = By.id("client_tab");
+    private By todaysActivityTab = By.id("activity-today_tab");
+    private By thisWeeksActivityTab = By.id("activity-week_tab");
+    private By thisMonthsActivityTab = By.id("activity-month_tab");
+    private By profileOverview = By.id("profile-overview");
 
     public final static String EMAIL_SENT =
             "You will soon receive an email with a link to activate your " +
@@ -74,49 +56,50 @@ public class DashboardBasePage extends BasePage {
 
     public String getUserFullName() {
         log.info("Query user full name");
-        return getDriver().findElement(By.id("profile-overview"))
+        return waitForWebElement(profileOverview)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public DashboardActivityTab gotoActivityTab() {
         log.info("Click Activity tab");
-        clickWhenTabEnabled(activityTab);
+        clickWhenTabEnabled(waitForWebElement(activityTab));
         return new DashboardActivityTab(getDriver());
     }
 
     public boolean activityTabIsSelected() {
         log.info("Query is Activity tab displayed");
-        return getDriver().findElement(
-                By.cssSelector("#activity.is-active")) != null;
+        return getDriver()
+                .findElements(By.cssSelector("#activity.is-active"))
+                .size() > 0;
     }
 
     public DashboardProjectsTab gotoProjectsTab() {
         log.info("Click Projects tab");
-        projectsTab.click();
+        clickWhenTabEnabled(waitForWebElement(projectsTab));
         return new DashboardProjectsTab(getDriver());
     }
 
     public DashboardBasePage goToSettingsTab() {
         log.info("Click Settings tab");
-        clickWhenTabEnabled(settingsTab);
+        clickWhenTabEnabled(waitForWebElement(settingsTab));
         return new DashboardBasePage(getDriver());
     }
 
     public DashboardAccountTab gotoSettingsAccountTab() {
         log.info("Click Account settings sub-tab");
-        clickWhenTabEnabled(settingsAccountTab);
+        clickWhenTabEnabled(waitForWebElement(settingsAccountTab));
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardProfileTab goToSettingsProfileTab() {
         log.info("Click Profile settings sub-tab");
-        clickWhenTabEnabled(settingsProfileTab);
+        clickWhenTabEnabled(waitForWebElement(settingsProfileTab));
         return new DashboardProfileTab(getDriver());
     }
 
     public DashboardClientTab goToSettingsClientTab() {
         log.info("Click Client settings sub-tab");
-        clickWhenTabEnabled(settingsClientTab);
+        clickWhenTabEnabled(waitForWebElement(settingsClientTab));
         return new DashboardClientTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
@@ -26,7 +26,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zanata.page.projects.CreateProjectPage;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,27 +34,23 @@ import java.util.List;
 @Slf4j
 public class DashboardProjectsTab extends DashboardBasePage {
 
+    private By maintainedProjectsList = By.id("maintainedProjects");
+    private By createProjectLink = By.id("create-project-link");
+
     public DashboardProjectsTab(WebDriver driver) {
         super(driver);
     }
 
     public List<WebElement> getMaintainedProjectList() {
         log.info("Query maintained projects list");
-        WebElement listWrapper =
-                getDriver().findElement(By.id("maintainedProjects"))
-                        .findElement(By.tagName("ul"));
-
-        if (listWrapper != null) {
-            return listWrapper.findElements(By.xpath("./li"));
-        }
-        return new ArrayList<WebElement>();
+        return waitForWebElement(maintainedProjectsList)
+                .findElement(By.tagName("ul"))
+                .findElements(By.xpath("./li"));
     }
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        WebElement createProjLink =
-                getDriver().findElement(By.id("create-project-link"));
-        createProjLink.click();
+        waitForWebElement(createProjectLink).click();
         return new CreateProjectPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
@@ -21,9 +21,8 @@
 package org.zanata.page.dashboard.dashboardsettings;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.dashboard.DashboardBasePage;
 
 /**
@@ -43,20 +42,11 @@ public class DashboardAccountTab extends DashboardBasePage {
     public static final String EMAIL_TAKEN_ERROR =
             "This email address is already taken";
 
-    @FindBy(id = "email-update-form:emailField:email")
-    private WebElement emailField;
-
-    @FindBy(id = "email-update-form:updateEmailButton")
-    private WebElement updateEmailButton;
-
-    @FindBy(id = "passwordChangeForm:oldPasswordField:oldPassword")
-    private WebElement oldPasswordField;
-
-    @FindBy(id = "passwordChangeForm:newPasswordField:newPassword")
-    private WebElement newPasswordField;
-
-    @FindBy(id = "passwordChangeForm:changePasswordButton")
-    private WebElement changePasswordButton;
+    private By emailField = By.id("email-update-form:emailField:email");
+    private By updateEmailButton = By.id("email-update-form:updateEmailButton");
+    private By oldPasswordField = By.id("passwordChangeForm:oldPasswordField:oldPassword");
+    private By newPasswordField = By.id("passwordChangeForm:newPasswordField:newPassword");
+    private By changePasswordButton = By.id("passwordChangeForm:changePasswordButton");
 
     public DashboardAccountTab(WebDriver driver) {
         super(driver);
@@ -64,34 +54,34 @@ public class DashboardAccountTab extends DashboardBasePage {
 
     public DashboardAccountTab typeNewAccountEmailAddress(String emailAddress) {
         log.info("Enter email {}", emailAddress);
-        emailField.clear();
-        emailField.sendKeys(emailAddress);
-        return this;
+        waitForWebElement(emailField).clear();
+        waitForWebElement(emailField).sendKeys(emailAddress);
+        return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdateEmailButton() {
         log.info("Click Update Email");
-        updateEmailButton.click();
-        return this;
+        waitForWebElement(updateEmailButton).click();
+        return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeOldPassword(String oldPassword) {
         log.info("Enter old password {}", oldPassword);
-        oldPasswordField.clear();
-        oldPasswordField.sendKeys(oldPassword);
-        return this;
+        waitForWebElement(oldPasswordField).clear();
+        waitForWebElement(oldPasswordField).sendKeys(oldPassword);
+        return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeNewPassword(String newPassword) {
         log.info("Enter new password {}", newPassword);
-        newPasswordField.clear();
-        newPasswordField.sendKeys(newPassword);
-        return this;
+        waitForWebElement(newPasswordField).clear();
+        waitForWebElement(newPasswordField).sendKeys(newPassword);
+        return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdatePasswordButton() {
         log.info("Click Update Password");
-        changePasswordButton.click();
-        return this;
+        waitForWebElement(changePasswordButton).click();
+        return new DashboardAccountTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
@@ -22,9 +22,8 @@ package org.zanata.page.dashboard.dashboardsettings;
 
 import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.dashboard.DashboardBasePage;
 
 /**
@@ -33,14 +32,9 @@ import org.zanata.page.dashboard.DashboardBasePage;
 @Slf4j
 public class DashboardClientTab extends DashboardBasePage {
 
-    @FindBy(id = "generateKeyButton")
-    private WebElement generateApiKeyButton;
-
-    @FindBy(id = "apiKey")
-    private WebElement apiKeyLabel;
-
-    @FindBy(id = "config")
-    private WebElement configurationTextArea;
+    private By generateApiKeyButton = By.id("generateKeyButton");
+    private By apiKeyLabel = By.id("apiKey");
+    private By configurationTextArea = By.id("config");
 
     public DashboardClientTab(WebDriver driver) {
         super(driver);
@@ -48,19 +42,19 @@ public class DashboardClientTab extends DashboardBasePage {
 
     public DashboardClientTab pressApiKeyGenerateButton() {
         log.info("Press Generate API Key");
-        generateApiKeyButton.click();
+        waitForWebElement(generateApiKeyButton).click();
         getDriver().switchTo().alert().accept();
         return new DashboardClientTab(getDriver());
     }
 
     public String getApiKey() {
         log.info("Query API Key");
-        return apiKeyLabel.getAttribute("value");
+        return waitForWebElement(apiKeyLabel).getAttribute("value");
     }
 
     public String getConfigurationDetails() {
         log.info("Query configuration details");
-        return configurationTextArea.getText();
+        return waitForWebElement(configurationTextArea).getText();
     }
 
     public void waitForApiKeyChanged(final String current) {

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
@@ -23,8 +23,6 @@ package org.zanata.page.dashboard.dashboardsettings;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.dashboard.DashboardBasePage;
 
 /**
@@ -34,11 +32,8 @@ import org.zanata.page.dashboard.DashboardBasePage;
 @Slf4j
 public class DashboardProfileTab extends DashboardBasePage {
 
-    @FindBy(id = "profileForm:nameField:accountName")
-    private WebElement accountNameField;
-
-    @FindBy(id = "updateProfileButton")
-    private WebElement updateProfileButton;
+    private By accountNameField = By.id("profileForm:nameField:accountName");
+    private By updateProfileButton = By.id("updateProfileButton");
 
     public DashboardProfileTab(WebDriver driver) {
         super(driver);
@@ -46,21 +41,21 @@ public class DashboardProfileTab extends DashboardBasePage {
 
     public String getUsername() {
         log.info("Query user name");
-        return getDriver().findElement(By.id("profileForm"))
+        return waitForWebElement(By.id("profileForm"))
                 .findElement(By.className("l--push-bottom-0"))
                 .getText();
     }
 
     public DashboardProfileTab enterName(String name) {
         log.info("Enter name {}", name);
-        accountNameField.clear();
-        accountNameField.sendKeys(name);
-        return this;
+        waitForWebElement(accountNameField).clear();
+        waitForWebElement(accountNameField).sendKeys(name);
+        return new DashboardProfileTab(getDriver());
     }
 
     public DashboardProfileTab clickUpdateProfileButton() {
         log.info("Click Update");
-        updateProfileButton.click();
-        return this;
+        waitForWebElement(updateProfileButton).click();
+        return new DashboardProfileTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
+++ b/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
@@ -26,8 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -38,8 +36,7 @@ import org.zanata.util.WebElementUtil;
 @Slf4j
 public class GlossaryPage extends BasePage {
 
-    @FindBy(id = "glossary_form:data_table")
-    private WebElement glossaryTable;
+    private By glossaryTable = By.id("glossary_form:data_table");
 
     public GlossaryPage(WebDriver driver) {
         super(driver);
@@ -47,8 +44,7 @@ public class GlossaryPage extends BasePage {
 
     public List<String> getAvailableGlossaryLanguages() {
         log.info("Query available glossary languages");
-        return WebElementUtil.getColumnContents(getDriver(),
-                By.id("glossary_form:data_table"), 0);
+        return WebElementUtil.getColumnContents(getDriver(), glossaryTable, 0);
     }
 
     public int getGlossaryEntryCount(String lang) {
@@ -58,7 +54,7 @@ public class GlossaryPage extends BasePage {
         if (row >= 0) {
             return Integer
                     .parseInt(WebElementUtil.getColumnContents(getDriver(),
-                            By.id("glossary_form:data_table"), 2).get(row));
+                            glossaryTable, 2).get(row));
         }
         return -1;
     }

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
@@ -23,8 +23,6 @@ package org.zanata.page.googleaccount;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.AbstractPage;
 
 /**
@@ -33,17 +31,13 @@ import org.zanata.page.AbstractPage;
  */
 @Slf4j
 public class GoogleAccountPage extends AbstractPage {
-    @FindBy(id = "Email")
-    private WebElement emailField;
 
-    @FindBy(id = "reauthEmail")
-    private WebElement emailLabelField;
-
-    @FindBy(id = "Passwd")
-    private WebElement passwordField;
-
-    @FindBy(id = "signIn")
-    private WebElement signInButton;
+    private By emailField = By.id("Email");
+    private By emailLabelField = By.id("reauthEmail");
+    private By passwordField = By.id("Passwd");
+    private By signInButton = By.id("signIn");
+    private By signInDifferent = By.linkText("Sign in with a different account");
+    private By profileImage = By.id("profile-img");
 
     public GoogleAccountPage(WebDriver driver) {
         super(driver);
@@ -51,41 +45,41 @@ public class GoogleAccountPage extends AbstractPage {
 
     public GoogleAccountPage enterGoogleEmail(String email) {
         log.info("Enter email {}", email);
-        emailField.sendKeys(email);
+        waitForWebElement(emailField).sendKeys(email);
         return new GoogleAccountPage(getDriver());
     }
 
     public GoogleAccountPage enterGooglePassword(String password) {
         log.info("Enter password {}", password);
-        passwordField.sendKeys(password);
+        waitForWebElement(passwordField).sendKeys(password);
         return new GoogleAccountPage(getDriver());
     }
 
     public GooglePermissionsPage clickSignIn() {
         log.info("Click account Sign In");
-        signInButton.click();
+        waitForWebElement(signInButton).click();
         return new GooglePermissionsPage(getDriver());
     }
 
     public GoogleManagePermissionsPage clickPermissionsSignIn() {
         log.info("Click account management Sign In");
-        signInButton.click();
+        waitForWebElement(signInButton).click();
         return new GoogleManagePermissionsPage(getDriver());
     }
 
     public String rememberedUser() {
         log.info("Query remembered user email");
-        return emailLabelField.getText();
+        return waitForWebElement(emailLabelField).getText();
     }
 
     public boolean hasRememberedAuthentication() {
         log.info("Query is user remembered");
-        return emailLabelField.isDisplayed();
+        return getDriver().findElements(emailLabelField).size() > 0;
     }
 
     public GoogleAccountPage removeSavedAuthentication() {
         log.info("Click Sign in with different account");
-        getDriver().findElement(By.linkText("Sign in with a different account")).click();
+        waitForWebElement(signInDifferent).click();
         return new GoogleAccountPage(getDriver());
     }
 
@@ -98,6 +92,6 @@ public class GoogleAccountPage extends AbstractPage {
      */
     public boolean isTheOldGoogleSite() {
         log.info("Query is the old Google site displayed");
-        return getDriver().findElements(By.id("profile-img")).size() < 1;
+        return getDriver().findElements(profileImage).size() < 1;
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
@@ -34,6 +34,9 @@ import com.google.common.base.Function;
  */
 @Slf4j
 public class GooglePermissionsPage extends AbstractPage {
+
+    private By approveAccessButton = By.id("submit_approve_access");
+
     public GooglePermissionsPage(WebDriver driver) {
         super(driver);
     }
@@ -43,11 +46,11 @@ public class GooglePermissionsPage extends AbstractPage {
         waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
             public Boolean apply(WebDriver driver) {
-                return getDriver().findElement(By.id("submit_approve_access"))
+                return getDriver().findElement(approveAccessButton)
                         .isEnabled();
             }
         });
-        getDriver().findElement(By.id("submit_approve_access")).click();
+        waitForWebElement(approveAccessButton).click();
         return new EditProfilePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
@@ -1,16 +1,11 @@
 package org.zanata.page.groups;
 
-import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
 
 /**
  * @author Patrick Huang <a
@@ -26,74 +21,61 @@ public class CreateVersionGroupPage extends BasePage {
             "must start and end with letter or number, and contain only " +
             "letters, numbers, periods, underscores and hyphens.";
 
-    @FindBy(id = "group-form:descriptionField:description")
-    private WebElement groupDescriptionField;
-
-    @FindBy(id = "group-form:group-create-new")
-    private WebElement saveButton;
+    private By groupIdField = By.id("group-form:slugField:slug");
+    private By groupNameField = By.id("group-form:nameField:name");
+    private By groupDescriptionField = By.id("group-form:descriptionField:description");
+    private By saveButton = By.id("group-form:group-create-new");
+    private By createNewButton = By.id("group-form:group-create-new");
 
     public CreateVersionGroupPage(WebDriver driver) {
         super(driver);
-        List<By> elementBys =
-                ImmutableList.<By> builder()
-                        .add(By.id("group-form:slugField:slug"))
-                        .add(By.id("group-form:nameField:name"))
-                        .add(By.id("group-form:descriptionField:description"))
-                        .add(By.id("group-form:group-create-new")).build();
-        waitForPage(elementBys);
     }
 
     public CreateVersionGroupPage inputGroupId(String groupId) {
         log.info("Enter Group ID {}", groupId);
-        getGroupSlugField().sendKeys(groupId);
+        waitForWebElement(groupIdField).sendKeys(groupId);
         return new CreateVersionGroupPage(getDriver());
-    }
-
-    private WebElement getGroupSlugField() {
-        return waitForWebElement(By.id("group-form:slugField:slug"));
     }
 
     public String getGroupIdValue() {
         log.info("Query Group ID");
-        return getGroupSlugField().getAttribute("value");
+        return waitForWebElement(groupIdField).getAttribute("value");
     }
 
     public CreateVersionGroupPage inputGroupName(String groupName) {
         log.info("Enter Group name {}", groupName);
-        getGroupNameField().sendKeys(groupName);
+        waitForWebElement(groupNameField).sendKeys(groupName);
         return new CreateVersionGroupPage(getDriver());
-    }
-
-    private WebElement getGroupNameField() {
-        return waitForWebElement(By.id("group-form:nameField:name"));
     }
 
     public CreateVersionGroupPage inputGroupDescription(String desc) {
         log.info("Enter Group description {}", desc);
-        groupDescriptionField.sendKeys(desc);
+        waitForWebElement(groupDescriptionField).sendKeys(desc);
         return this;
     }
 
     public VersionGroupsPage saveGroup() {
         log.info("Click Save");
-        clickAndCheckErrors(saveButton);
+        clickAndCheckErrors(waitForWebElement(saveButton));
         return new VersionGroupsPage(getDriver());
     }
 
     public CreateVersionGroupPage saveGroupFailure() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public CreateVersionGroupPage clearFields() {
-        getGroupSlugField().clear();
-        getGroupNameField().clear();
-        groupDescriptionField.clear();
+        waitForWebElement(groupIdField).clear();
+        waitForWebElement(groupNameField).clear();
+        waitForWebElement(groupDescriptionField).clear();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                return getGroupIdValue().equals("") && getGroupNameField().getAttribute("value").equals("");
+                return getGroupIdValue().equals("") &&
+                        waitForWebElement(groupNameField).getAttribute("value")
+                                .equals("");
             }
         });
         return new CreateVersionGroupPage(getDriver());

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.projects.ProjectVersionsPage;
 import org.zanata.page.projectversion.VersionLanguagesPage;
@@ -17,8 +16,6 @@ import org.zanata.util.WebElementUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 
-import javax.annotation.Nullable;
-
 /**
  * @author Patrick Huang <a
  *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
@@ -26,26 +23,34 @@ import javax.annotation.Nullable;
 @Slf4j
 public class VersionGroupPage extends BasePage {
 
-    private By versionsInGroupTableBy = By.id("projects-project_list");
+    private By versionsInGroupTable = By.id("projects-project_list");
+    private By projectForm = By.id("projects-project_form");
+    private By projectSearchField = By
+            .id("settings-projects-form:newVersionField:newVersionInput");
+    private By projectAddButton = By
+            .id("settings-projects-form:group-add-new-project-button");
+    private final By newVersionList = By
+            .id("settings-projects-form:newVersionField:newVersionItems");
+    private By groupNameLabel = By.id("group-info");
+
+    private By languagesTab = By.id("languages_tab");
+    private By projectsTab = By.id("projects_tab");
+    private By maintainersTab = By.id("maintainers_tab");
+    private By settingsTab = By.id("settings_tab");
+    private By settingsLanguagesTab = By.id("settings-languages_tab");
 
     public VersionGroupPage(final WebDriver driver) {
         super(driver);
     }
 
-    @FindBy(id = "settings-projects-form:newVersionField:newVersionInput")
-    private WebElement projectSearchField;
-
-    private final By newVersionListBy = By
-            .id("settings-projects-form:newVersionField:newVersionItems");
-
     public String getGroupName() {
-        return getDriver().findElement(By.id("group-info"))
+        return waitForWebElement(groupNameLabel)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public List<WebElement> searchProject(final String projectName,
             final int expectedResultNum) {
-        projectSearchField.sendKeys(projectName);
+        waitForWebElement(projectSearchField).sendKeys(projectName);
 
         return refreshPageUntil(this,
                 new Function<WebDriver, List<WebElement>>() {
@@ -61,7 +66,7 @@ public class VersionGroupPage extends BasePage {
 
                         List<WebElement> listItems =
                                 WebElementUtil.getListItems(getDriver(),
-                                        newVersionListBy);
+                                        newVersionList);
 
                         if (listItems.size() != expectedResultNum) {
                             log.debug("waiting for search result refresh...");
@@ -73,18 +78,10 @@ public class VersionGroupPage extends BasePage {
     }
 
     public VersionGroupPage addToGroup(int rowIndex) {
-
-        List<WebElement> listItems =
-                WebElementUtil.getListItems(getDriver(), newVersionListBy);
-
-        listItems.get(rowIndex).click();
-
-        WebElement addButton =
-                getDriver()
-                        .findElement(
-                                By.id("settings-projects-form:group-add-new-project-button"));
-        addButton.click();
-        return this;
+        WebElementUtil.getListItems(getDriver(), newVersionList)
+                .get(rowIndex).click();
+        waitForWebElement(projectAddButton).click();
+        return new VersionGroupPage(getDriver());
     }
 
     /**
@@ -95,7 +92,7 @@ public class VersionGroupPage extends BasePage {
     public List<String> getProjectVersionsInGroup() {
         log.info("Query Group project versions");
         List<WebElement> elements = WebElementUtil
-                .getListItems(getDriver(), versionsInGroupTableBy);
+                .getListItems(getDriver(), versionsInGroupTable);
 
         List<String> result = new ArrayList<String>();
 
@@ -110,7 +107,7 @@ public class VersionGroupPage extends BasePage {
     public ProjectVersionsPage clickOnProjectLinkOnRow(int row) {
         List<TableRow> tableRows =
                 WebElementUtil
-                        .getTableRows(getDriver(), versionsInGroupTableBy);
+                        .getTableRows(getDriver(), versionsInGroupTable);
         WebElement projectLink =
                 tableRows.get(row).getCells().get(0)
                         .findElement(By.tagName("a"));
@@ -121,7 +118,7 @@ public class VersionGroupPage extends BasePage {
     public VersionLanguagesPage clickOnProjectVersionLinkOnRow(int row) {
         List<TableRow> tableRows =
                 WebElementUtil
-                        .getTableRows(getDriver(), versionsInGroupTableBy);
+                        .getTableRows(getDriver(), versionsInGroupTable);
         WebElement versionLink =
                 tableRows.get(row).getCells().get(1)
                         .findElement(By.tagName("a"));
@@ -130,61 +127,52 @@ public class VersionGroupPage extends BasePage {
     }
 
     public void clickOnTab(String tabId) {
-        WebElement tab = getDriver().findElement(By.id(tabId));
-        tab.click();
+        waitForWebElement(By.id(tabId)).click();
     }
 
     public VersionGroupPage clickAddProjectVersionsButton() {
         log.info("Click Add Project Version");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver driver) {
-                WebElement addProjectVersionButton = driver
-                        .findElement(By.id("projects-project_form"))
-                        .findElement(By.className("button--primary"));
-                addProjectVersionButton.click();
-                return true;
-            }
-        });
+        waitForWebElement(waitForElementExists(projectForm), //parent
+                By.className("button--primary")).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesTab() {
         log.info("Click Languages tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("languages_tab")));
+        clickWhenTabEnabled(waitForWebElement(languagesTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickProjectsTab() {
         log.info("Click Projects tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("projects_tab")));
+        clickWhenTabEnabled(waitForWebElement(projectsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickMaintainersTab() {
         log.info("Click Maintainers tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("maintainers_tab")));
+        clickWhenTabEnabled(waitForWebElement(maintainersTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickSettingsTab() {
         log.info("Click Settings tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("settings_tab")));
+        clickWhenTabEnabled(waitForWebElement(settingsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesSettingsTab() {
         clickSettingsTab();
-        getDriver().findElement(By.id("settings-languages_tab")).click();
+        waitForWebElement(settingsLanguagesTab).click();
         return new VersionGroupPage(getDriver());
     }
 
     public Boolean isLanguagesTabActive() {
         log.info("Query is languages tab displayed");
-        final WebElement languagesTab = getDriver().findElement(By.id("languages"));
+        final WebElement languagesTab = waitForWebElement(By.id("languages"));
         waitForAMoment().until( new Predicate<WebDriver>() {
             @Override
-            public boolean apply(@Nullable WebDriver webDriver) {
+            public boolean apply(WebDriver webDriver) {
                 return languagesTab.getAttribute("class").contains("is-active");
             }
         } );
@@ -192,10 +180,10 @@ public class VersionGroupPage extends BasePage {
     }
 
     public Boolean isProjectsTabActive() {
-        final WebElement languagesTab = getDriver().findElement(By.id("projects"));
+        final WebElement languagesTab = waitForElementExists(By.id("projects"));
         waitForAMoment().until( new Predicate<WebDriver>() {
             @Override
-            public boolean apply(@Nullable WebDriver webDriver) {
+            public boolean apply(WebDriver webDriver) {
                 return languagesTab.getAttribute("class").contains("is-active");
             }
         } );
@@ -209,8 +197,7 @@ public class VersionGroupPage extends BasePage {
      */
     public VersionGroupPage enterProjectVersion(String projectVersion) {
         log.info("Enter project version {}", projectVersion);
-        getDriver()
-                .findElement(By.id("versionAutocomplete-autocomplete__input"))
+        waitForWebElement(By.id("versionAutocomplete-autocomplete__input"))
                 .sendKeys(projectVersion);
         return new VersionGroupPage(getDriver());
     }

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -22,48 +21,43 @@ public class VersionGroupsPage extends BasePage {
     public static final int GROUP_TIMESTAMP_COLUMN = 2;
     public static final int GROUP_STATUS_COLUMN = 3;
 
-    @FindBy(id = "groupForm:groupTable")
-    private WebElement groupTable;
-
-    @FindBy(className = "infomsg.icon-info-circle-2")
-    private WebElement infomsg;
+    private By groupTable = By.id("groupForm:groupTable");
+    private By infomsg = By.className("infomsg.icon-info-circle-2");
+    private By createGroupButton = By.id("group-create");
+    private By toggleObsolete = By.id("groupForm:showObsolete");
+    private By obsoleteLink = By.className("obsolete_link");
 
     public VersionGroupsPage(WebDriver driver) {
         super(driver);
     }
 
     public List<String> getGroupNames() {
-        By by = By.id("groupForm:groupTable");
-        return WebElementUtil.getColumnContents(getDriver(), by,
+        return WebElementUtil.getColumnContents(getDriver(), groupTable,
                 GROUP_NAME_COLUMN);
     }
 
     public CreateVersionGroupPage createNewGroup() {
         log.info("Click New Group button");
-        WebElement createLink =
-                getDriver().findElement(By.id("group-create"));
-        createLink.click();
+        waitForWebElement(createGroupButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public VersionGroupPage goToGroup(String groupName) {
         log.info("Click group {}", groupName);
-        groupTable.findElement(By.linkText(groupName)).click();
+        waitForWebElement(groupTable).findElement(By.linkText(groupName)).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupsPage toggleObsolete(final boolean show) {
-        WebElement showObsolete =
-                getDriver().findElement(By.id("groupForm:showObsolete"));
+        WebElement showObsolete = waitForWebElement(toggleObsolete);
         if (show != showObsolete.isSelected()) {
             showObsolete.click();
         }
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                WebElement table =
-                        input.findElement(By.id("groupForm:groupTable"));
-                return table.findElements(By.className("obsolete_link"))
+                return waitForWebElement(groupTable)
+                        .findElements(obsoleteLink)
                         .isEmpty() == !show;
             }
         });
@@ -72,10 +66,8 @@ public class VersionGroupsPage extends BasePage {
 
     public String getInfoMessage() {
         log.info("Test info msg");
-        log.info(getDriver().findElement(
-                By.className("infomsg.icon-info-circle-2")).getText());
-        return getDriver().findElement(
-                By.className("infomsg.icon-info-circle-2")).getText();
+        log.info(waitForWebElement(infomsg).getText());
+        return waitForWebElement(infomsg).getText();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
@@ -23,8 +23,6 @@ package org.zanata.page.languages;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -34,11 +32,9 @@ import org.zanata.util.WebElementUtil;
 @Slf4j
 public class ContactTeamPage extends BasePage {
 
-    @FindBy(id = "contactCoordinatorForm:messageField:message")
-    private WebElement messageField;
-
-    @FindBy(id = "contactCoordinatorForm:send")
-    private WebElement sendButton;
+    private By subjectField = By.id("contactCoordinatorForm:subjectField:subject");
+    private By messageField = By.id("contactCoordinatorForm:messageField:message");
+    private By sendButton = By.id("contactCoordinatorForm:send");
 
     public ContactTeamPage(WebDriver driver) {
         super(driver);
@@ -46,22 +42,21 @@ public class ContactTeamPage extends BasePage {
 
     public ContactTeamPage enterSubject(String subject) {
         log.info("Enter subject {}", subject);
-        getDriver().findElement(
-                By.id("contactCoordinatorForm:subjectField:subject"))
-                .sendKeys(subject);
+        waitForWebElement(subjectField).sendKeys(subject);
         return new ContactTeamPage(getDriver());
     }
 
     public ContactTeamPage enterMessage(String message) {
         log.info("Enter message {}", message);
-        WebElementUtil
-                .setRichTextEditorContent(getDriver(), messageField, message);
+        WebElementUtil.setRichTextEditorContent(getDriver(),
+                waitForWebElement(messageField),
+                message);
         return new ContactTeamPage(getDriver());
     }
 
     public LanguagesPage clickSend() {
         log.info("Click the Send Message button");
-        sendButton.click();
+        waitForWebElement(sendButton).click();
         return new LanguagesPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
@@ -31,13 +31,16 @@ import org.zanata.page.BasePage;
 @Slf4j
 public class LanguagePage extends BasePage {
 
+    private By contactCoordinatorsButton =
+            By.linkText("Contact Team Coordinators");
+
     public LanguagePage(WebDriver driver) {
         super(driver);
     }
 
     public ContactTeamPage clickContactCoordinatorsButton() {
         log.info("Click Contact Coordinators button");
-        getDriver().findElement(By.linkText("Contact Team Coordinators")).click();
+        waitForWebElement(contactCoordinatorsButton).click();
         return new ContactTeamPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
@@ -35,6 +35,8 @@ import java.util.List;
 @Slf4j
 public class LanguagesPage extends BasePage {
 
+    private By languagesList = By.id("tribesForm:latestTribes");
+
     public LanguagesPage(WebDriver driver) {
         super(driver);
     }
@@ -42,7 +44,7 @@ public class LanguagesPage extends BasePage {
     public LanguagePage selectLanguage(String language) {
         log.info("Select {} from the language list", language);
         List<TableRow> tableRowList = WebElementUtil
-                .getTableRows(getDriver(), By.id("tribesForm:latestTribes"));
+                .getTableRows(getDriver(), waitForWebElement(languagesList));
         boolean clicked = false;
         for (TableRow tableRow : tableRowList) {
             if (tableRow.getCells().get(0).getText().equals(language)) {

--- a/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
@@ -26,20 +26,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 @Slf4j
 public class CreateProjectPage extends BasePage {
 
-    @FindBy(id = "project-form:descriptionField:description")
-    private WebElement descriptionField;
-
-    @FindBy(id = "project-types")
-    private WebElement projectTypeList;
-
-    @FindBy(id = "project-form:create-new")
-    private WebElement createButton;
+    private By idField = By.id("project-form:slugField:slug");
+    private By nameField = By.id("project-form:nameField:name");
+    private By descriptionField = By.id("project-form:descriptionField:description");
+    private By projectTypeList = By.id("project-types");
+    private By createButton = By.id("project-form:create-new");
 
     public CreateProjectPage(final WebDriver driver) {
         super(driver);
@@ -47,28 +43,26 @@ public class CreateProjectPage extends BasePage {
 
     public CreateProjectPage enterProjectId(String projectId) {
         log.info("Enter project ID {}", projectId);
-        getDriver().findElement(By.id("project-form:slugField:slug"))
-                .sendKeys(projectId);
+        waitForWebElement(idField).sendKeys(projectId);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        getDriver().findElement(By.id("project-form:nameField:name"))
-                .sendKeys(projectName);
+        waitForWebElement(nameField).sendKeys(projectName);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        descriptionField.sendKeys(projectDescription);
+        waitForWebElement(descriptionField).sendKeys(projectDescription);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage selectProjectType(String projectType) {
         log.info("Click project type {}", projectType);
-        List<WebElement> projectTypes =
-                projectTypeList.findElements(By.tagName("li"));
+        List<WebElement> projectTypes = waitForWebElement(projectTypeList)
+                .findElements(By.tagName("li"));
 
         for (WebElement projectTypeLi : projectTypes) {
             if (projectTypeLi.findElement(By.xpath(".//div/label")).getText()
@@ -82,7 +76,7 @@ public class CreateProjectPage extends BasePage {
 
     public ProjectVersionsPage pressCreateProject() {
         log.info("Click Create");
-        clickAndCheckErrors(createButton);
+        clickAndCheckErrors(waitForWebElement(createButton));
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
@@ -21,7 +21,6 @@
 
 package org.zanata.page.projects;
 
-import com.google.common.base.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -32,18 +31,14 @@ import org.openqa.selenium.WebDriver;
 @Slf4j
 public class ProjectAboutPage extends ProjectBasePage {
 
+    private By aboutText = By.id("project-about");
+
     public ProjectAboutPage(WebDriver driver) {
         super(driver);
     }
 
     public String getAboutText() {
         log.info("Query About content");
-        return waitForAMoment().until(new Function<WebDriver, String>() {
-            @Override
-            public String apply(WebDriver driver) {
-                return getDriver()
-                        .findElement(By.id("project-about")).getText();
-            }
-        });
+        return waitForWebElement(aboutText).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.projects.projectsettings.ProjectAboutTab;
 import org.zanata.page.projects.projectsettings.ProjectGeneralTab;
@@ -40,32 +39,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProjectBasePage extends BasePage {
 
-    @FindBy(id = "versions_tab")
-    private WebElement versionsTab;
-
-    @FindBy(id = "maintainers_tab")
-    private WebElement maintainersTab;
-
-    @FindBy(id = "about_tab")
-    private WebElement aboutTab;
-
-    @FindBy(id = "settings_tab")
-    private WebElement settingsTab;
-
-    @FindBy(id = "settings-general_tab")
-    private WebElement settingsGeneralTab;
-
-    @FindBy(id = "settings-permissions_tab")
-    private WebElement settingsPermissionTab;
-
-    @FindBy(id = "settings-translation_tab")
-    private WebElement settingsTranslationTab;
-
-    @FindBy(id = "settings-languages_tab")
-    private WebElement settingsLanguagesTab;
-
-    @FindBy(id = "settings-about_tab")
-    private WebElement settingsAboutTab;
+    private By versionsTab = By.id("versions_tab");
+    private By maintainersTab = By.id("maintainers_tab");
+    private By aboutTab = By.id("about_tab");
+    private By settingsTab = By.id("settings_tab");
+    private By settingsGeneralTab = By.id("settings-general_tab");
+    private By settingsPermissionTab = By.id("settings-permissions_tab");
+    private By settingsTranslationTab = By.id("settings-translation_tab");
+    private By settingsLanguagesTab = By.id("settings-languages_tab");
+    private By settingsAboutTab = By.id("settings-about_tab");
+    private By projectInfo = By.id("project-info");
 
     public ProjectBasePage(final WebDriver driver) {
         super(driver);
@@ -73,148 +56,82 @@ public class ProjectBasePage extends BasePage {
 
     public String getProjectName() {
         log.info("Query Project name");
-        return getDriver()
-                .findElement(By.id("project-info"))
+        return waitForWebElement(projectInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage gotoVersionsTab() {
         log.info("Click Versions tab");
-        clickWhenTabEnabled(versionsTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("versions"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(versionsTab));
+        waitForWebElement(By.id("versions"));
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectMaintainersPage gotoMaintainersTab() {
         log.info("Click Maintainers tab");
-        clickWhenTabEnabled(maintainersTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("maintainers"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(maintainersTab));
+        waitForWebElement(By.id("maintainers"));
         return new ProjectMaintainersPage(getDriver());
     }
 
     public ProjectAboutPage gotoAboutTab() {
         log.info("Click About tab");
-        clickWhenTabEnabled(aboutTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("about"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(aboutTab));
+        waitForWebElement(By.id("about"));
         return new ProjectAboutPage(getDriver());
     }
 
     public boolean settingsTabIsDisplayed() {
         log.info("Query Settings tab is displayed");
-        return settingsTab.isDisplayed();
-    }
-
-    public void reloadUntilSettingsIsDisplayed() {
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return settingsTab.isDisplayed();
-            }
-        });
+        return waitForElementExists(settingsTab).isDisplayed();
     }
 
     public ProjectBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
-        slightPause();
-        clickWhenTabEnabled(settingsTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings_tab"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsTab));
+        waitForWebElement(settingsTab);
         return new ProjectBasePage(getDriver());
     }
 
     public ProjectGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(settingsGeneralTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings-general"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsGeneralTab));
+        waitForWebElement(By.id("settings-general"));
         return new ProjectGeneralTab(getDriver());
     }
 
     public ProjectPermissionsTab gotoSettingsPermissionsTab() {
         log.info("Click Permissions settings sub-tab");
-        clickWhenTabEnabled(settingsPermissionTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings-permissions"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsPermissionTab));
+        waitForWebElement(By.id("settings-permissions"));
         return new ProjectPermissionsTab(getDriver());
     }
 
     public ProjectTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(settingsTranslationTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings-translation"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsTranslationTab));
+        waitForWebElement(By.id("settings-translation"));
         return new ProjectTranslationTab(getDriver());
     }
 
     public ProjectLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(settingsLanguagesTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings-languages"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsLanguagesTab));
+        waitForWebElement(By.id("settings-languages"));
         return new ProjectLanguagesTab(getDriver());
     }
 
     public ProjectAboutTab gotoSettingsAboutTab() {
         log.info("Click About settings sub-tab");
-        clickWhenTabEnabled(settingsAboutTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("settings-about"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsAboutTab));
+        waitForWebElement(By.id("settings-about"));
         return new ProjectAboutTab(getDriver());
     }
 
     public List<String> getContentAreaParagraphs() {
         log.info("Query Project info");
         List<String> paragraphTexts = new ArrayList<String>();
-        List<WebElement> paragraphs =
-                getDriver().findElement(By.id("project-info"))
+        List<WebElement> paragraphs = waitForWebElement(projectInfo)
                         .findElements(By.tagName("p"));
         for (WebElement element : paragraphs) {
             paragraphTexts.add(element.getText());
@@ -224,8 +141,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getHomepage() {
         log.info("Query Project homepage");
-        for (WebElement element : getDriver()
-                .findElement(By.id("project-info"))
+        for (WebElement element : waitForWebElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title"))
                     .getText().trim()
@@ -238,8 +154,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getGitUrl() {
         log.info("Query Project repo");
-        for (WebElement element : getDriver()
-                .findElement(By.id("project-info"))
+        for (WebElement element : waitForWebElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title")).getText()
                     .trim().equals("Repository:")) {

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
@@ -35,20 +35,18 @@ import java.util.List;
 @Slf4j
 public class ProjectMaintainersPage extends ProjectBasePage {
 
+    private By maintainersList = By.id("maintainers");
     public ProjectMaintainersPage(WebDriver driver) {
         super(driver);
     }
 
     public List<String> getMaintainers() {
         log.info("Query maintainers list");
-        List<WebElement> rows = getDriver()
-                .findElement(By.id("maintainers"))
-                .findElements(By.tagName("li"));
         List<String> names = new ArrayList<String>();
-        for (WebElement row : rows) {
+        for (WebElement row : waitForWebElement(maintainersList)
+                .findElements(By.tagName("li"))) {
             names.add(row.getText());
         }
-        System.out.print(names);
         return names;
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
@@ -42,11 +42,12 @@ import com.google.common.base.Predicate;
 @Slf4j
 public class ProjectVersionsPage extends ProjectBasePage {
 
-    @FindBy(id = "versions-more-actions")
-    private WebElement versionTabMoreAction;
-
-    @FindBy(id = "new-version-link")
-    private WebElement createNewVersion;
+    private By versionTabMoreAction = By.id("versions-more-actions");
+    private By createNewVersion = By.id("new-version-link");
+    private By versionCount = By.id("versionSearch:versionSearch-page-info");
+    private By versions = By.id("versions");
+    private By searchIcon = By.className("panel__search__button");
+    private By versionSearchInput = By.id("versionSearch__input");
 
     public ProjectVersionsPage(WebDriver driver) {
         super(driver);
@@ -96,9 +97,7 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public int getNumberOfDisplayedVersions() {
         log.info("Query number of displayed versions");
-        return Integer.parseInt(getDriver()
-                .findElement(By.id("versionSearch:versionSearch-page-info"))
-                .getText());
+        return Integer.parseInt(waitForWebElement(versionCount).getText());
     }
 
     public ProjectVersionsPage waitForDisplayedVersions(final int expected) {
@@ -115,20 +114,17 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public ProjectVersionsPage clickSearchIcon() {
         log.info("Click Search icon");
-        getDriver()
-                .findElement(By.id("versions"))
-                .findElement(By.className("panel__search__button"))
-                .click();
+        waitForWebElement(waitForElementExists(versions), searchIcon).click();
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectVersionsPage clearVersionSearch() {
         log.info("Clear version search field");
         int maxKeys = 500;
-        while (!getDriver().findElement(By.id("versionSearch__input"))
+        while (!waitForWebElement(versionSearchInput)
                 .getAttribute("value").isEmpty() && maxKeys > 0) {
-            getDriver().findElement(By.id("versionSearch__input"))
-                .sendKeys(Keys.BACK_SPACE);
+            waitForWebElement(versionSearchInput).sendKeys(Keys.BACK_SPACE);
+            maxKeys = maxKeys - 1;
         }
         if (maxKeys == 0) {
             log.warn("Exceeded max keypresses for clearing search bar");
@@ -138,8 +134,7 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public ProjectVersionsPage enterVersionSearch(String searchTerm) {
         log.info("Enter version search {}", searchTerm);
-        getDriver().findElement(By.id("versionSearch__input"))
-                .sendKeys(searchTerm);
+        waitForWebElement(versionSearchInput).sendKeys(searchTerm);
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -35,11 +34,15 @@ import java.util.List;
 
 @Slf4j
 public class ProjectsPage extends BasePage {
-    public static final int PROJECT_NAME_COLUMN = 0;
-    @FindBy(id = "main_body_content")
-    private WebElement mainContentDiv;
 
-    private By projectTableBy = By.id("main_content:form:projectList");
+    public static final int PROJECT_NAME_COLUMN = 0;
+
+    private By createProjectButton = By.id("createProjectLink");
+    private By mainContentDiv = By.id("main_body_content");
+    private By projectTable = By.id("main_content:form:projectList");
+    private By activeCheckBox = By.xpath("//*[@data-original-title='Filter active projects']");
+    private By readOnlyCheckBox = By.xpath("//*[@data-original-title='Filter read-only projects']");
+    private By obsoleteCheckBox = By.xpath("//*[@data-original-title='Filter obsolete projects']");
 
     public ProjectsPage(final WebDriver driver) {
         super(driver);
@@ -47,14 +50,7 @@ public class ProjectsPage extends BasePage {
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        WebElement createProjectActionLink =
-                waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                    @Override
-                    public WebElement apply(WebDriver driver) {
-                        return driver.findElement(By.id("createProjectLink"));
-                    }
-                });
-        createProjectActionLink.click();
+        waitForWebElement(createProjectButton).click();
         return new CreateProjectPage(getDriver());
     }
 
@@ -64,9 +60,9 @@ public class ProjectsPage extends BasePage {
         return refreshPageUntil(this, new Function<WebDriver, ProjectVersionsPage>() {
             @Override
             public ProjectVersionsPage apply(WebDriver input) {
-                WebElement table = input.findElement(projectTableBy);
+                WebElement table = input.findElement(projectTable);
                 log.info("current projects: {}", WebElementUtil
-                        .getColumnContents(input, projectTableBy,
+                        .getColumnContents(input, projectTable,
                                 PROJECT_NAME_COLUMN));
                 WebElement link = table.findElement(By.linkText(projectName));
                 link.click();
@@ -77,11 +73,12 @@ public class ProjectsPage extends BasePage {
 
     public List<String> getProjectNamesOnCurrentPage() {
         log.info("Query Projects list");
-        if (mainContentDiv.getText().contains("No project exists")) {
+        if (waitForWebElement(mainContentDiv)
+                .getText().contains("No project exists")) {
             return Collections.emptyList();
         }
 
-        return WebElementUtil.getColumnContents(getDriver(), projectTableBy,
+        return WebElementUtil.getColumnContents(getDriver(), projectTable,
                 PROJECT_NAME_COLUMN);
     }
 
@@ -106,8 +103,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setActiveFilterEnabled(boolean enabled) {
         log.info("Click to set Active filter enabled to {}", enabled);
-        WebElement activeCheckbox = getDriver()
-                .findElement(By.xpath("//*[@data-original-title='Filter active projects']"));
+        WebElement activeCheckbox = waitForWebElement(activeCheckBox);
         if (activeCheckbox.isSelected() != enabled) {
             activeCheckbox.click();
         }
@@ -116,8 +112,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setReadOnlyFilterEnabled(final boolean enabled) {
         log.info("Click to set Read-only filter enabled to {}", enabled);
-        WebElement readOnlyCheckbox = getDriver().findElement(
-                By.xpath("//*[@data-original-title='Filter read-only projects']"));
+        WebElement readOnlyCheckbox = waitForWebElement(readOnlyCheckBox);
         if (readOnlyCheckbox.isSelected() != enabled) {
             readOnlyCheckbox.click();
         }
@@ -126,10 +121,9 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setObsoleteFilterEnabled(boolean enabled) {
         log.info("Click to set Obsolete filter enabled to {}", enabled);
-        WebElement readOnlyCheckbox = getDriver().findElement(
-                By.xpath("//*[@data-original-title='Filter obsolete projects']"));
-        if (readOnlyCheckbox.isSelected() != enabled) {
-            readOnlyCheckbox.click();
+        WebElement obsoleteCheckbox = waitForWebElement(obsoleteCheckBox);
+        if (obsoleteCheckbox.isSelected() != enabled) {
+            obsoleteCheckbox.click();
         }
         return new ProjectsPage(getDriver());
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
@@ -36,33 +36,33 @@ import org.zanata.page.projects.ProjectBasePage;
 @Slf4j
 public class ProjectAboutTab extends ProjectBasePage {
 
+    private By aboutTextField = By.id("settings-about-form:homeContent");
+    private By saveButton = By.linkText("Save notes");
+
     public ProjectAboutTab(WebDriver driver) {
         super(driver);
     }
 
     public ProjectAboutTab enterAboutText(String aboutText) {
         log.info("Enter About text {}", aboutText);
-        getDriver().findElement(By.id("settings-about-form:homeContent"))
-                .sendKeys(aboutText);
+        waitForWebElement(aboutTextField).sendKeys(aboutText);
         return new ProjectAboutTab(getDriver());
     }
 
     public ProjectAboutTab clearAboutText() {
         log.info("Clear About textedit");
-        getDriver().findElement(By.id("settings-about-form:homeContent"))
-                .clear();
+        waitForWebElement(aboutTextField).clear();
         return new ProjectAboutTab(getDriver());
     }
 
     public String getAboutText() {
         log.info("Query About text");
-        return getDriver().findElement(By.id("settings-about-form:homeContent"))
-                .getText();
+        return waitForWebElement(aboutTextField).getText();
     }
 
     public ProjectAboutTab pressSave() {
         log.info("Click Save notes");
-        clickElement(By.linkText("Save notes"));
+        clickElement(saveButton);
         return new ProjectAboutTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.projects.ProjectBasePage;
 
 import java.util.HashMap;
@@ -39,23 +38,17 @@ import java.util.Map;
 @Slf4j
 public class ProjectGeneralTab extends ProjectBasePage {
 
-    @FindBy(id = "settings-general-form:slugField")
-    private WebElement projectIdField;
-
-    @FindBy(id = "settings-general-form:nameField:name")
-    private WebElement projectNameField;
-
-    @FindBy(id = "settings-general-form:descriptionField:description")
-    private WebElement descriptionField;
-
-    @FindBy(id = "project-types")
-    private WebElement projectTypeList;
-
-    @FindBy(id = "settings-general-form:homePageField:homePage")
-    private WebElement homepageField;
-
-    @FindBy(id = "settings-general-form:repoField:repo")
-    private WebElement repoField;
+    private By projectIdField = By.id("settings-general-form:slugField");
+    private By projectNameField = By.id("settings-general-form:nameField:name");
+    private By descriptionField = By.id("settings-general-form:descriptionField:description");
+    private By projectTypeList = By.id("project-types");
+    private By homepageField = By.id("settings-general-form:homePageField:homePage");
+    private By repoField = By.id("settings-general-form:repoField:repo");
+    private By archiveButton = By.id("settings-general-form:button-archive-project");
+    private By unarchiveButton = By.id("settings-general-form:button-unarchive-project");
+    private By lockProjectButton = By.id("settings-general-form:button-lock-project");
+    private By unlockProjectButton = By.id("settings-general-form:button-unlock-project");
+    private By updateButton = By.id("settings-general-form:button-update-settings");
 
     public ProjectGeneralTab(WebDriver driver) {
         super(driver);
@@ -67,7 +60,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      * @return project ID string
      */
     public String getProjectId() {
-        return projectIdField.getAttribute("value");
+        return waitForWebElement(projectIdField).getAttribute("value");
     }
 
     /**
@@ -78,8 +71,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        projectNameField.clear();
-        projectNameField.sendKeys(projectName);
+        waitForWebElement(projectNameField).clear();
+        waitForWebElement(projectNameField).sendKeys(projectName);
         defocus();
         return new ProjectGeneralTab(getDriver());
     }
@@ -91,8 +84,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        descriptionField.clear();
-        descriptionField.sendKeys(projectDescription);
+        waitForWebElement(descriptionField).clear();
+        waitForWebElement(descriptionField).sendKeys(projectDescription);
         defocus();
         return new ProjectGeneralTab(getDriver());
     }
@@ -133,8 +126,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
     // Return a map of project type to div container
     private Map<String, WebElement> getProjectTypes() {
         Map<String, WebElement> types = new HashMap<String, WebElement>();
-        for (WebElement projectTypeRow
-                : projectTypeList.findElements(By.tagName("li"))) {
+        for (WebElement projectTypeRow : waitForWebElement(projectTypeList)
+                .findElements(By.tagName("li"))) {
             String label = projectTypeRow.findElement(By.tagName("label"))
                     .getText();
             String meta = projectTypeRow.findElement(By.className("txt--meta"))
@@ -152,9 +145,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public boolean isArchiveButtonAvailable() {
         log.info("Query is Archive button displayed");
-        return getDriver().findElements(
-                By.id("settings-general-form:button-archive-project"))
-                .size() > 0;
+        return getDriver().findElements(archiveButton).size() > 0;
     }
 
     /**
@@ -163,7 +154,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab archiveProject() {
         log.info("Click Archive this project");
-        clickElement(By.id("settings-general-form:button-archive-project"));
+        clickElement(archiveButton);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -173,7 +164,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab unarchiveProject() {
         log.info("Click Unarchive this project");
-        clickElement(By.id("settings-general-form:button-unarchive-project"));
+        clickElement(unarchiveButton);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -183,7 +174,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab lockProject() {
         log.info("Click Make this project read only");
-        clickElement(By.id("settings-general-form:button-lock-project"));
+        clickElement(lockProjectButton);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -193,7 +184,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab unlockProject() {
         log.info("Click Make this project writable");
-        clickElement(By.id("settings-general-form:button-unlock-project"));
+        clickElement(unlockProjectButton);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -204,8 +195,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterHomePage(String homepage) {
         log.info("Enter home page {}", homepage);
-        homepageField.clear();
-        homepageField.sendKeys(homepage);
+        waitForWebElement(homepageField).clear();
+        waitForWebElement(homepageField).sendKeys(homepage);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -216,8 +207,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterRepository(String repo) {
         log.info("Enter repository {}", repo);
-        repoField.clear();
-        repoField.sendKeys(repo);
+        waitForWebElement(repoField).clear();
+        waitForWebElement(repoField).sendKeys(repo);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -227,14 +218,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab updateProject() {
         log.info("Click Update general settings");
-        scrollIntoView(updateButton());
-        clickAndCheckErrors(updateButton());
+        scrollIntoView(waitForWebElement(updateButton));
+        clickAndCheckErrors(waitForWebElement(updateButton));
         return new ProjectGeneralTab(getDriver());
     }
-
-    private WebElement updateButton() {
-        return getDriver().findElement(
-                By.id("settings-general-form:button-update-settings"));
-    }
-
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
@@ -28,10 +28,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.projects.ProjectBasePage;
 import org.zanata.util.WebElementUtil;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -43,8 +43,8 @@ import java.util.List;
 @Slf4j
 public class ProjectLanguagesTab extends ProjectBasePage {
 
-    @FindBy(id = "languageAutocomplete-autocomplete__input")
-    private WebElement addNewLanguageField;
+    private By addNewLanguageField = By.id("languageAutocomplete-autocomplete__input");
+    private By settingsLanguagesForm = By.id("settings-languages-form");
 
     public ProjectLanguagesTab(WebDriver driver) {
         super(driver);
@@ -57,18 +57,27 @@ public class ProjectLanguagesTab extends ProjectBasePage {
      */
     public List<String> getEnabledLocaleList() {
         log.info("Query enabled locales");
-        List<String> rows = Lists.transform(getEnabledLocaleListElement(),
+        return Lists.transform(getEnabledLocaleListElement(),
                 new Function<WebElement, String>() {
                         @Override
                         public String apply(WebElement li) {
                             return li.getText();
                         }
                 });
-        return rows;
+    }
+
+    public ProjectLanguagesTab expectEnabledLocaleListCount(final int count) {
+        waitForAMoment().until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return getEnabledLocaleList().size() == count;
+            }
+        });
+        return new ProjectLanguagesTab(getDriver());
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return getDriver().findElement(By.id("settings-languages-form"))
+        return waitForWebElement(settingsLanguagesForm)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("reveal--list-item"));
     }
@@ -78,8 +87,7 @@ public class ProjectLanguagesTab extends ProjectBasePage {
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver driver) {
-                return getDriver()
-                        .findElement(By.id("settings-languages-form"))
+                return driver.findElement(settingsLanguagesForm)
                         .findElement(By.className("list--slat"))
                         .isDisplayed();
             }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
@@ -40,6 +40,8 @@ import java.util.List;
 @Slf4j
 public class ProjectPermissionsTab extends ProjectBasePage {
 
+    private By maintainersForm = By.id("settings-permissions-form");
+
     public ProjectPermissionsTab(WebDriver driver) {
         super(driver);
     }
@@ -133,8 +135,7 @@ public class ProjectPermissionsTab extends ProjectBasePage {
     }
 
     private List<WebElement> getSettingsMaintainersElement() {
-        return getDriver()
-                .findElement(By.id("settings-permissions-form"))
+        return waitForWebElement(maintainersForm)
                 .findElement(By.id("maintainers-list"))
                 .findElements(By.className("reveal--list-item"));
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
@@ -20,7 +20,6 @@
  */
 package org.zanata.page.projects.projectsettings;
 
-import com.google.common.base.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -40,6 +39,9 @@ public class ProjectTranslationTab extends ProjectBasePage {
 
     private Map validationNames = getValidationMapping();
 
+    private By validationsList =
+            By.id("settings-translation-form:validation-list");
+
     public ProjectTranslationTab(WebDriver driver) {
         super(driver);
     }
@@ -48,12 +50,7 @@ public class ProjectTranslationTab extends ProjectBasePage {
         log.info("Query is {} validation level {}", optionName, level);
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-        WebElement option = waitForAMoment().until(new Function<WebDriver, WebElement>() {
-            @Override
-            public WebElement apply(WebDriver input) {
-                return getDriver().findElement(By.id(optionElementID));
-            }
-        });
+        WebElement option = waitForElementExists(By.id(optionElementID));
         return option.getAttribute("checked").equals("true");
     }
 
@@ -63,8 +60,7 @@ public class ProjectTranslationTab extends ProjectBasePage {
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        WebElement option =  getDriver().findElement(
-                By.id("settings-translation-form:validation-list"))
+        WebElement option =  waitForWebElement(validationsList)
                 .findElement(By.id(optionElementID));
 
         ((JavascriptExecutor) getDriver())

--- a/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
@@ -20,14 +20,12 @@
  */
 package org.zanata.page.projectversion;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.Constants;
 
@@ -41,17 +39,11 @@ public class CreateVersionPage extends BasePage {
             "must start and end with letter or number, and contain only " +
                     "letters, numbers, periods, underscores and hyphens.";
 
-    @FindBy(id = "create-version-form:project-type")
-    private WebElement projectTypeSelection;
-
-    @FindBy(id = "create-version-form:statusField:status")
-    private WebElement statusSelection;
-
-    @FindBy(id = "create-version-form:button-create")
-    private WebElement saveButton;
-
-    @FindBy(id = "create-version-form:copy-from-version")
-    private WebElement copyFromPreviousVersionChk;
+    private By projectTypeSelection = By.id("create-version-form:project-type");
+    private By statusSelection = By.id("create-version-form:statusField:status");
+    private By saveButton = By.id("create-version-form:button-create");
+    private By copyFromPreviousVersionChk = By.id("create-version-form:copy-from-version");
+    private By projectTypesList = By.id("create-version-form:project-type-list");
 
     private static final Map<String, String> projectTypeOptions =
             Constants.projectTypeOptions();
@@ -83,27 +75,20 @@ public class CreateVersionPage extends BasePage {
 
     public CreateVersionPage clickCopyFromVersion() {
         log.info("Click Copy From Previous checkbox");
-        copyFromPreviousVersionChk.click();
-        waitForAMoment().until(new Function<WebDriver, WebElement>() {
-            @Override
-            public WebElement apply(WebDriver driver) {
-                return getDriver().findElement(By.id(
-                        "create-version-form:project-type-list"));
-            }
-        });
-        return this;
+        waitForWebElement(copyFromPreviousVersionChk).click();
+        waitForWebElement(projectTypesList);
+        return new CreateVersionPage(getDriver());
     }
 
     private WebElement getVersionIdField() {
         log.info("Query Version ID");
-        return getDriver().findElement(
-                By.id("create-version-form:slugField:slug"));
+        return waitForWebElement(By.id("create-version-form:slugField:slug"));
     }
 
     public CreateVersionPage selectProjectType(String projectType) {
         log.info("Click project type {}", projectType);
-        List<WebElement> projectTypes =
-                projectTypeSelection.findElements(By.tagName("li"));
+        List<WebElement> projectTypes = waitForWebElement(projectTypeSelection)
+                .findElements(By.tagName("li"));
         for (WebElement projectTypeLi : projectTypes) {
             if (projectTypeLi.findElement(By.xpath(".//div/label")).getText()
                     .startsWith(projectType)) {
@@ -111,18 +96,18 @@ public class CreateVersionPage extends BasePage {
                 break;
             }
         }
-        return this;
+        return new CreateVersionPage(getDriver());
     }
 
     public VersionLanguagesPage saveVersion() {
         log.info("Click Save");
-        clickAndCheckErrors(saveButton);
+        clickAndCheckErrors(waitForWebElement(saveButton));
         return new VersionLanguagesPage(getDriver());
     }
 
     public CreateVersionPage saveExpectingError() {
         log.info("Click Save");
-        saveButton.click();
+        waitForWebElement(saveButton).click();
         return new CreateVersionPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
@@ -21,9 +21,7 @@
 package org.zanata.page.projectversion;
 
 import org.openqa.selenium.*;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
-import com.google.common.base.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
 import org.zanata.page.projects.ProjectVersionsPage;
@@ -35,26 +33,15 @@ import org.zanata.page.projectversion.versionsettings.VersionTranslationTab;
 @Slf4j
 public class VersionBasePage extends BasePage {
 
-    @FindBy(id = "settings_tab")
-    private WebElement settingsTab;
-
-    @FindBy(id = "settings-general_tab")
-    private WebElement settingsGeneralTab;
-
-    @FindBy(id = "settings-languages_tab")
-    private WebElement settingsLanguagesTab;
-
-    @FindBy(id = "settings-documents_tab")
-    private WebElement settingsDocumentsTab;
-
-    @FindBy(id = "settings-translation_tab")
-    private WebElement settingsTranslationTab;
-
-    @FindBy(id = "documents")
-    private WebElement documentsTab;
-
-    @FindBy(id = "languages")
-    private WebElement languageTab;
+    private By settingsTab = By.id("settings_tab");
+    private By settingsGeneralTab = By.id("settings-general_tab");
+    private By settingsLanguagesTab = By.id("settings-languages_tab");
+    private By settingsDocumentsTab = By.id("settings-documents_tab");
+    private By settingsTranslationTab = By.id("settings-translation_tab");
+    private By documentsTab = By.id("documents");
+    private By languageTab = By.id("languages");
+    private By versionInfo = By.id("version-info");
+    private By versionPage = By.id("version-page");
 
     public VersionBasePage(final WebDriver driver) {
         super(driver);
@@ -62,128 +49,65 @@ public class VersionBasePage extends BasePage {
 
     public String getProjectVersionName() {
         log.info("Query Version name");
-        return getDriver()
-                .findElement(By.id("version-info"))
+        return waitForWebElement(versionInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage clickProjectLink(String projectName) {
         log.info("Click Project link");
-        getDriver().findElement(By.id("version-page"))
+        waitForWebElement(versionPage)
                 .findElement(By.linkText(projectName))
                 .click();
         return new ProjectVersionsPage(getDriver());
     }
 
-    public boolean settingsTabIsDisplayed() {
-        return settingsTab.isDisplayed();
-    }
-
-    public void reloadUntilSettingsIsDisplayed() {
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return settingsTab.isDisplayed();
-            }
-        });
-    }
-
     public VersionDocumentsPage gotoDocumentTab() {
         log.info("Click Documents tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("documents_tab")));
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("documents"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(By.id("documents_tab")));
+        waitForWebElement(By.id("documents"));
         return new VersionDocumentsPage(getDriver());
     }
 
     public VersionLanguagesPage gotoLanguageTab() {
         log.info("Click Languages tab");
-        clickWhenTabEnabled(getDriver().findElement(By.id("languages_tab")));
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("languages"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(By.id("languages_tab")));
+        waitForWebElement(By.id("languages"));
         return new VersionLanguagesPage(getDriver());
     }
 
     public VersionBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
         slightPause();
-        clickWhenTabEnabled(getDriver().findElement(By.id("settings_tab")));
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("settings"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(By.id("settings_tab")));
+        waitForWebElement(By.id("settings"));
         return new VersionBasePage(getDriver());
     }
 
     public VersionGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(settingsGeneralTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("settings-general_form"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsGeneralTab));
+        waitForWebElement(By.id("settings-general_form"));
         return new VersionGeneralTab(getDriver());
     }
 
     public VersionLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(settingsLanguagesTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("settings-languages-form"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsLanguagesTab));
+        waitForWebElement(By.id("settings-languages-form"));
         return new VersionLanguagesTab(getDriver());
     }
 
     public VersionDocumentsTab gotoSettingsDocumentsTab() {
         log.info("Click Documents settings sub-tab");
-        clickWhenTabEnabled(settingsDocumentsTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("settings-document_form"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsDocumentsTab));
+        waitForWebElement(By.id("settings-document_form"));
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(settingsTranslationTab);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("settings-translation-review-form"))
-                        .isDisplayed();
-            }
-        });
+        clickWhenTabEnabled(waitForWebElement(settingsTranslationTab));
+        waitForWebElement(By.id("settings-translation-review-form"));
         return new VersionTranslationTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.page.projectversion;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
@@ -53,40 +54,30 @@ public class VersionDocumentsPage extends VersionBasePage {
 
     public boolean sourceDocumentsContains(String document) {
         log.info("Query source documents contains {}", document);
-        List<WebElement> documentList = getDocumentsTabDocumentList();
-        for (final WebElement tableRow : documentList) {
-            if (tableRow.findElement(By.className("list__title")).getText()
-                    .contains(document)) {
-                return true;
-            }
-        }
-        return false;
+        return getSourceDocumentNames().contains(document);
     }
 
     public List<String> getSourceDocumentNames() {
         log.info("Query source documents list");
-        List<String> filenames = new ArrayList<String>();
-        for (WebElement element : getDocumentsTabDocumentList()) {
-            filenames.add(element.findElement(By.className("list__title"))
-                    .getText());
-        }
-        return filenames;
+        // getText often falls into a UI change
+        return waitForAMoment().until(new Function<WebDriver, List<String>>() {
+            @Override
+            public List<String> apply(WebDriver input) {
+                List<String> fileNames = new ArrayList<String>();
+                for (WebElement element : getDocumentsTabDocumentList()) {
+                    fileNames.add(waitForWebElement(element,
+                            By.className("list__title"))
+                            .getText());
+                }
+                return fileNames;
+            }
+        });
     }
 
     private List<WebElement> getDocumentsTabDocumentList() {
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(By.id("documents-document_list"))
-                        .isDisplayed();
-            }
-        });
-
-        List<WebElement> rows =
-                getDriver().findElement(By.id("documents-document_list"))
+        slightPause();
+        return waitForWebElement(By.id("documents-document_list"))
                         .findElements(By.xpath("./li"));
-        return rows;
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
@@ -45,15 +45,8 @@ public class VersionLanguagesPage extends VersionBasePage {
     }
 
     private List<WebElement> getLanguageTabLocaleList() {
-        WebElement languageList =
-                waitForAMoment().until(new Function<WebDriver, WebElement>() {
-                    @Override
-                    public WebElement apply(WebDriver input) {
-                        return getDriver().findElement(
-                                By.id("languages-language_list"));
-                    }
-                });
-        return languageList.findElements(By.tagName("li"));
+        return waitForWebElement(By.id("languages-language_list"))
+                .findElements(By.tagName("li"));
     }
 
     public EditorPage translate(final String locale, final String docName) {
@@ -103,18 +96,9 @@ public class VersionLanguagesPage extends VersionBasePage {
 
     private List<WebElement> getVersionTabDocumentList() {
         log.info("Query documents list");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                        .findElement(
-                                By.xpath("//form[@id='languages-document_list']/ul[@class='list--stats']"))
-                        .isDisplayed();
-            }
-        });
-        return getDriver()
-                .findElements(
-                        By.xpath("//form[@id='languages-document_list']/ul[@class='list--stats']/li"));
+        return waitForWebElement(
+                By.xpath("//form[@id='languages-document_list']/ul[@class='list--stats']"))
+                .findElements(By.tagName("li"));
     }
 
     public String getStatisticsForLocale(final String localeId) {
@@ -128,14 +112,13 @@ public class VersionLanguagesPage extends VersionBasePage {
 
                 List<WebElement> localeList = getLanguageTabLocaleList();
                 for (WebElement locale : localeList) {
-                    if (locale
-                            .findElement(
-                                    By.xpath(".//a/div/div/span[@class='list__item__meta']"))
-                            .getText().equals(localeId)) {
-                        figure =
-                                locale.findElement(
-                                        By.xpath(".//a/div/div[2]/span/span[@class='stats__figure']"))
-                                        .getText();
+                    if (locale.findElement(
+                            By.xpath(".//a/div/div/span[@class='list__item__meta']"))
+                            .getText()
+                            .equals(localeId)) {
+                        figure = locale.findElement(
+                                By.xpath(".//a/div/div[2]/span/span[@class='stats__figure']"))
+                                .getText();
                         break;
                     }
                 }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
@@ -22,13 +22,21 @@ public class VersionDocumentsTab extends VersionBasePage {
     public static final String UNSUPPORTED_FILETYPE =
             " is not a supported file type.";
 
+    private By uploadButton = By.id("file-upload-component-toggle-button");
+    private By startUploadButton = By.id("file-upload-component-start-upload");
+    private By cancelUploadButton = By.id("file-upload-component-cancel-upload");
+    private By fileUploadInput = By.id("file-upload-component-file-input");
+    private By fileUploadDone = By.id("file-upload-component-done-upload");
+    private By filesListPanel = By.className("js-files-panel");
+    private By fileUploadPanel = By.id("file-upload-component");
+
     public VersionDocumentsTab(WebDriver driver) {
         super(driver);
     }
 
     public VersionDocumentsTab pressUploadFileButton() {
         log.info("Click Upload file button");
-        clickLinkAfterAnimation(By.id("file-upload-component-toggle-button"));
+        clickLinkAfterAnimation(waitForWebElement(uploadButton));
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -39,16 +47,12 @@ public class VersionDocumentsTab extends VersionBasePage {
      */
     public boolean canSubmitDocument() {
         log.info("Query can start upload");
-        return getDriver().findElement(
-                By.id("file-upload-component-start-upload"))
-                .isEnabled();
+        return waitForElementExists(startUploadButton).isEnabled();
     }
 
     public VersionDocumentsTab cancelUpload() {
         log.info("Click Cancel");
-        getDriver()
-                .findElement(By.id("file-upload-component-cancel-upload"))
-                .click();
+        waitForWebElement(cancelUploadButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply( WebDriver input) {
@@ -69,42 +73,21 @@ public class VersionDocumentsTab extends VersionBasePage {
                         "arguments[0].style.height = '1px'; " +
                         "arguments[0].style.width = '1px'; " +
                         "arguments[0].style.opacity = 1",
-                        getDriver().findElement(
-                                By.id("file-upload-component-file-input")));
+                        waitForElementExists(fileUploadInput));
 
-        getDriver().findElement(
-                By.id("file-upload-component-file-input"))
-                .sendKeys(filePath);
+        waitForWebElement(fileUploadInput).sendKeys(filePath);
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab submitUpload() {
         log.info("Click Submit upload");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(
-                        By.id("file-upload-component-start-upload"))
-                        .isEnabled();
-            }
-        });
-        getDriver().findElement(
-                By.id("file-upload-component-start-upload")).click();
+        waitForWebElement(startUploadButton).click();
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab clickUploadDone() {
         log.info("Click upload Done button");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver()
-                .findElement(By.id("file-upload-component-done-upload"))
-                .isEnabled();
-            }
-        });
-        getDriver().findElement(By.id("file-upload-component-done-upload"))
-                .click();
+        waitForWebElement(fileUploadDone).click();
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -114,8 +97,8 @@ public class VersionDocumentsTab extends VersionBasePage {
                 .until(new Function<WebDriver, List<String>>() {
                     @Override
                     public List<String> apply(WebDriver input) {
-                        List<WebElement> elements = getDriver()
-                                .findElement(By.id("settings-document_form"))
+                        List<WebElement> elements = waitForElementExists(
+                                By.id("settings-document_form"))
                                 .findElement(By.tagName("ul"))
                                 .findElements(By.xpath(".//li/label[@class='" +
                                         "form__checkbox__label']"));
@@ -157,21 +140,13 @@ public class VersionDocumentsTab extends VersionBasePage {
     }
 
     private List<WebElement> getUploadListElements() {
-        return getDriver().findElement(By.className("js-files-panel"))
-                .findElement(By.tagName("ul"))
+        return waitForWebElement(filesListPanel).findElement(By.tagName("ul"))
                 .findElements(By.tagName("li"));
     }
 
     public String getUploadError() {
         log.info("Query upload error message");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getDriver().findElement(By.id("file-upload-component"))
-                        .findElement(By.className("message--danger")).isDisplayed();
-            }
-        });
-        return getDriver().findElement(By.id("file-upload-component"))
-                .findElement(By.className("message--danger")).getText();
+        return waitForWebElement(waitForElementExists(fileUploadPanel),
+                By.className("message--danger")).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.projectversion.VersionBasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -43,8 +42,8 @@ import java.util.List;
 @Slf4j
 public class VersionLanguagesTab extends VersionBasePage {
 
-    @FindBy(id = "languageAutocomplete-autocomplete__input")
-    private WebElement addNewLanguageField;
+    private By addNewLanguageField = By.id("languageAutocomplete-autocomplete__input");
+    private By languagesSettingForm = By.id("settings-languages-form");
 
     public VersionLanguagesTab(WebDriver driver) {
         super(driver);
@@ -57,8 +56,8 @@ public class VersionLanguagesTab extends VersionBasePage {
      */
     public VersionLanguagesTab clickInheritCheckbox() {
         log.info("Click Inherit check box");
-        getDriver().findElement(By.id("settings-languages-form"))
-                .findElement(By.className("form__checkbox"))
+        waitForWebElement(waitForWebElement(languagesSettingForm),
+                By.className("form__checkbox"))
                 .click();
         return new VersionLanguagesTab(getDriver());
     }
@@ -68,8 +67,7 @@ public class VersionLanguagesTab extends VersionBasePage {
         waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
             public Boolean apply(WebDriver driver) {
-                return getDriver()
-                        .findElement(By.id("settings-languages-form"))
+                return waitForWebElement(languagesSettingForm)
                         .findElement(By.className("list--slat"))
                         .isDisplayed();
             }
@@ -84,29 +82,30 @@ public class VersionLanguagesTab extends VersionBasePage {
      */
     public List<String> getEnabledLocaleList() {
         log.info("Query enabled locales list");
-        List<String> rows =Lists.transform(getEnabledLocaleListElement(),
+        return Lists.transform(getEnabledLocaleListElement(),
                 new Function<WebElement, String>() {
                     @Override
                     public String apply(WebElement li) {
                         return li.getText();
                     }
                 });
-        return rows;
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return getDriver().findElement(By.id("settings-languages-form"))
+        return waitForWebElement(languagesSettingForm)
                 .findElements(By.xpath(".//ul/li[@class='reveal--list-item']"));
     }
 
-    public void waitForLanguagesContains(String language) {
+    public VersionLanguagesTab waitForLanguagesContains(String language) {
         log.info("Wait for languages contains {}", language);
         waitForLanguageEntryExpected(language, true);
+        return new VersionLanguagesTab(getDriver());
     }
 
-    public void waitForLanguagesNotContains(String language) {
+    public VersionLanguagesTab waitForLanguagesNotContains(String language) {
         log.info("Wait for languages does not contain {}", language);
         waitForLanguageEntryExpected(language, false);
+        return new VersionLanguagesTab(getDriver());
     }
 
     private void waitForLanguageEntryExpected(final String language,
@@ -165,6 +164,7 @@ public class VersionLanguagesTab extends VersionBasePage {
 
                 for (WebElement searchResult : searchResults) {
                     if (searchResult.getText().contains(localeId)) {
+                        slightPause();
                         searchResult.click();
                         return true;
                     }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
@@ -27,8 +27,7 @@ public class VersionTranslationTab extends VersionBasePage {
         String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        return getDriver()
-                .findElement(By.id(optionElementID))
+        return waitForElementExists(By.id(optionElementID))
                 .getAttribute("checked")
                 .equals("true");
     }
@@ -39,7 +38,7 @@ public class VersionTranslationTab extends VersionBasePage {
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        WebElement option =  getDriver().findElement(
+        WebElement option = waitForWebElement(
                 By.id("settings-translation-validation-form"))
                 .findElement(By.id(optionElementID));
 

--- a/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
@@ -1,9 +1,8 @@
 package org.zanata.page.utility;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.util.WebElementUtil;
 
@@ -13,14 +12,10 @@ import org.zanata.util.WebElementUtil;
  */
 @Slf4j
 public class ContactAdminFormPage extends BasePage {
-    @FindBy(id = "contactAdminForm:subjectField:subject")
-    private WebElement subjectField;
 
-    @FindBy(id = "contactAdminForm:messageField:message")
-    private WebElement messageField;
-
-    @FindBy(id = "contactAdminForm:send")
-    private WebElement sendButton;
+    private By subjectField = By.id("contactAdminForm:subjectField:subject");
+    private By messageField = By.id("contactAdminForm:messageField:message");
+    private By sendButton = By.id("contactAdminForm:send");
 
     public ContactAdminFormPage(WebDriver driver) {
         super(driver);
@@ -28,21 +23,23 @@ public class ContactAdminFormPage extends BasePage {
 
     public ContactAdminFormPage inputSubject(String subject) {
         log.info("Enter subject {}", subject);
-        subjectField.clear();
-        subjectField.sendKeys(subject);
+        waitForWebElement(subjectField).clear();
+        waitForWebElement(subjectField).sendKeys(subject);
         return new ContactAdminFormPage(getDriver());
     }
 
     public ContactAdminFormPage inputMessage(String message) {
         log.info("Enter message {}", message);
-        WebElementUtil
-                .setRichTextEditorContent(getDriver(), messageField, message);
+        WebElementUtil.setRichTextEditorContent(
+                getDriver(),
+                waitForWebElement(messageField),
+                message);
         return new ContactAdminFormPage(getDriver());
     }
 
     public HelpPage send() {
         log.info("Click Send");
-        sendButton.click();
+        waitForWebElement(sendButton).click();
         return new HelpPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
@@ -1,9 +1,8 @@
 package org.zanata.page.utility;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 
 /**
@@ -12,8 +11,8 @@ import org.zanata.page.BasePage;
  */
 @Slf4j
 public class HelpPage extends BasePage {
-    @FindBy(linkText = "Contact Admin")
-    private WebElement contactAdminLink;
+
+    private By contactAdminLink = By.linkText("Contact Admin");
 
     public HelpPage(WebDriver driver) {
         super(driver);
@@ -21,7 +20,7 @@ public class HelpPage extends BasePage {
 
     public ContactAdminFormPage clickContactAdmin() {
         log.info("Click Contact Admin button");
-        contactAdminLink.click();
+        waitForWebElement(contactAdminLink).click();
         return new ContactAdminFormPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
@@ -23,8 +23,6 @@ package org.zanata.page.utility;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.administration.EditHomeCodePage;
 import org.zanata.page.administration.EditHomeContentPage;
@@ -36,8 +34,9 @@ public class HomePage extends BasePage {
             "You will soon receive an email " +
             "with a link to activate your account.";
 
-    @FindBy(id = "main_body_content")
-    private WebElement mainBodyContent;
+    private By mainBodyContent = By.id("main_body_content");
+    private By editPageContentButton = By.linkText("Edit Page Content");
+    private By editPageCodeButton = By.linkText("Edit Page Code");
 
     public HomePage(final WebDriver driver) {
         super(driver);
@@ -45,18 +44,18 @@ public class HomePage extends BasePage {
 
     public EditHomeContentPage goToEditPageContent() {
         log.info("Click Edit Page Content");
-        getDriver().findElement(By.linkText("Edit Page Content")).click();
+        waitForWebElement(editPageContentButton).click();
         return new EditHomeContentPage(getDriver());
     }
 
     public EditHomeCodePage goToEditPageCode() {
         log.info("Click Edit Page Code");
-        getDriver().findElement(By.linkText("Edit Page Code")).click();
+        waitForWebElement(editPageCodeButton).click();
         return new EditHomeCodePage(getDriver());
     }
 
     public String getMainBodyContent() {
         log.info("Query homepage content");
-        return mainBodyContent.getText();
+        return waitForWebElement(mainBodyContent).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
+++ b/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
@@ -28,7 +28,7 @@ public class DocumentsViewPage extends BasePage {
 
     public EditorPage clickDocumentLink(String path, String name) {
         String id = "gwt-debug-docLabel-" + path + name;
-        getDriver().findElement(By.id(id)).click();
+        waitForWebElement(By.id(id)).click();
         return new EditorPage(getDriver());
     }
 

--- a/functional-test/src/test/java/org/zanata/feature/dashboard/DashboardTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/dashboard/DashboardTest.java
@@ -92,6 +92,7 @@ public class DashboardTest extends ZanataTestCase {
 
     private boolean activityListExpands() throws Exception {
         DashboardActivityTab activityTab = dashboard.gotoActivityTab();
+        assertThat(activityTab.isMoreActivity());
         assertThat(activityTab.getMyActivityList()).isNotEmpty();
         return activityTab.clickMoreActivity();
     }

--- a/functional-test/src/test/java/org/zanata/feature/language/JoinLanguageTeamTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/language/JoinLanguageTeamTest.java
@@ -20,12 +20,14 @@
  */
 package org.zanata.feature.language;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.zanata.feature.Feature;
 import org.zanata.feature.testharness.ZanataTestCase;
 import org.zanata.feature.testharness.TestPlan.DetailedTest;
 import org.zanata.page.administration.ManageLanguageTeamMemberPage;
+import org.zanata.util.SampleProjectRule;
 import org.zanata.workflow.LoginWorkFlow;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +38,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Category(DetailedTest.class)
 public class JoinLanguageTeamTest extends ZanataTestCase {
+
+    @ClassRule
+    public static SampleProjectRule sampleProjectRule = new SampleProjectRule();
 
     @Feature(summary = "The administrator can add a member to a language team",
             tcmsTestPlanIds = 5316, tcmsTestCaseIds = 181703)

--- a/functional-test/src/test/java/org/zanata/feature/project/EditProjectLanguagesTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/EditProjectLanguagesTest.java
@@ -55,9 +55,8 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .goToProjects()
                 .goToProject("about fedora")
                 .gotoSettingsTab()
-                .gotoSettingsLanguagesTab();
-
-        projectLanguagesTab.slightPause();
+                .gotoSettingsLanguagesTab()
+                .expectEnabledLocaleListCount(3);
 
         List<String> enabledLocaleList = projectLanguagesTab
                 .getEnabledLocaleList();
@@ -74,11 +73,10 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
         projectLanguagesTab = projectLanguagesTab
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab()
-                .removeLocale("pl");
+                .removeLocale("pl")
+                .expectEnabledLocaleListCount(2);
 
         enabledLocaleList = projectLanguagesTab
-                .gotoSettingsTab()
-                .gotoSettingsLanguagesTab()
                 .getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
@@ -91,6 +89,7 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .gotoSettingsLanguagesTab()
                 .enterSearchLanguage("en-US")
                 .addLanguage("English (United States)[en-US]")
+                .expectEnabledLocaleListCount(3)
                 .getEnabledLocaleList();
 
         Assertions.assertThat(enabledLocaleList)

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
@@ -62,7 +62,6 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
             "for a project version",
             tcmsTestPlanIds = 5316, tcmsTestCaseIds = 0)
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
-    @Ignore("Behaviour changed - needs review")
     public void changeVersionLanguages() throws Exception {
         assertThat(new LoginWorkFlow()
                 .signIn("admin", "admin")
@@ -81,40 +80,31 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
         List<String> enabledLocaleList = versionLanguagesTab
                 .getEnabledLocaleList();
 
-        assertThat(enabledLocaleList)
-                .contains("French[fr]", "Hindi[hi]", "Polish[pl]")
-                .as("The enabled list contains three languages");
-
-        assertThat(enabledLocaleList)
-                .doesNotContain("English (United States)[en-US]")
-                .as("The enabled list does not contain " +
-                        "'English (United States)[en-US]'");
-
-        versionLanguagesTab = versionLanguagesTab.removeLocale("pl");
-        versionLanguagesTab.waitForLanguagesNotContains(
-                "English (United States)[en-US]");
-        versionLanguagesTab.waitForLanguagesNotContains("Polish[pl]");
-        enabledLocaleList = versionLanguagesTab.getEnabledLocaleList();
-
-        assertThat(enabledLocaleList)
-                .doesNotContain("English (United States)[en-US]")
-                .doesNotContain("Polish[pl]")
-                .as("The enabled list does not contain 'US English' or Polish");
+        assertThat(enabledLocaleList.isEmpty())
+                .as("The enabled list contains no languages");
 
         versionLanguagesTab = versionLanguagesTab
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab()
                 .enterSearchLanguage("en-US")
                 .addLocale("English (United States)[en-US]");
+        versionLanguagesTab.expectNotification("Language \"English " +
+                "(United States)\" has been added to version.");
+        versionLanguagesTab = versionLanguagesTab
+                .waitForLanguagesContains("English (United States)[en-US]");
 
-        versionLanguagesTab.waitForLanguagesContains(
-                "English (United States)[en-US]");
+        versionLanguagesTab = versionLanguagesTab
+                .enterSearchLanguage("fr")
+                .addLocale("French[fr]");
+        versionLanguagesTab.expectNotification("Language \"French\" has " +
+                "been added to version.");
+        versionLanguagesTab = versionLanguagesTab
+                .waitForLanguagesContains("French[fr]");
+
         enabledLocaleList = versionLanguagesTab.getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
-                .contains("English (United States)[en-US]",
-                        "French[fr]",
-                        "Hindi[hi]")
-                .as("Three languages are available to translate");
+                .contains("English (United States)[en-US]", "French[fr]")
+                .as("Two languages are available to translate");
     }
 }


### PR DESCRIPTION
In yearning for stability, we want to always ensure the elements are
there before we attempt to interact with them. There are two levels of
this:
- The element exists and its attributes can be read
- The element is displayed and enabled, ready for interaction.

As much as possible, this change replaces the unchecked interactions
with search and wait, and removes the existing inline waitFor.untils
that were introduced in specific problem areas.
