### PR TITLE
Display version state in a standard way

### DIFF
--- a/zanata-war/src/main/java/org/zanata/ui/ActivityEntry.java
+++ b/zanata-war/src/main/java/org/zanata/ui/ActivityEntry.java
@@ -40,6 +40,10 @@ import org.zanata.util.ShortString;
 import org.zanata.util.UrlUtil;
 
 /**
+ * Provides data and operations needed to display an activity entry.
+ *
+ * This is used by template activity-entry.xhtml
+ *
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  */
 @Name("activityEntry")
@@ -203,16 +207,23 @@ public class ActivityEntry {
     }
 
     public String getVersionName(Activity activity) {
+        HProjectIteration version = getVersion(activity);
+        if (version == null) {
+            return "";
+        } else {
+            return version.getSlug();
+        }
+    }
+
+    public HProjectIteration getVersion(Activity activity) {
         Object context =
                 getEntity(activity.getContextType(), activity.getContextId());
-
         if (isTranslationUpdateActivity(activity.getActivityType())
                 || activity.getActivityType() == ActivityType.UPLOAD_SOURCE_DOCUMENT
                 || activity.getActivityType() == ActivityType.UPLOAD_TRANSLATION_DOCUMENT) {
-            HProjectIteration version = (HProjectIteration) context;
-            return version.getSlug();
+            return (HProjectIteration) context;
         }
-        return "";
+        return null;
     }
 
     public String getDocumentName(Activity activity) {

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/AppPresenter.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/presenter/AppPresenter.java
@@ -193,7 +193,12 @@ public class AppPresenter extends WidgetPresenter<AppDisplay> implements
                     userWorkspaceContext.getWorkspaceContext().getLocaleName()));
         }
 
