### PR TITLE
Set merge=union for release-notes.md in .gitattributes

### DIFF
--- a/docs/.gitattributes
+++ b/docs/.gitattributes
@@ -1,0 +1,1 @@
+release-notes.md merge=union


### PR DESCRIPTION
This should prevent merge conflicts due to ~~changelog~~ release notes updates.