### PR TITLE
Check errors when a test page is created/returned

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -53,6 +53,7 @@ public class CorePage extends AbstractPage {
 
     public CorePage(WebDriver driver) {
         super(driver);
+        assertNoCriticalErrors();
     }
 
     public String getTitle() {
@@ -159,18 +160,13 @@ public class CorePage extends AbstractPage {
     }
 
     public void assertNoCriticalErrors() {
-        log.info("Query critical errors");
-        List<WebElement> errors =
-                getDriver().findElements(By.id("errorMessage"));
+        List<WebElement> errors = getDriver()
+                .findElements(By.className("alert--danger"));
         if (errors.size() > 0) {
+            log.info("Error page displayed");
             throw new RuntimeException("Critical error: \n"
                     + errors.get(0).getText());
         }
-    }
-
-    public boolean hasNoCriticalErrors() {
-        log.info("Query critical errors");
-        return getDriver().findElements(By.id("errorMessage")).size() <= 0;
     }
 
     /**

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
@@ -77,8 +77,6 @@ public class EditVersionValidationsTest extends ZanataTestCase {
         versionTranslationTab = versionTranslationTab
                 .setValidationLevel("Tab characters (\\t)", "Error");
 
-        assumeTrue("RHBZ1017458", versionTranslationTab.hasNoCriticalErrors());
-
         versionTranslationTab = versionTranslationTab
                 .goToHomePage()
                 .goToProjects()
@@ -103,8 +101,6 @@ public class EditVersionValidationsTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsTranslationTab()
                 .setValidationLevel("Tab characters (\\t)", "Error");
-
-        assumeTrue("RHBZ1017458", versionTranslationTab.hasNoCriticalErrors());
 
         EditorPage editorPage = new ProjectWorkFlow()
                 .goToProjectByName("about fedora")
@@ -140,8 +136,6 @@ public class EditVersionValidationsTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsTranslationTab()
                 .setValidationLevel("Tab characters (\\t)", "Error");
-
-        assumeTrue("RHBZ1017458", versionTranslationTab.hasNoCriticalErrors());
 
         EditorPage editorPage = new ProjectWorkFlow()
                 .goToProjectByName("about fedora")
@@ -212,8 +206,6 @@ public class EditVersionValidationsTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsTranslationTab()
                 .setValidationLevel("Tab characters (\\t)", "Off");
-
-        assumeTrue("RHBZ1017458", versionTranslationTab.hasNoCriticalErrors());
 
         EditorPage editorPage = new ProjectWorkFlow()
                 .goToProjectByName("about fedora")


### PR DESCRIPTION
We can assume, in cases other than testing the error page, that
the error page should not be seen when transitioning between
other pages.  Add a check in the constructor for all core pages
of Zanata.