### PR TITLE
Reduce unnecessary log warnings

### DIFF
--- a/functional-test/src/test/resources/conf/standalone.xml
+++ b/functional-test/src/test/resources/conf/standalone.xml
@@ -85,6 +85,18 @@
       <logger category="org.jboss.as.config">
         <level name="DEBUG" />
       </logger>
+      <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+      <logger category="org.jboss.modules">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "Queue with name '...' has already been registered" -->
+      <logger category="org.richfaces.log.Components">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+      <logger category="org.openid4java.server.RealmVerifier">
+        <level name="ERROR"/>
+      </logger>
       <logger category="sun.rmi">
         <level name="WARN" />
       </logger>

--- a/functional-test/src/test/resources/conf/standalone_wildfly.xml
+++ b/functional-test/src/test/resources/conf/standalone_wildfly.xml
@@ -104,6 +104,18 @@
       <logger category="org.jboss.as.config">
         <level name="DEBUG"/>
       </logger>
+      <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+      <logger category="org.jboss.modules">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "Queue with name '...' has already been registered" -->
+      <logger category="org.richfaces.log.Components">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+      <logger category="org.openid4java.server.RealmVerifier">
+        <level name="ERROR"/>
+      </logger>
       <logger category="sun.rmi">
         <level name="WARN"/>
       </logger>

--- a/zanata-overlay/distros/eap-6/standalone/configuration/standalone-zanata.xml
+++ b/zanata-overlay/distros/eap-6/standalone/configuration/standalone-zanata.xml
@@ -112,7 +112,16 @@
             <logger category="org.jboss.as.config">
                 <level name="DEBUG"/>
             </logger>
+            <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+            <logger category="org.jboss.modules">
+                <level name="ERROR"/>
+            </logger>
+            <!-- Disable WARN: "Queue with name '...' has already been registered" -->
             <logger category="org.richfaces.log.Components">
+                <level name="ERROR"/>
+            </logger>
+            <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+            <logger category="org.openid4java.server.RealmVerifier">
                 <level name="ERROR"/>
             </logger>
             <logger category="sun.rmi">

--- a/zanata-overlay/distros/wildfly-8.1/standalone/configuration/standalone-zanata.xml
+++ b/zanata-overlay/distros/wildfly-8.1/standalone/configuration/standalone-zanata.xml
@@ -110,6 +110,18 @@
             <logger category="org.jboss.as.config">
                 <level name="DEBUG"/>
             </logger>
+            <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+            <logger category="org.jboss.modules">
+                <level name="ERROR"/>
+            </logger>
+            <!-- Disable WARN: "Queue with name '...' has already been registered" -->
+            <logger category="org.richfaces.log.Components">
+                <level name="ERROR"/>
+            </logger>
+            <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+            <logger category="org.openid4java.server.RealmVerifier">
+                <level name="ERROR"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
@@ -106,6 +106,18 @@
       <logger category="org.jboss.as.config">
         <level name="DEBUG"/>
       </logger>
+      <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+      <logger category="org.jboss.modules">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "Queue with name '...' has already been registered" -->
+      <logger category="org.richfaces.log.Components">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+      <logger category="org.openid4java.server.RealmVerifier">
+        <level name="ERROR"/>
+      </logger>
       <logger category="sun.rmi">
         <level name="WARN"/>
       </logger>

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
@@ -83,6 +83,18 @@
       <logger category="org.apache.tomcat.util.modeler">
         <level name="WARN" />
       </logger>
+      <!-- Disable WARN about GWT's org.hibernate.validator.ValidationMessages -->
+      <logger category="org.jboss.modules">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "Queue with name '...' has already been registered" -->
+      <logger category="org.richfaces.log.Components">
+        <level name="ERROR"/>
+      </logger>
+      <!-- Disable WARN: "RP discovery / realm validation disabled;" -->
+      <logger category="org.openid4java.server.RealmVerifier">
+        <level name="ERROR"/>
+      </logger>
       <logger category="sun.rmi">
         <level name="WARN" />
       </logger>


### PR DESCRIPTION
We really need to generate these files from a template, or perhaps a template for EAP and one for WildFly.