### PR TITLE
Restore constraints on glossary tables for H2

### DIFF
--- a/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
+++ b/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
@@ -27,6 +27,16 @@
     </addColumn>
   </changeSet>
 
+  <!-- Restore H2 constraints removed by changeset db.changelog-1.6a.xml:1:aeng@redhat.com -->
+  <changeSet author="sflaniga@redhat.com" id="1.6a:1:aeng@redhat.com:fix" dbms="h2">
+    <addForeignKeyConstraint baseTableName="HGlossaryTerm"
+      baseColumnNames="glossaryEntryId" constraintName="UKglossaryterm_glossary_entry_id"
+      referencedTableName="HGlossaryEntry" referencedColumnNames="id" />
+    <addPrimaryKey tableName="HGlossaryEntry" columnNames="id" />
+    <addPrimaryKey tableName="HGlossaryTerm" columnNames="id" />
+    <addPrimaryKey tableName="HTermComment" columnNames="id" />
+  </changeSet>
+
   <!-- This change was added in the 3.7 development branch, but back-ported to the 3.6 branch at patch 3.6.1 -->
   <changeSet author="damason@redhat.com" id="1">
     <comment>Modify existing id for plaintext and libreoffice documents to use content hash instead of old positional id.</comment>


### PR DESCRIPTION
The constraints which were dropped by changeset db.changelog-1.6a.xml:1:aeng@redhat.com were never reinstated, so this changeset puts them back.  (Discovered while investigating https://bugzilla.redhat.com/show_bug.cgi?id=1048293)

Note: this change is untested, and to test it will require running Zanata server against a persistent H2 database.  That isn't something we normally do these days, but I want to record this for completeness, and in case we ever want to run Zanata against H2 in future (eg for demos or quickstarts).

TODO (some time): Add a basic test which deploys Zanata on H2, thus validating that our liquibase changesets at least work on an empty H2 database.  Trying to be database-agnostic might help with future migration, eg https://bugzilla.redhat.com/show_bug.cgi?id=1205945