### PR TITLE
Increase timeout on server startup in all standalone.xml files.

### DIFF
--- a/functional-test/src/test/resources/conf/standalone.xml
+++ b/functional-test/src/test/resources/conf/standalone.xml
@@ -28,6 +28,7 @@
   </extensions>
   <system-properties>
     <property name="zanata.countAjax" value="true" />
+    <property name="jboss.as.management.blocking.timeout" value="1000"/>
   </system-properties>
   <management>
     <security-realms>

--- a/functional-test/src/test/resources/conf/standalone_wildfly.xml
+++ b/functional-test/src/test/resources/conf/standalone_wildfly.xml
@@ -28,6 +28,7 @@
   </extensions>
   <system-properties>
     <property name="zanata.countAjax" value="true" />
+    <property name="jboss.as.management.blocking.timeout" value="1000"/>
   </system-properties>
   <management>
     <security-realms>

--- a/zanata-overlay/distros/eap-6/standalone/configuration/standalone-zanata.xml
+++ b/zanata-overlay/distros/eap-6/standalone/configuration/standalone-zanata.xml
@@ -31,6 +31,7 @@
     <system-properties>
         <property name="javamelody.storage-directory" value="${user.home}/zanata/stats"/>
         <property name="hibernate.search.default.indexBase" value="${user.home}/zanata/indexes"/>
+        <property name="jboss.as.management.blocking.timeout" value="1000"/>
     </system-properties>
 
 

--- a/zanata-overlay/distros/wildfly-8.1/standalone/configuration/standalone-zanata.xml
+++ b/zanata-overlay/distros/wildfly-8.1/standalone/configuration/standalone-zanata.xml
@@ -32,6 +32,7 @@
         <property name="javamelody.storage-directory" value="${user.home}/zanata/stats"/>
         <property name="hibernate.search.default.indexBase" value="${user.home}/zanata/indexes"/>
         <property name="ehcache.disk.store.dir" value="${user.home}/zanata/ehcache"/>
+        <property name="jboss.as.management.blocking.timeout" value="1000"/>
     </system-properties>
 
 

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
@@ -29,6 +29,7 @@
   <system-properties>
     <property name="hibernate.search.default.indexBase"
       value="./target/zanatasearchindex" />
+    <property name="jboss.as.management.blocking.timeout" value="1000"/>
     <!--javamelody.storage-directory=/var/lib/zanata/stats-->
   </system-properties>
   <management>

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
@@ -31,6 +31,7 @@
   <system-properties>
     <property name="hibernate.search.default.indexBase"
       value="./target/zanatasearchindex" />
+    <property name="jboss.as.management.blocking.timeout" value="1000"/>
     <!--javamelody.storage-directory=/var/lib/zanata/stats-->
   </system-properties>
 


### PR DESCRIPTION
Changes the timeout to 1000 seconds (16min 40s) from default 300s (5min)
to prevent timeout when liquibase changesets take longer than 5 minutes
to run.

Already reviewed and verified in https://github.com/zanata/zanata-server/pull/735 and was a clean cherry-pick.