### PR TITLE
Cache downloaded wildfly modules to ~/Downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,8 @@
     <!-- This URL must be set by a profile (wildfly), settings.xml or mvn command line -->
     <!-- <cargo.installation></cargo.installation> -->
 
+    <download.dir>${user.home}/Downloads</download.dir>
+
   </properties>
 
   <dependencyManagement>
@@ -999,7 +1001,7 @@
               <!--if install from url-->
               <zipUrlInstaller>
                 <url>${cargo.installation}</url>
-                <downloadDir>${user.home}/Downloads</downloadDir>
+                <downloadDir>${download.dir}</downloadDir>
                 <extractDir>${cargo.extract.dir}</extractDir>
               </zipUrlInstaller>
             </container>
@@ -1210,7 +1212,6 @@
         <mojarra.module.name>wildfly-${module.wildfly.version}-module-mojarra-${mojarra.module.version}.zip</mojarra.module.name>
         <hibernate.module.version>4.2.15.Final</hibernate.module.version>
         <hibernate.module.name>wildfly-${module.wildfly.version}-module-hibernate-main-${hibernate.module.version}.zip</hibernate.module.name>
-        <module.download.dir>${project.build.directory}/downloads</module.download.dir>
       </properties>
 
       <build>
@@ -1230,21 +1231,20 @@
                 </goals>
                 <configuration>
                   <target unless="skipITs">
-                    <!-- TODO put these zips under ${user.home}/Downloads too -->
-                    <mkdir dir="${module.download.dir}" />
+                    <mkdir dir="${download.dir}" />
                     <get
                       src="http://sourceforge.net/projects/zanata/files/wildfly/${mojarra.module.name}/download"
-                      dest="${module.download.dir}/${mojarra.module.name}"
-                      usetimestamp="true" />
+                      dest="${download.dir}/${mojarra.module.name}"
+                      skipexisting="true" />
                     <get
                       src="http://sourceforge.net/projects/zanata/files/wildfly/${hibernate.module.name}/download"
-                      dest="${module.download.dir}/${hibernate.module.name}"
-                      usetimestamp="true" />
+                      dest="${download.dir}/${hibernate.module.name}"
+                      skipexisting="true" />
                     <unzip
-                      src="${module.download.dir}/${mojarra.module.name}"
+                      src="${download.dir}/${mojarra.module.name}"
                       dest="${appserver.home}" />
                     <unzip
-                      src="${module.download.dir}/${hibernate.module.name}"
+                      src="${download.dir}/${hibernate.module.name}"
                       dest="${appserver.home}" />
                   </target>
                 </configuration>


### PR DESCRIPTION
If Sourceforge is in "Disaster Recovery mode", you will need to download the module zips to `~/Downloads` using your browser, from here: http://sourceforge.net/projects/zanata/files/wildfly/