### PR TITLE
check database compatibility at start up

### DIFF
--- a/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
+++ b/zanata-war/src/main/java/org/zanata/ApplicationConfiguration.java
@@ -266,10 +266,10 @@ public class ApplicationConfiguration implements Serializable {
     public List<String> getAdminEmail() {
         String s = databaseBackedConfig.getAdminEmailAddress();
         if (s == null || s.trim().length() == 0) {
-            return new ArrayList<String>();
+            return new ArrayList<>();
         }
         String[] ss = s.trim().split("\\s*,\\s*");
-        return new ArrayList<String>(Arrays.asList(ss));
+        return new ArrayList<>(Arrays.asList(ss));
     }
 
     public String getFromEmailAddr() {
@@ -346,11 +346,7 @@ public class ApplicationConfiguration implements Serializable {
     public boolean isEmailLogAppenderEnabled() {
         String strVal = databaseBackedConfig.getShouldLogEvents();
 
-        if (strVal == null) {
-            return false;
-        } else {
-            return Boolean.parseBoolean(strVal);
-        }
+        return strVal != null && Boolean.parseBoolean(strVal);
     }
 
     public List<String> getLogDestinationEmails() {

--- a/zanata-war/src/main/java/org/zanata/ZanataInit.java
+++ b/zanata-war/src/main/java/org/zanata/ZanataInit.java
@@ -67,6 +67,8 @@ import org.jboss.seam.core.Events;
 import org.zanata.exception.ZanataInitializationException;
 import org.zanata.rest.dto.VersionInfo;
 import org.zanata.util.VersionUtility;
+import org.zanata.util.ZanataDatabaseDriverMetadata;
+import org.zanata.util.ZanataDatabaseMetaData;
 
 /**
  * This class handles various tasks at startup.  It disables warnings for a
@@ -117,11 +119,8 @@ public class ZanataInit {
         Attributes atts = null;
         if (manifestFile.canRead()) {
             Manifest mf = new Manifest();
-            final FileInputStream fis = new FileInputStream(manifestFile);
-            try {
+            try (FileInputStream fis = new FileInputStream(manifestFile)) {
                 mf.read(fis);
-            } finally {
-                fis.close();
             }
             atts = mf.getMainAttributes();
         }
@@ -426,6 +425,8 @@ public class ZanataInit {
         if (appServerVersion.eapVersion.isPresent()) {
             log.info("  EAP version: " + appServerVersion.eapVersion.get());
         }
+        log.info("  Database: {}", ZanataDatabaseMetaData.instance);
+        log.info("  JDBC Driver: {}", ZanataDatabaseDriverMetadata.instance);
         log.info("  AS version: " + appServerVersion.asVersion.orNull());
         log.info("  SCM: " + ver.getScmDescribe());
         log.info("  Red Hat Inc 2008-2014");

--- a/zanata-war/src/main/java/org/zanata/servlet/ZanataDatabaseMetadataServletListener.java
+++ b/zanata-war/src/main/java/org/zanata/servlet/ZanataDatabaseMetadataServletListener.java
@@ -1,0 +1,109 @@
+package org.zanata.servlet;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.sql.DataSource;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.zanata.util.ZanataDatabaseDriverMetadata;
+import org.zanata.util.ZanataDatabaseMetaData;
+
+/**
+ * @author Patrick Huang <a
+ *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+@Slf4j
+public class ZanataDatabaseMetadataServletListener implements
+        ServletContextListener {
+    private static final String LIQUIBASE_DATASOURCE = "liquibase.datasource";
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        ServletContext servletContext = servletContextEvent.getServletContext();
+        InitialContext ic = null;
+        Connection connection = null;
+        try {
+            ic = new InitialContext();
+            String dataSourceName =
+                    getValue(LIQUIBASE_DATASOURCE, servletContext, ic);
+            DataSource dataSource = (DataSource) ic.lookup(dataSourceName);
+            connection = dataSource.getConnection();
+            DatabaseMetaData metaData = connection.getMetaData();
+
+            String dbProductName = metaData.getDatabaseProductName();
+            int dbMajorVer = metaData.getDatabaseMajorVersion();
+            int dbMinorVer = metaData.getDatabaseMinorVersion();
+            String dbVersion =
+                    metaData.getDatabaseProductVersion();
+            ZanataDatabaseMetaData databaseMetaData = ZanataDatabaseMetaData
+                    .createAndSet(dbProductName, dbMajorVer, dbMinorVer,
+                            dbVersion);
+            databaseMetaData.checkCompatibility();
+            ZanataDatabaseDriverMetadata.createAndSet(metaData.getDriverName(),
+                    metaData.getDriverVersion());
+
+        } catch (Exception e) {
+            log.warn("fail on getting database metadata", e);
+        } finally {
+            closeResources(ic, connection);
+        }
+    }
+
+    /**
+     * Try to read the value that is stored by the given key from
+     * <ul>
+     * <li>JNDI</li>
+     * <li>the servlet context's init parameters</li>
+     * <li>system properties</li>
+     * </ul>
+     */
+    public String getValue(String key, ServletContext servletContext,
+            InitialContext initialContext) {
+        // Try to get value from JNDI
+        try {
+            Context envCtx = (Context) initialContext.lookup("java:comp/env");
+            return (String) envCtx.lookup(key);
+        } catch (NamingException e) {
+            // Ignore
+        }
+
+        // Return the value from the servlet context
+        String valueFromServletContext = servletContext.getInitParameter(key);
+        if (valueFromServletContext != null) {
+            return valueFromServletContext;
+        }
+
+        // Otherwise: Return system property
+        return System.getProperty(key);
+    }
+
+    private static void closeResources(InitialContext ic, Connection conn) {
+        if (ic != null) {
+            try {
+                ic.close();
+            } catch (NamingException e) {
+                // ignore
+            }
+        }
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                // ignore
+            }
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    }
+}

--- a/zanata-war/src/main/java/org/zanata/util/ZanataDatabaseDriverMetadata.java
+++ b/zanata-war/src/main/java/org/zanata/util/ZanataDatabaseDriverMetadata.java
@@ -1,0 +1,31 @@
+package org.zanata.util;
+
+import lombok.RequiredArgsConstructor;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * @author Patrick Huang <a
+ *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+@RequiredArgsConstructor
+public class ZanataDatabaseDriverMetadata {
+    public static ZanataDatabaseDriverMetadata instance =
+            new ZanataDatabaseDriverMetadata("Unknown", "Unknown");
+    private final String name;
+    private final String version;
+
+    public static ZanataDatabaseDriverMetadata createAndSet(String name,
+            String version) {
+        instance = new ZanataDatabaseDriverMetadata(name, version);
+        return instance;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper("")
+                .add("name", name)
+                .add("version", version)
+                .toString();
+    }
+}

--- a/zanata-war/src/main/java/org/zanata/util/ZanataDatabaseMetaData.java
+++ b/zanata-war/src/main/java/org/zanata/util/ZanataDatabaseMetaData.java
@@ -1,0 +1,86 @@
+package org.zanata.util;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+
+/**
+ * @author Patrick Huang <a
+ *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public class ZanataDatabaseMetaData {
+    public static ZanataDatabaseMetaData instance = new ZanataDatabaseMetaData(
+            "Unknown", 0, 0, "Unknown");
+    private final String name;
+    private final int majorVersion;
+    private final int minorVersion;
+    private final String version;
+
+    public static ZanataDatabaseMetaData createAndSet(String name,
+            int majorVersion, int minorVersion, String version) {
+        instance =
+                new ZanataDatabaseMetaData(name, majorVersion, minorVersion,
+                        version);
+        return instance;
+    }
+
+    public void checkCompatibility() {
+        String dbName = Strings.nullToEmpty(name).toLowerCase();
+
+        if (dbName.contains("maria")) {
+            checkMariaDB(isMariaDBCompatible());
+        } else if (dbName.contains("mysql")) {
+            checkMsyql(isMysqlCompatible());
+        } else {
+            log.warn("Untested or unknown database: {}. Good luck!!", name);
+            // we let it run and if it falls apart later we have a warning out
+            // upfront
+        }
+    }
+
+    private void checkMsyql(boolean mysqlCompatible) {
+        if (!mysqlCompatible) {
+            log.error(
+                    "Incompatible MySql DB version: {}. Compatible up to 5.5",
+                    version);
+            throw new IllegalArgumentException("Incompatible MySQL DB version:"
+                    + version);
+        }
+    }
+
+    private boolean isMysqlCompatible() {
+        // we are only compatible up to mysql 5.5
+        return majorVersion == 5 && minorVersion < 6;
+    }
+
+    private void checkMariaDB(boolean mariaDBCompatible) {
+        if (!mariaDBCompatible) {
+            log.error(
+                    "Incompatible Maria DB version: {}. Compatible from 5.1 to 10.0",
+                    version);
+            throw new IllegalArgumentException("Incompatible Maria DB version:"
+                    + version);
+        }
+    }
+
+    private boolean isMariaDBCompatible() {
+        // compatible "presumably" from mariaDB 5.1 to 10.0
+        if (majorVersion == 5) {
+            return minorVersion >= 1;
+        }
+        // we hope minor version change is indeed backward compatible
+        return majorVersion == 10;
+    }
+
+    public String toString() {
+        return MoreObjects.toStringHelper("")
+                .add("name", name)
+                .add("version", version)
+                .toString();
+    }
+}

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
@@ -119,6 +119,10 @@
   </listener>
 
   <listener>
+    <listener-class>org.zanata.servlet.ZanataDatabaseMetadataServletListener</listener-class>
+  </listener>
+
+  <listener>
     <listener-class>liquibase.integration.servlet.LiquibaseServletListener</listener-class>
   </listener>
 


### PR DESCRIPTION
If running zanata against a whole new database schema which will execute all liquibase change logs, we are known to only compatible with mysql up to 5.5. Not quite sure about mariaDB as I am on RHEL and I don't have access to it.

This change will check for database and its version. If it's incompatible, it will log the message and throw exception. It will be easier for people to figure out what's wrong with their setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/662)
<!-- Reviewable:end -->
