### PR TITLE
Move back to Ehcache for hibernate 2nd level cache.

### DIFF
--- a/docs/configuration/infinispan.md
+++ b/docs/configuration/infinispan.md
@@ -1,9 +1,6 @@
 # Infinispan for caching
 
-Zanata uses Infinispan to manage its internal data caches and search indexes. Configuration for these caches happens in JBoss' `standalone/configuration/standalone.xml`. There are two different caches that need to be configured for Zanata:
-
-1. Hibernate search Indexes
-1. Other internal data caches
+Zanata uses Infinispan to manage some of its internal data caches. Configuration for these caches happens in JBoss' `standalone/configuration/standalone.xml`.
 
 The Infinispan configuration will be located inside the following module in `standalone.xml`:
 
@@ -15,40 +12,16 @@ The Infinispan configuration will be located inside the following module in `sta
 
 Keep in mind that the module version may vary depending on your JBoss version.
 
-### Hibernate Cache
-
-The following is the recommended configuration for the Hibernate cache:
-
-```xml
-...
-<cache-container name="hibernate" default-cache="local-query" jndi-name="java:jboss/infinispan/container/hibernate" start="EAGER" module="org.jboss.as.jpa.hibernate:4">
-    <local-cache name="entity">
-        <transaction mode="NON_XA"/>
-        <eviction strategy="LRU" max-entries="10000"/>
-        <expiration max-idle="100000"/>
-   	</local-cache>
-    <local-cache name="local-query">
-        <transaction mode="NONE"/>
-        <eviction strategy="LRU" max-entries="10000"/>
-        <expiration max-idle="100000"/>
-    </local-cache>
-    <local-cache name="timestamps">
-        <transaction mode="NONE"/>
-        <eviction strategy="NONE"/>
-    </local-cache>
-</cache-container>
-...
-```
-
 Depending on your JBoss installation, the hibernate cache might already be present in the configuration, in which case there is no need to create another one, but just modify it.
 
-### Other internal data caches
+### Configuration for Internal data caches
 
 ```xml
 ...
-<cache-container name="zanata" default-cache="default" jndi-name="java:jboss/infinispan/container/zanata" 
-                 start="EAGER" 
-                 module="org.jboss.as.clustering.web.infinispan">
+<cache-container name="zanata" default-cache="default"
+    jndi-name="java:jboss/infinispan/container/zanata"
+    start="EAGER"
+    module="org.jboss.as.clustering.web.infinispan">
     <local-cache name="default">
         <transaction mode="NON_XA"/>
         <eviction strategy="LRU" max-entries="10000"/>

--- a/pom.xml
+++ b/pom.xml
@@ -765,6 +765,12 @@
 
       <dependency>
         <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-ehcache</artifactId>
+        <version>${hibernate.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hibernate</groupId>
         <artifactId>hibernate-testing</artifactId>
         <version>${hibernate.version}</version>
       </dependency>

--- a/zanata-model/src/main/java/org/zanata/model/HAccount.java
+++ b/zanata-model/src/main/java/org/zanata/model/HAccount.java
@@ -64,7 +64,7 @@ import org.zanata.rest.dto.Account;
  *
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = "username"))
 @Indexed
 @Setter
