### PR TITLE
Replace CSS file with JS for loading Google Web Fonts

### DIFF
--- a/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
+++ b/zanata-war/src/main/resources/org/zanata/webtrans/public/Application.xhtml
@@ -23,8 +23,22 @@
       href="#{applicationConfiguration.webAssetsStyleUrl}"/>
     <link type="text/css" rel="stylesheet"
       href="#{applicationConfiguration.webAssetsUrl}/assets/css/application.css"/>
-    <link type="text/css" rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+
+    <!-- Async Google Fonts -->
+    <script type="text/javascript">
+      WebFontConfig = {
+        google: { families: [ 'Source+Sans+Pro:300,400,600,700,400italic:latin,latin-ext' ] }
+      };
+      (function() {
+        var wf = document.createElement('script');
+        wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+          '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+        wf.type = 'text/javascript';
+        wf.async = 'true';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(wf, s);
+      })();
+    </script>
 
     <script src="codemirror/codemirror-compressed-3.21.cache.js"
       type="text/javascript"></script>

--- a/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
@@ -38,8 +38,22 @@
     <script src="js/vendor/selectivizr-min.js"></script>
     <![endif]-->
 
-    <link type="text/css" rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+    <!-- Async Google Fonts -->
+    <script type="text/javascript">
+      WebFontConfig = {
+        google: { families: [ 'Source+Sans+Pro:300,400,600,700,400italic:latin,latin-ext' ] }
+      };
+      (function() {
+        var wf = document.createElement('script');
+        wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+          '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+        wf.type = 'text/javascript';
+        wf.async = 'true';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(wf, s);
+      })();
+    </script>
+
     <ui:insert name="head"/>
 
     <script type="application/javascript">

--- a/zanata-war/src/main/webapp/WEB-INF/template/template_2x.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template_2x.xhtml
@@ -19,8 +19,23 @@
       href="#{request.contextPath}/resources/fontello/css/fontello.css"/>
     <link type="text/css" rel="stylesheet"
       href="#{applicationConfiguration.webAssetsStyleUrl}"/>
-    <link type="text/css" rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+
+    <!-- Async Google Fonts -->
+    <script type="text/javascript">
+      WebFontConfig = {
+        google: { families: [ 'Source+Sans+Pro:300,400,600,700,400italic:latin,latin-ext' ] }
+      };
+      (function() {
+        var wf = document.createElement('script');
+        wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+          '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+        wf.type = 'text/javascript';
+        wf.async = 'true';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(wf, s);
+      })();
+    </script>
+
     <ui:insert name="head"/>
   </h:head>
 

--- a/zanata-war/src/main/webapp/WEB-INF/template/template_nobanner.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template_nobanner.xhtml
@@ -42,8 +42,22 @@
     <title>#{msgs['jsf.Zanata']}: <ui:insert name="page_title"/></title>
     <link type="text/css" rel="stylesheet"
       href="#{request.contextPath}/resources/fontello/css/fontello.css"/>
-    <link type="text/css" rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic"/>
+    <!-- Async Google Fonts -->
+    <script type="text/javascript">
+      WebFontConfig = {
+        google: { families: [ 'Source+Sans+Pro:300,400,600,700,400italic:latin,latin-ext' ] }
+      };
+      (function() {
+        var wf = document.createElement('script');
+        wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+          '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+        wf.type = 'text/javascript';
+        wf.async = 'true';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(wf, s);
+      })();
+    </script>
+
     <ui:insert name="head"/>
   </h:head>
 

--- a/zanata-war/src/main/webapp/app/index.html
+++ b/zanata-war/src/main/webapp/app/index.html
@@ -21,9 +21,21 @@
   <script src="js/templates.js"></script>
   <script src="js/app.js"></script>
 
-  <link
-    href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,400italic'
-    rel='stylesheet' type='text/css' async>
+  <!-- Async Google Fonts -->
+  <script type="text/javascript">
+    WebFontConfig = {
+      google: { families: [ 'Source+Sans+Pro:300,400,600,700,400italic:latin,latin-ext' ] }
+    };
+    (function() {
+      var wf = document.createElement('script');
+      wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+        '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+      wf.type = 'text/javascript';
+      wf.async = 'true';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(wf, s);
+    })();
+  </script>
 
 </head>
 


### PR DESCRIPTION
Uses the JS service instead of CSS file so it doesn't block rendering.

Should fix: [Bug: WebUI is very slow if users cannot access Google](https://bugzilla.redhat.com/show_bug.cgi?id=1186084)