### PR TITLE
Separate wildfly client version from server version

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -358,7 +358,7 @@
         <standalone.xml.file>standalone_wildfly.xml</standalone.xml.file>
         <jndi-remote-client.groupId>org.wildfly</jndi-remote-client.groupId>
         <jndi-remote-client.artifactId>wildfly-controller-client</jndi-remote-client.artifactId>
-        <jndi-remote-client.version>${wildfly.version}</jndi-remote-client.version>
+        <jndi-remote-client.version>${wildfly.client.version}</jndi-remote-client.version>
       </properties>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1413,7 +1413,9 @@
       </activation>
       <properties>
         <cargo.container>wildfly8x</cargo.container>
+        <wildfly.client.version>8.1.0.Final</wildfly.client.version>
         <!-- used in the wildfly8 profile in zanata-war -->
+        <!-- This is the server version -->
         <wildfly.version>8.1.0.Final</wildfly.version>
         <!-- In case this profile was activated by default: -->
         <appserver>wildfly8</appserver>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1204,7 +1204,7 @@
         <dependency>
           <groupId>org.wildfly</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${wildfly.version}</version>
+          <version>${wildfly.client.version}</version>
           <scope>test</scope>
           <exclusions>
             <exclusion>


### PR DESCRIPTION
I'm hoping this will help with running Zanata on WildFly 9.

Edit: looks like it will take more, but I think it's still a good change.