@@ -86,21 +86,21 @@ public class HAccount extends ModelEntityBase implements Serializable {
     private HAccount mergedInto;
     private Map<String, HAccountOption> editorOptions;
 
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY,
             mappedBy = "account")
     public HAccountActivationKey getAccountActivationKey() {
         return accountActivationKey;
     }
 
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY,
             mappedBy = "account")
     public HAccountResetPasswordKey getAccountResetPasswordKey() {
         return accountResetPasswordKey;
     }
 
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @OneToOne(mappedBy = "account", cascade = CascadeType.ALL)
     public HPerson getPerson() {
         return person;
@@ -134,7 +134,7 @@ public class HAccount extends ModelEntityBase implements Serializable {
         return apiKey;
     }
 
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @UserRoles
     @ManyToMany(targetEntity = HAccountRole.class)
     @JoinTable(name = "HAccountMembership", joinColumns = @JoinColumn(

--- a/zanata-model/src/main/java/org/zanata/model/HAccountResetPasswordKey.java
+++ b/zanata-model/src/main/java/org/zanata/model/HAccountResetPasswordKey.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class HAccountResetPasswordKey extends AccountKeyBase implements
         Serializable {
 

--- a/zanata-model/src/main/java/org/zanata/model/HCopyTransOptions.java
+++ b/zanata-model/src/main/java/org/zanata/model/HCopyTransOptions.java
@@ -43,7 +43,7 @@ import org.zanata.model.type.ConditionRuleActionType;
 @Entity
 @TypeDef(name = "conditionRuleAction",
         typeClass = ConditionRuleActionType.class)
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/zanata-model/src/main/java/org/zanata/model/HDocument.java
+++ b/zanata-model/src/main/java/org/zanata/model/HDocument.java
@@ -82,7 +82,7 @@ import com.google.common.collect.ImmutableList;
  */
 @Entity
 @EntityListeners({HDocument.EntityListener.class})
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @TypeDef(name = "contentType", typeClass = ContentTypeType.class)
 @Setter
 @NoArgsConstructor

--- a/zanata-model/src/main/java/org/zanata/model/HGlossaryEntry.java
+++ b/zanata-model/src/main/java/org/zanata/model/HGlossaryEntry.java
@@ -50,7 +50,7 @@ import org.zanata.hibernate.search.LocaleIdBridge;
  *
  **/
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Indexed
 @Setter
 @EqualsAndHashCode(callSuper = true, doNotUseGetters = true,

--- a/zanata-model/src/main/java/org/zanata/model/HGlossaryTerm.java
+++ b/zanata-model/src/main/java/org/zanata/model/HGlossaryTerm.java
@@ -59,7 +59,7 @@ import org.zanata.hibernate.search.LocaleIdBridge;
  *
  **/
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Indexed
 @FullTextFilterDef(name = "glossaryLocaleFilter",
         impl = LocaleFilterFactory.class,

--- a/zanata-model/src/main/java/org/zanata/model/HLocale.java
+++ b/zanata-model/src/main/java/org/zanata/model/HLocale.java
@@ -51,7 +51,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.ibm.icu.util.ULocale;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @TypeDef(name = "localeId", typeClass = LocaleIdType.class)
 @Setter
 @NoArgsConstructor
@@ -103,7 +103,7 @@ public class HLocale extends ModelEntityBase implements Serializable {
     }
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "id.supportedLanguage")
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     public Set<HLocaleMember> getMembers() {
         if (this.members == null) {
             this.members = new HashSet<HLocaleMember>();

--- a/zanata-model/src/main/java/org/zanata/model/HPerson.java
+++ b/zanata-model/src/main/java/org/zanata/model/HPerson.java
@@ -51,7 +51,7 @@ import org.zanata.rest.dto.Person;
  *
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @EqualsAndHashCode(callSuper = true, of = { "id", "email", "name" },
         doNotUseGetters = true)

--- a/zanata-model/src/main/java/org/zanata/model/HProject.java
+++ b/zanata-model/src/main/java/org/zanata/model/HProject.java
@@ -80,7 +80,7 @@ import com.google.common.collect.Sets;
  *
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Access(AccessType.FIELD)
 @TypeDefs({
     @TypeDef(name = "entityStatus", typeClass = EntityStatusType.class),
@@ -151,7 +151,7 @@ public class HProject extends SlugEntityBase implements Serializable,
     @JoinTable(name = "HProject_Maintainer", joinColumns = @JoinColumn(
             name = "projectId"), inverseJoinColumns = @JoinColumn(
             name = "personId"))
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Set<HPerson> maintainers = Sets.newHashSet();
 
     @ManyToMany
@@ -168,7 +168,7 @@ public class HProject extends SlugEntityBase implements Serializable,
     private Map<String, String> customizedValidations = Maps.newHashMap();
 
     @OneToMany(mappedBy = "project")
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private List<HProjectIteration> projectIterations = Lists.newArrayList();
 
     @Type(type = "entityStatus")

--- a/zanata-model/src/main/java/org/zanata/model/HProjectIteration.java
+++ b/zanata-model/src/main/java/org/zanata/model/HProjectIteration.java
@@ -76,7 +76,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @TypeDef(name = "entityStatus", typeClass = EntityStatusType.class)
 @Restrict
 @EntityRestrict({ INSERT, UPDATE, DELETE })

--- a/zanata-model/src/main/java/org/zanata/model/HRoleAssignmentRule.java
+++ b/zanata-model/src/main/java/org/zanata/model/HRoleAssignmentRule.java
@@ -38,7 +38,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @ToString(callSuper = true)
 public class HRoleAssignmentRule extends ModelEntityBase {

--- a/zanata-model/src/main/java/org/zanata/model/HSimpleComment.java
+++ b/zanata-model/src/main/java/org/zanata/model/HSimpleComment.java
@@ -50,7 +50,7 @@ import org.hibernate.annotations.Type;
  */
 @Entity
 @EntityListeners({ HSimpleComment.EntityListener.class })
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @BatchSize(size = 20)
 @Setter
 @NoArgsConstructor

--- a/zanata-model/src/main/java/org/zanata/model/HTermComment.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTermComment.java
@@ -45,7 +45,7 @@ import org.hibernate.annotations.Type;
  *
  **/
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @NoArgsConstructor
 @ToString(of = "comment")

--- a/zanata-model/src/main/java/org/zanata/model/HTextFlow.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTextFlow.java
@@ -88,7 +88,7 @@ import com.google.common.collect.ImmutableList;
  */
 @Entity
 @EntityListeners({ HTextFlow.EntityListener.class })
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @NoArgsConstructor
 @ToString(of = { "resId", "revision", "comment", "obsolete" })
@@ -384,7 +384,7 @@ public class HTextFlow extends HTextContainer implements Serializable,
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "textFlow")
     @MapKeyColumn(name = "locale")
     @BatchSize(size = 10)
-    @Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     public Map<Long, HTextFlowTarget> getTargets() {
         if (targets == null) {
             targets = new HashMap<Long, HTextFlowTarget>();

--- a/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
@@ -83,7 +83,7 @@ import com.google.common.collect.Lists;
  */
 @Entity
 @EntityListeners({ HTextFlowTarget.EntityListener.class })
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Indexed
 @Setter
 @NoArgsConstructor

--- a/zanata-model/src/main/java/org/zanata/model/HTextFlowTargetReviewComment.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTextFlowTargetReviewComment.java
@@ -49,7 +49,7 @@ import org.hibernate.validator.constraints.NotEmpty;
  */
 @Entity
 @Immutable
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @BatchSize(size = 20)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Access(AccessType.FIELD)

--- a/zanata-model/src/main/java/org/zanata/model/po/HPoHeader.java
+++ b/zanata-model/src/main/java/org/zanata/model/po/HPoHeader.java
@@ -33,7 +33,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
  * @see org.zanata.rest.dto.extensions.gettext.PoHeader
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @ToString(callSuper = true)
 public class HPoHeader extends PoHeaderBase {
     private static final long serialVersionUID = 1L;

--- a/zanata-model/src/main/java/org/zanata/model/po/HPoTargetHeader.java
+++ b/zanata-model/src/main/java/org/zanata/model/po/HPoTargetHeader.java
@@ -39,7 +39,7 @@ import org.zanata.model.HLocale;
  * @see org.zanata.rest.dto.extensions.gettext.PoTargetHeader
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Setter
 @ToString(callSuper = true, of = "targetLanguage")
 public class HPoTargetHeader extends PoHeaderBase {

--- a/zanata-model/src/main/java/org/zanata/model/po/HPotEntryData.java
+++ b/zanata-model/src/main/java/org/zanata/model/po/HPotEntryData.java
@@ -47,7 +47,7 @@ import org.zanata.model.HTextFlow;
  * @see org.zanata.rest.dto.extensions.gettext.PotEntryHeader
  */
 @Entity
-@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @BatchSize(size = 20)
 @Setter
 public class HPotEntryData implements Serializable {

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1520,6 +1520,11 @@
 
     <dependency>
       <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-ehcache</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
       <artifactId>hibernate-testing</artifactId>
       <scope>test</scope>
       <exclusions>
@@ -1528,6 +1533,12 @@
           <groupId>com.sun</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache-core</artifactId>
+      <version>2.5.1</version>
     </dependency>
 
     <dependency>

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/persistence.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/persistence.xml
@@ -50,8 +50,6 @@
     <class>org.zanata.model.tm.TransMemory</class>
     <class>org.zanata.model.WebHook</class>
 
-    <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
-
     <properties>
       <!--
           Binds the EntityManagerFactory to JNDI where Seam can look it up. This is only relevant when
@@ -121,9 +119,7 @@
            See http://stackoverflow.com/a/8701914
       -->
       <property name="hibernate.cache.region.factory_class"
-        value="org.hibernate.cache.infinispan.JndiInfinispanRegionFactory" />
-      <property name="hibernate.cache.infinispan.cachemanager"
-        value="java:jboss/infinispan/container/hibernate" />
+        value="org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory" />
       <property name="hibernate.cache.region_prefix" value="" />
 
       <!-- Default EHcache config location -->

--- a/zanata-war/src/test/resources/arquillian/persistence.xml
+++ b/zanata-war/src/test/resources/arquillian/persistence.xml
@@ -74,9 +74,7 @@
       <property name="hibernate.cache.use_second_level_cache" value="true" />
       <property name="hibernate.show_sql" value="false" />
       <property name="hibernate.cache.region.factory_class"
-        value="org.hibernate.cache.infinispan.JndiInfinispanRegionFactory" />
-      <property name="hibernate.cache.infinispan.cachemanager"
-        value="java:jboss/infinispan/container/hibernate" />
+        value="org.hibernate.testing.cache.CachingRegionFactory" />
       <property name="hibernate.hbm2ddl.auto" value="create-drop" />
 
       <property name="hibernate.connection.provider_class"


### PR DESCRIPTION
At least until a solution is found in terms of compatibility between Wildfly (hibernate 4.3, infinispan 6) and EAP (hibernate 4.2, infinispan 5).
Other data caches will still use infinispan.
The main reverted commit is: c513552187f78dcf7db96af66c6f2b6236c85a71
Parts of these commits were also reverted: 
0fa0a8ea34fe1a5c6463daa29f70f081748df0e4
f1a16afa548e0337514d5a093cf8d6938f08c234