-        display.setReadOnlyVisible(userWorkspaceContext.hasReadOnlyAccess());
+        boolean showObsolete = userWorkspaceContext.getWorkspaceRestrictions().isProjectObsolete();
+        boolean showReadOnly = !showObsolete && userWorkspaceContext.hasReadOnlyAccess();
+
+        display.setReadOnlyVisible(showReadOnly);
+        display.setObsoleteVisible(showObsolete);
+
     }
 
     private void registerKeyShortcuts() {

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/resources/WebTransMessages.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/resources/WebTransMessages.java
@@ -381,8 +381,11 @@ public interface WebTransMessages extends Messages {
     @DefaultMessage("Page size")
     String pageSize();
 
-    @DefaultMessage("Read only")
-    String readOnly();
+    @DefaultMessage("This project-version is readonly. It cannot be edited.")
+    String readOnlyTooltip();
+
+    @DefaultMessage("This project-version is archived. It cannot be edited.")
+    String obsoleteTooltip();
 
     @DefaultMessage("Advanced user configuration")
     String otherConfiguration();

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppDisplay.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppDisplay.java
@@ -24,6 +24,8 @@ public interface AppDisplay extends WidgetDisplay {
 
     void setReadOnlyVisible(boolean visible);
 
+    void setObsoleteVisible(boolean showObsolete);
+
     void showSideMenu(boolean isShowing);
 
     void setProjectLinkLabel(String text);

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppView.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppView.java
@@ -91,6 +91,9 @@ public class AppView extends Composite implements AppDisplay,
     @UiField
     InlineLabel readOnlyLabel;
 
+    @UiField
+    InlineLabel obsoleteLabel;
+
     @UiField(provided = true)
     Breadcrumb selectedDocumentSpan;
 
@@ -172,7 +175,8 @@ public class AppView extends Composite implements AppDisplay,
 
         initWidget(uiBinder.createAndBindUi(this));
 
-        readOnlyLabel.setTitle(messages.readOnly());
+        readOnlyLabel.setTitle(messages.readOnlyTooltip());
+        obsoleteLabel.setTitle(messages.obsoleteTooltip());
 
         keyShortcuts.setTitle(messages.availableKeyShortcutsTitle());
 
@@ -276,6 +280,11 @@ public class AppView extends Composite implements AppDisplay,
     @Override
     public void setReadOnlyVisible(boolean visible) {
         readOnlyLabel.setVisible(visible);
+    }
+
+    @Override
+    public void setObsoleteVisible(boolean visible) {
+        obsoleteLabel.setVisible(visible);
     }
 
     private final static double MIN_MENU_WIDTH = 2;

--- a/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppView.ui.xml
+++ b/zanata-war/src/main/java/org/zanata/webtrans/client/view/AppView.ui.xml
@@ -75,7 +75,9 @@
           <li class="{style.topPanel-Workspace}">
             <nobr>
               <g:InlineLabel ui:field="readOnlyLabel"
-                styleName="i i--lock txt--warning txt--hero l--push-right-quarter" />
+                styleName="i i--lock txt--danger txt--hero l--push-right-quarter" />
+              <g:InlineLabel ui:field="obsoleteLabel"
+                styleName="i i--archive txt--danger txt--hero l--push-right-quarter" />
               <fui:Breadcrumb ui:field="projectLink" />
               <fui:Breadcrumb ui:field="versionLink" />
               <fui:Breadcrumb ui:field="filesLink" />

--- a/zanata-war/src/main/java/org/zanata/webtrans/server/rpc/ActivateWorkspaceHandler.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/server/rpc/ActivateWorkspaceHandler.java
@@ -129,13 +129,14 @@ public class ActivateWorkspaceHandler extends
         boolean isProjectActive =
                 isProjectIterationActive(project.getStatus(),
                         projectIteration.getStatus());
+        boolean isProjectObsolete = isProjectIterationObsolete(project.getStatus(), projectIteration.getStatus());
         boolean hasWriteAccess = hasWritePermission(project, locale);
         boolean hasGlossaryUpdateAccess = hasGlossaryUpdatePermission();
         boolean requireReview = projectIteration.getRequireTranslationReview();
         boolean hasReviewAccess = hasReviewerPermission(locale, project);
 
         WorkspaceRestrictions workspaceRestrictions =
-                new WorkspaceRestrictions(isProjectActive, hasWriteAccess,
+                new WorkspaceRestrictions(isProjectActive, isProjectObsolete, hasWriteAccess,
                         hasGlossaryUpdateAccess, hasReviewAccess, requireReview);
         log.debug("workspace restrictions: {}", workspaceRestrictions);
 
@@ -181,6 +182,12 @@ public class ActivateWorkspaceHandler extends
             EntityStatus iterStatus) {
         return (projectStatus.equals(EntityStatus.ACTIVE) && iterStatus
                 .equals(EntityStatus.ACTIVE));
+    }
+
+    private boolean isProjectIterationObsolete(EntityStatus projectStatus,
+                                               EntityStatus iterStatus) {
+        return (projectStatus.equals(EntityStatus.OBSOLETE) || iterStatus
+                .equals(EntityStatus.OBSOLETE));
     }
 
     protected Person retrievePerson() {

--- a/zanata-war/src/main/java/org/zanata/webtrans/shared/model/WorkspaceRestrictions.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/shared/model/WorkspaceRestrictions.java
@@ -9,6 +9,7 @@ import com.google.gwt.user.client.rpc.IsSerializable;
  */
 public class WorkspaceRestrictions implements IsSerializable {
     private boolean isProjectActive;
+    private boolean isProjectObsolete;
     private boolean hasEditTranslationAccess;
     private boolean hasReviewAccess;
     private boolean hasGlossaryUpdateAccess;
@@ -18,10 +19,11 @@ public class WorkspaceRestrictions implements IsSerializable {
     private WorkspaceRestrictions() {
     }
 
-    public WorkspaceRestrictions(boolean projectActive,
+    public WorkspaceRestrictions(boolean projectActive, boolean projectObsolete,
             boolean hasEditTranslationAccess, boolean hasGlossaryUpdateAccess,
             boolean hasReviewAccess, boolean projectRequireReview) {
         this.isProjectActive = projectActive;
+        this.isProjectObsolete = projectObsolete;
         this.hasEditTranslationAccess = hasEditTranslationAccess;
         this.hasGlossaryUpdateAccess = hasGlossaryUpdateAccess;
         this.hasReviewAccess = hasReviewAccess;
@@ -30,6 +32,10 @@ public class WorkspaceRestrictions implements IsSerializable {
 
     public boolean isProjectActive() {
         return isProjectActive;
+    }
+
+    public boolean isProjectObsolete() {
+        return isProjectObsolete;
     }
 
     public boolean isHasEditTranslationAccess() {
@@ -49,20 +55,26 @@ public class WorkspaceRestrictions implements IsSerializable {
     }
 
     public WorkspaceRestrictions changeProjectActivity(boolean projectActive) {
-        return new WorkspaceRestrictions(projectActive,
+        return new WorkspaceRestrictions(projectActive, isProjectObsolete,
+                hasEditTranslationAccess, hasGlossaryUpdateAccess,
+                hasReviewAccess, projectRequireReview);
+    }
+
+    public WorkspaceRestrictions changeProjectObsolescence(boolean projectObsolete) {
+        return new WorkspaceRestrictions(isProjectActive, projectObsolete,
                 hasEditTranslationAccess, hasGlossaryUpdateAccess,
                 hasReviewAccess, projectRequireReview);
     }
 
     public WorkspaceRestrictions changeEditTranslationAccess(
             boolean hasEditTranslationAccess) {
-        return new WorkspaceRestrictions(isProjectActive,
+        return new WorkspaceRestrictions(isProjectActive, isProjectObsolete,
                 hasEditTranslationAccess, hasGlossaryUpdateAccess,
                 hasReviewAccess, projectRequireReview);
     }
 
     public WorkspaceRestrictions changeReviewAccess(boolean hasReviewAccess) {
-        return new WorkspaceRestrictions(isProjectActive,
+        return new WorkspaceRestrictions(isProjectActive, isProjectObsolete,
                 hasEditTranslationAccess, hasGlossaryUpdateAccess,
                 hasReviewAccess, projectRequireReview);
     }

--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -439,6 +439,7 @@ jsf.iteration.CopyTrans.Completed="Copy Translations" completed.
 jsf.iteration.CopyTrans.Cancelled="Copy Translations" cancelled.
 jsf.iteration.CopyTransOpts.tooltip=Help: Set this version's "Copy Translations" settings.
 jsf.iteration.tooltip.readonly=This version is currently read only
+jsf.iteration.tooltip.obsolete=This version is currently obsolete
 
 
 #------ [home] > Projects > [project-id] > [version-id] ------

--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -380,6 +380,7 @@ jsf.group.RemoveVersion.sr.label=Remove
 jsf.group.RemoveVersion.title=Remove Version
 jsf.group.RemoveMaintainer.sr.label=Remove
 jsf.group.RemoveMaintainer.title=Remove Maintainer
+jsf.group.ArchivedVersionNotIncluded=This project-version is archived and will not be included.
 
 
 #------ [home] > Projects > [project-id] > Copy Trans Options ------
@@ -439,7 +440,7 @@ jsf.iteration.CopyTrans.Completed="Copy Translations" completed.
 jsf.iteration.CopyTrans.Cancelled="Copy Translations" cancelled.
 jsf.iteration.CopyTransOpts.tooltip=Help: Set this version's "Copy Translations" settings.
 jsf.iteration.tooltip.readonly=This version is currently read only
-jsf.iteration.tooltip.obsolete=This version is currently obsolete
+jsf.iteration.tooltip.obsolete=This version is currently archived
 
 
 #------ [home] > Projects > [project-id] > [version-id] ------
@@ -563,7 +564,7 @@ jsf.generatezip.ProgressLabel={0} of {1}
 jsf.iteration.files.WhyCantITranslate=Why can't I translate?
 jsf.iteration.files.translateDenied.NotLoggedIn=You are not logged In.
 jsf.iteration.files.translateDenied.VersionIsReadOnly=This project version is Read-Only.
-jsf.iteration.files.translateDenied.VersionIsObsolete=This project version is Obsolete.
+jsf.iteration.files.translateDenied.VersionIsObsolete=This project version is Archived.
 ! {0} is a language name
 jsf.iteration.files.translateDenied.UserNotTranslatorInLanguageTeam=You are a not translator of the {0} language team.
 ! {0} is a list of user roles

--- a/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/activity.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/activity.xhtml
@@ -1,10 +1,9 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
   xmlns:s="http://jboss.org/schema/seam/taglib"
   xmlns:ui="http://java.sun.com/jsf/facelets"
-  xmlns:f="http://java.sun.com/jsf/core"
   xmlns:h="http://java.sun.com/jsf/html"
-  xmlns:rich="http://richfaces.org/rich"
-  xmlns:a4j="http://richfaces.org/a4j">
+  xmlns:a4j="http://richfaces.org/a4j"
+  xmlns:zanata="http://java.sun.com/jsf/composite/zanata">
 
   <a4j:jsFunction name="loadNextActivity"
     action="#{activityAction.loadNextActivity()}"
@@ -81,7 +80,7 @@
                     <i aria-hidden="true" class="i i--version txt--neutral"
                       title="#{msgs['jsf.Version']}"><span
                       class="is-invisible">#{msgs['jsf.Version']}</span></i>
-                    <a href="#{activityAction.getVersionUrl(activity)}">#{versionName}</a>
+                    <a href="#{activityAction.getVersionUrl(activity)}"><zanata:version-label version="#{activityEntry.getVersion(activity)}"/></a>
                   </li>
                 </s:fragment>
 

--- a/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/projects.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/projects.xhtml
@@ -65,18 +65,18 @@
                       <span class="is-invisible">#{msgs['jsf.dashboard.projects.translateOptions.label']}</span>
                     </a>
                     <ul class="dropdown__content js-dropdown__content">
-                      <li class="dropdown__header">
+                      <li class="dropdown__header txt--nowrap">
                         <span class="txt--meta">
                           <i class="i i--version i__item__icon"></i>
                           #{msgs['jsf.dashboard.projects.versions.label']}
                         </span>
                       </li>
                       <ui:repeat value="#{project.projectIterations}" var="version">
-                        <li>
+                        <li class="txt--nowrap">
                           <s:link view="/iteration/view.xhtml" propagation="none">
                             <f:param name="projectSlug" value="#{project.slug}"/>
                             <f:param name="iterationSlug" value="#{version.slug}"/>
-                            <h:outputText value="#{version.slug}"/>
+                            <zanata:version-label version="#{version}"/>
                           </s:link>
                         </li>
                       </ui:repeat>

--- a/zanata-war/src/main/webapp/WEB-INF/layout/project/versions-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/project/versions-tab.xhtml
@@ -194,7 +194,7 @@
 
               <div class="list__item__content">
                 <div class="list__item__info">
-                  <h3 class="list__title">#{version.slug}</h3>
+                  <h3 class="list__title"><zanata:version-label version="#{version}"/></h3>
                   <s:span styleClass="txt--meta"
                     rendered="#{projectHomeAction.isVersionCopying(version.project.slug, version.slug)}"
                     id="copy-version-message">

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version-group/languages-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version-group/languages-tab.xhtml
@@ -225,7 +225,7 @@
                     <h3 class="list__title">#{version.project.name}</h3>
                       <span class="list__item__meta">
                         <i
-                          class="txt--neutral i i--version"></i> #{version.slug}
+                          class="txt--neutral i i--version"></i> <zanata:version-label version="#{version}"/>
 
                         <s:fragment
                           rendered="#{!versionGroupHomeAction.isLocaleActivatedInVersion(version, versionGroupHomeAction.selectedLocale.localeId)}">

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version-group/projects-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version-group/projects-tab.xhtml
@@ -91,8 +91,7 @@
                 <div class="list__item__info">
                   <h3 class="list__title">#{version.project.name}</h3>
                     <span class="list__item__meta">
-                      <i
-                        class="txt--neutral i i--version"></i> #{version.slug}
+                      <i class="txt--neutral i i--version"></i> <zanata:version-label version="#{version}" />
                       <s:fragment
                         rendered="#{!versionGroupHomeAction.getMissingLocale(version).isEmpty()}">
                           <span

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version-group/settings-tab.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version-group/settings-tab.xhtml
@@ -157,8 +157,10 @@
             <s:link view="/iteration/view.xhtml">
               <f:param name="projectSlug" value="#{version.project.slug}"/>
               <f:param name="iterationSlug" value="#{version.slug}"/>
-              #{version.project.name} <i
-              class="i i--version"></i> #{version.slug}
+              #{version.project.name} <i class="i i--version"></i> <zanata:version-label version="#{version}"/>
+              <s:fragment rendered="#{version.status == 'OBSOLETE'}">
+                <span class="txt--danger l--push-left-half">#{msgs['jsf.group.ArchivedVersionNotIncluded']}</span>
+              </s:fragment>
             </s:link>
             <a4j:commandLink
               styleClass="button--link l--float-right reveal__target"
@@ -191,7 +193,7 @@
             oncomplete="refreshStatistics();focusCurrentActiveInput();"
             placeholder="#{msgs['jsf.SearchProjects']}">
 
-            #{result.project.slug} <i class="i i--version"></i> #{result.slug}
+            #{result.project.slug} <i class="i i--version"></i> <zanata:version-label version="#{result}"/>
           </zanata:autocomplete>
         </li>
       </ul>

--- a/zanata-war/src/main/webapp/WEB-INF/layout/version/edit_form.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/version/edit_form.xhtml
@@ -179,13 +179,13 @@
                   id="#{status.index}:version:#{versionItem.version.slug}"/>
               </s:fragment>
               <label for="#{status.index}:version:#{versionItem.version.slug}"
-                class="form__radio__label">#{versionItem.version.slug} <span
-                class="txt--meta">
-                <i class="i--document i txt--neutral"
-                  title="#{msgs['jsf.Documents']}"></i> #{versionItem.version.documents.size()}  <i
-                class="i--language i txt--neutral"
-                title="#{msgs['jsf.Languages']}"></i> #{versionHomeAction.getVersionSupportedLocaleCount(versionItem.version.project.slug, versionItem.version.slug)}
-              </span>
+                class="form__radio__label"><zanata:version-label version="#{versionItem.version}"/>
+                <span class="txt--meta l--push-left-half">
+                  <i class="i--document i txt--neutral" title="#{msgs['jsf.Documents']}"></i>
+                  #{versionItem.version.documents.size()}
+                  <i class="i--language i txt--neutral" title="#{msgs['jsf.Languages']}"></i>
+                  #{versionHomeAction.getVersionSupportedLocaleCount(versionItem.version.project.slug, versionItem.version.slug)}
+                </span>
               </label>
             </div>
           </li>

--- a/zanata-war/src/main/webapp/iteration/view.xhtml
+++ b/zanata-war/src/main/webapp/iteration/view.xhtml
@@ -188,20 +188,7 @@
   </p>
 
   <s:div styleClass="l--push-bottom-half" id="version-info">
-    <s:fragment rendered="#{versionHome.instance.status eq 'ACTIVE'}">
-      <h1 class="l--push-all-0">
-        <i class="i--small i--version txt--neutral i--left"></i>
-        #{versionHomeAction.versionSlug}
-      </h1>
-    </s:fragment>
-    <s:fragment rendered="#{versionHome.instance.status ne 'ACTIVE'}">
-      <h1 class="l--push-all-0 txt--neutral">
-        <i class="i--small i--version txt--neutral i--left"></i>
-        #{versionHomeAction.versionSlug}
-        <i class="i--small i--right i--lock"
-          title="#{msgs['jsf.iteration.tooltip.readonly']}"></i>
-      </h1>
-    </s:fragment>
+    <h1 class="l--push-all-0"><zanata:version-label version="#{versionHome.instance}"/></h1>
   </s:div>
 
   <s:div styleClass="progress-bar--large__expander l--pad-bottom-half"

--- a/zanata-war/src/main/webapp/resources/zanata/activity-entry.xhtml
+++ b/zanata-war/src/main/webapp/resources/zanata/activity-entry.xhtml
@@ -3,7 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
   xmlns:composite="http://java.sun.com/jsf/composite"
   xmlns:ui="http://java.sun.com/jsf/facelets"
-  xmlns:s="http://jboss.org/schema/seam/taglib">
+  xmlns:s="http://jboss.org/schema/seam/taglib"
+  xmlns:zanata="http://java.sun.com/jsf/composite/zanata">
 
 <composite:interface>
   <composite:attribute name="value" type="org.zanata.model.Activity"
@@ -124,8 +125,9 @@
           title="#{msgs['jsf.Version']}">
           <span class="is-invisible">#{msgs['jsf.Version']}</span>
         </i>
-        <a
-          href="#{activityEntry.getVersionUrl(cc.attrs.value)}">#{versionName}</a>
+        <a href="#{activityEntry.getVersionUrl(cc.attrs.value)}">
+          <zanata:version-label version="#{activityEntry.getVersion(cc.attrs.value)}"/>
+        </a>
       </li>
     </s:fragment>
   </ul>

--- a/zanata-war/src/main/webapp/resources/zanata/version-label.xhtml
+++ b/zanata-war/src/main/webapp/resources/zanata/version-label.xhtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:composite="http://java.sun.com/jsf/composite"
+      xmlns:s="http://jboss.org/schema/seam/taglib">
+
+<composite:interface>
+    <composite:attribute name="version" type="org.zanata.model.HProjectIteration"
+                         shortDescription="Version to display" required="true"/>
+    <composite:attribute name="showIcon" type="java.lang.Boolean"
+                         shortDescription="Optional, use to suppress icon display"
+                         required="false" default="true"/>
+</composite:interface>
+
+<composite:implementation>
+  <s:fragment rendered="#{cc.attrs.version.status == 'ACTIVE'}">
+    #{cc.attrs.version.slug}
+  </s:fragment>
+  <s:fragment rendered="#{cc.attrs.version.status == 'READONLY'}">
+    <span class="txt--neutral">#{cc.attrs.version.slug}
+      <s:fragment rendered="#{cc.attrs.showIcon}">
+        <i class="i--small i--right i--lock" title="#{msgs['jsf.iteration.tooltip.readonly']}"></i>
+      </s:fragment>
+    </span>
+  </s:fragment>
+  <s:fragment rendered="#{cc.attrs.version.status == 'OBSOLETE'}">
+    <span class="txt--neutral">#{cc.attrs.version.slug}
+      <s:fragment rendered="#{cc.attrs.showIcon}">
+        <i class="i--small i--right i--archive" title="#{msgs['jsf.iteration.tooltip.obsolete']}"></i>
+      </s:fragment>
+    </span>
+  </s:fragment>
+</composite:implementation>
+</html>
+
+
+

--- a/zanata-war/src/main/webapp/version-group/request_to_join.xhtml
+++ b/zanata-war/src/main/webapp/version-group/request_to_join.xhtml
@@ -6,7 +6,8 @@
   xmlns:f="http://java.sun.com/jsf/core"
   xmlns:h="http://java.sun.com/jsf/html"
   xmlns:rich="http://richfaces.org/rich"
-  template="../WEB-INF/template/template_2x.xhtml">
+  template="../WEB-INF/template/template_2x.xhtml"
+  xmlns:z="http://java.sun.com/jsf/composite/zanata">
 
   <ui:param name="showGlobalMessages" value="true"/>
 
@@ -34,7 +35,9 @@
         </rich:column>
         <rich:column sortBy="#{selectableVersion.projectIteration.slug}">
           <f:facet name="header">#{msgs['jsf.Version']}</f:facet>
-          #{selectableVersion.projectIteration.slug}
+          <div class="new-zanata">
+            <z:version-label version="#{selectableVersion.projectIteration}"/>
+          </div>
         </rich:column>
 
         <rich:column styleClass="centered">

--- a/zanata-war/src/test/java/org/zanata/model/TestFixture.java
+++ b/zanata-war/src/test/java/org/zanata/model/TestFixture.java
@@ -121,7 +121,7 @@ public class TestFixture {
         ProjectIterationId projectIterationId =
                 new ProjectIterationId(projectSlug, iterationSlug, projectType);
         WorkspaceRestrictions workspaceRestrictions =
-                new WorkspaceRestrictions(projectActive, hasWriteAccess, true,
+                new WorkspaceRestrictions(projectActive, false, hasWriteAccess, true,
                         true, true);
         return new UserWorkspaceContext(new WorkspaceContext(new WorkspaceId(
                 projectIterationId, LocaleId.EN_US), "workspaceName",
@@ -131,7 +131,7 @@ public class TestFixture {
     public static UserWorkspaceContext userWorkspaceContext(
             boolean projectActive, boolean hasWriteAccess) {
         WorkspaceRestrictions workspaceRestrictions =
-                new WorkspaceRestrictions(projectActive, hasWriteAccess, true,
+                new WorkspaceRestrictions(projectActive, false, hasWriteAccess, true,
                         true, true);
         return new UserWorkspaceContext(new WorkspaceContext(workspaceId(),
                 "workspaceName", LocaleId.EN_US.getId()), workspaceRestrictions);

--- a/zanata-war/src/test/java/org/zanata/webtrans/client/rpc/DummyActivateWorkspaceCommand.java
+++ b/zanata-war/src/test/java/org/zanata/webtrans/client/rpc/DummyActivateWorkspaceCommand.java
@@ -45,7 +45,7 @@ public class DummyActivateWorkspaceCommand implements Command {
                 new WorkspaceContext(action.getWorkspaceId(),
                         "Dummy Workspace", "Mock Sweedish");
         WorkspaceRestrictions workspaceRestrictions =
-                new WorkspaceRestrictions(true, true, true, true, true);
+                new WorkspaceRestrictions(true, false, true, true, true, true);
         UserWorkspaceContext userWorkspaceContext =
                 new UserWorkspaceContext(context, workspaceRestrictions);
         userWorkspaceContext.setSelectedDoc(new DocumentInfo(new DocumentId(


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1202670

Already reviewed in https://github.com/zanata/zanata-server/pull/736 but have rebased on release since changes are needed there.

One change could not be rebased because it is on the version merge template, which exists only on master. I will make a separate pull request for that change after this is merged to release and release is merged to master.