### PR TITLE
Handle missing/empty proxy header

### DIFF
--- a/zanata-war/src/main/java/org/zanata/util/HttpUtil.java
+++ b/zanata-war/src/main/java/org/zanata/util/HttpUtil.java
@@ -84,16 +84,20 @@ public final class HttpUtil {
     public static String getClientIp(HttpServletRequest request) {
         String ip;
 
-        if(StringUtils.isEmpty(PROXY_HEADER)) {
+        if (StringUtils.isEmpty(PROXY_HEADER)) {
             return request.getRemoteAddr();
         }
 
         // PROXY_HEADER can be list of ip address
+        String header = request.getHeader(PROXY_HEADER);
+        if (header == null) {
+            return request.getRemoteAddr();
+        }
         String[] ipList =
-                StringUtils.split(request.getHeader(PROXY_HEADER), ",");
+                StringUtils.split(header, ",");
 
-        if(ipList.length == 1) {
-            return ipList[0];
+        if (ipList.length == 0) {
+            return request.getRemoteAddr();
         }
 
         //return last ip address from list if found


### PR DESCRIPTION
Should fix this intermittent unit test failure:

    java.lang.NullPointerException: null
    	at org.zanata.util.HttpUtil.getClientIp(HttpUtil.java:95)
    	at org.zanata.rest.RestLimitingSynchronousDispatcher.invoke(RestLimitingSynchronousDispatcher.java:133)
    	at org.zanata.rest.RestLimitingSynchronousDispatcherTest.willProcessAnonymousWithGETAndNoApiKey(RestLimitingSynchronousDispatcherTest.java:123)