### PR TITLE
Use example.com instead of test.com for tests

### DIFF
--- a/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
@@ -65,7 +65,7 @@ public class RegisterTest extends ZanataTestCase {
 
         // Conflicting fields - must be set for each test function to avoid
         // "not available" errors
-        fields.put("email", "test@test.com");
+        fields.put("email", "test@example.com");
         fields.put("username", "testusername");
         fields.put("name", "test");
         fields.put("password", "testpassword");
@@ -98,7 +98,7 @@ public class RegisterTest extends ZanataTestCase {
             tcmsTestPlanIds = 5316, tcmsTestCaseIds = 0)
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
     public void usernameLengthValidation() throws Exception {
-        fields.put("email", "length.test@test.com");
+        fields.put("email", "length.test@example.com");
         RegisterPage registerPage = homePage.goToRegistration();
 
         fields.put("username", "bo");

--- a/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
@@ -197,7 +197,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsGeneral()
                 .enterHomePage("http://www.example.com")
-                .enterRepository("http://www.test.com")
+                .enterRepository("http://git.example.com")
                 .updateProject()
                 .goToProjects()
                 .goToProject("about fedora");
@@ -207,7 +207,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .as("The homepage is correct");
 
         assertThat(projectVersionsPage.getGitUrl())
-                .isEqualTo("http://www.test.com")
+                .isEqualTo("http://git.example.com")
                 .as("The git url is correct");
     }
 }

--- a/zanata-war/src/test/java/org/zanata/rest/editor/dto/UserTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/editor/dto/UserTest.java
@@ -18,13 +18,13 @@ public class UserTest {
     @Test
     public void testJsonOutput() throws IOException {
         String json =
-            "{\n" + "    \"username\" : \"_username\",\n" + "    \"email\" : \"test@test.com\",\n " +
+            "{\n" + "    \"username\" : \"_username\",\n" + "    \"email\" : \"test@example.com\",\n " +
                 "\"name\" : \"testUser\",\n   \"gravatarHash\" : \"hash\"" +
                 "\n}";
 
         User user= om.readValue(json, User.class);
 
-        User expected = new User("_username", "test@test.com", "testUser", "hash");
+        User expected = new User("_username", "test@example.com", "testUser", "hash");
 
         assertEquals(user, expected);
     }

--- a/zanata-war/src/test/java/org/zanata/search/FilterConstraintToQueryJpaTest.java
+++ b/zanata-war/src/test/java/org/zanata/search/FilterConstraintToQueryJpaTest.java
@@ -73,7 +73,7 @@ public class FilterConstraintToQueryJpaTest extends ZanataJpaTest {
                         .reuseEntity(hLocale).build()
                         .makeAndPersist(getEm(), HDocument.class);
         HProject hProject = hDocument.getProjectIteration().getProject();
-        hProject.getWebHooks().add(new WebHook(hProject, "http://www.test.com"));
+        hProject.getWebHooks().add(new WebHook(hProject, "http://www.test.example.com"));
         documentId = new DocumentId(hDocument.getId(), hDocument.getDocId());
 
         HTextFlowBuilder baseBuilder =

--- a/zanata-war/src/test/java/org/zanata/service/impl/DocumentServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/DocumentServiceImplTest.java
@@ -89,8 +89,8 @@ public class DocumentServiceImplTest {
         HDocument document = Mockito.mock(HDocument.class);
 
         webHooks = Lists.newArrayList();
-        webHooks.add(new WebHook(project, "http://test.com"));
-        webHooks.add(new WebHook(project, "http://test1.com"));
+        webHooks.add(new WebHook(project, "http://test.example.com"));
+        webHooks.add(new WebHook(project, "http://test1.example.com"));
 
         when(projectIterationDAO.findById(versionId)).thenReturn(version);
         when(version.getProject()).thenReturn(project);


### PR DESCRIPTION
I noticed that some functional tests had ERROR logs which suggested that they were trying to contact test.com and test1.com, so I have replaced such references with example.com, which is meant for such purposes: http://www.iana.org/domains/reserved
