### PR TITLE
Disable implicit wait in Selenium tests

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -50,7 +50,7 @@
     <webdriver.display>:0</webdriver.display>
     <webdriver.log>${project.build.directory}/webdriver.log</webdriver.log>
     <webdriver.screenshot.dir>${project.build.directory}/screenshots</webdriver.screenshot.dir>
-    <webdriver.wait>10</webdriver.wait>
+    <webdriver.wait>20</webdriver.wait>
     <googleopenid.credentials>zanata.user.1:</googleopenid.credentials>
     <!-- on jenkins, this needs to be set to empty - so that cargo can shutdown. see http://stackoverflow.com/questions/1096642/tomcat-failed-to-shutdown -->
     <cargo.debug.jvm.args>

--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -46,13 +46,11 @@ import com.google.common.base.Predicate;
 @Slf4j
 public class AbstractPage {
     private final WebDriver driver;
-    private final FluentWait<WebDriver> ajaxWaitForSec;
 
     public AbstractPage(final WebDriver driver) {
         PageFactory.initElements(new AjaxElementLocatorFactory(driver, 10),
                 this);
         this.driver = driver;
-        ajaxWaitForSec = WebElementUtil.waitForAMoment(driver);
         waitForPageSilence();
     }
 
@@ -88,7 +86,7 @@ public class AbstractPage {
     }
 
     public FluentWait<WebDriver> waitForAMoment() {
-        return ajaxWaitForSec;
+        return WebElementUtil.waitForAMoment(driver);
     }
 
     public Alert switchToAlert() {

--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -256,11 +256,11 @@ public class AbstractPage {
     }
 
     /**
-     * @deprecated use expectWebElement
+     * @deprecated use readyElement
      */
     @Deprecated
     public WebElement waitForWebElement(final By elementBy) {
-        return expectWebElement(elementBy);
+        return readyElement(elementBy);
     }
 
     /**
@@ -268,23 +268,23 @@ public class AbstractPage {
      * @param elementBy WebDriver By locator
      * @return target WebElement
      */
-    public WebElement expectWebElement(final By elementBy) {
+    public WebElement readyElement(final By elementBy) {
         String msg = "element ready " + elementBy;
         logWaiting(msg);
         waitForPageSilence();
-        WebElement targetElement = expectElementExists(elementBy);
+        WebElement targetElement = existingElement(elementBy);
         waitForElementReady(targetElement);
         assertReady(targetElement);
         return targetElement;
     }
 
     /**
-     * @deprecated use expectWebElement
+     * @deprecated use readyElement
      */
     @Deprecated
     public WebElement waitForWebElement(final WebElement parentElement,
             final By elementBy) {
-        return expectWebElement(parentElement, elementBy);
+        return readyElement(parentElement, elementBy);
     }
 
     /**
@@ -293,21 +293,21 @@ public class AbstractPage {
      * @param elementBy WebDriver By locator
      * @return target WebElement
      */
-    public WebElement expectWebElement(final WebElement parentElement,
+    public WebElement readyElement(final WebElement parentElement,
             final By elementBy) {
         String msg = "element ready " + elementBy;
         logWaiting(msg);
         waitForPageSilence();
-        WebElement targetElement = expectElementExists(parentElement, elementBy);
+        WebElement targetElement = existingElement(parentElement, elementBy);
         assertReady(targetElement);
         return targetElement;
     }
 
     /**
-     * @deprecated use expectElementExists
+     * @deprecated use existingElement
      */
     public WebElement waitForElementExists(final By elementBy) {
-        return expectElementExists(elementBy);
+        return existingElement(elementBy);
     }
 
     /**
@@ -317,7 +317,7 @@ public class AbstractPage {
      * @param elementBy WebDriver By locator
      * @return target WebElement
      */
-    public WebElement expectElementExists(final By elementBy) {
+    public WebElement existingElement(final By elementBy) {
         String msg = "element exists " + elementBy;
         logWaiting(msg);
         waitForPageSilence();
@@ -330,12 +330,12 @@ public class AbstractPage {
     }
 
     /**
-     * @deprecated use expectElementExists
+     * @deprecated use existingElement
      */
     @Deprecated
     public WebElement waitForElementExists(final WebElement parentElement,
             final By elementBy) {
-        return expectElementExists(parentElement, elementBy);
+        return existingElement(parentElement, elementBy);
     }
 
     /**
@@ -345,7 +345,7 @@ public class AbstractPage {
      * @param elementBy WebDriver By locator
      * @return target WebElement
      */
-    public WebElement expectElementExists(final WebElement parentElement,
+    public WebElement existingElement(final WebElement parentElement,
             final By elementBy) {
         String msg = "element exists " + elementBy;
         logWaiting(msg);

--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -39,8 +39,6 @@ import org.zanata.util.WebElementUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 
-import javax.annotation.Nullable;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -368,6 +366,7 @@ public class AbstractPage {
          });
     }
 
+    // Assert the element is available and visible
     private void assertReady(WebElement targetElement) {
         assertThat(targetElement.isDisplayed()).as("displayed").isTrue();
         assertThat(targetElement.isEnabled()).as("enabled").isTrue();

--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -51,6 +51,8 @@ import com.google.common.collect.Iterables;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * A Base Page is an extension of the Core Page, providing the navigation bar
  * and sidebar links common to most pages outside of the editor.
@@ -264,15 +266,11 @@ public class BasePage extends CorePage {
         return new ProjectsPage(getDriver());
     }
 
-    public BasePage waitForSearchListContains(final String expected) {
+    public BasePage expectSearchListContains(final String expected) {
+        waitForPageSilence();
         String msg = "Project search list contains " + expected;
-        logWaiting(msg);
-        waitForAMoment().withMessage(msg).until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getProjectSearchAutocompleteItems().contains(expected);
-            }
-        });
+        assertThat(getProjectSearchAutocompleteItems()).as(msg).contains(
+                expected);
         return new BasePage(getDriver());
     }
 
@@ -341,7 +339,7 @@ public class BasePage extends CorePage {
     }
 
     public void clickElement(By findby) {
-        scrollIntoView(waitForWebElement(findby));
-        waitForWebElement(findby).click();
+        scrollIntoView(expectWebElement(findby));
+        expectWebElement(findby).click();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/BasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/BasePage.java
@@ -339,7 +339,7 @@ public class BasePage extends CorePage {
     }
 
     public void clickElement(By findby) {
-        scrollIntoView(expectWebElement(findby));
-        expectWebElement(findby).click();
+        scrollIntoView(readyElement(findby));
+        readyElement(findby).click();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -61,7 +61,7 @@ public class CorePage extends AbstractPage {
     public HomePage goToHomePage() {
         log.info("Click Zanata home icon");
         scrollToTop();
-        expectWebElement(homeLink).click();
+        readyElement(homeLink).click();
         return new HomePage(getDriver());
     }
 
@@ -138,7 +138,7 @@ public class CorePage extends AbstractPage {
 
     public String getNotificationMessage() {
         log.info("Query notification message");
-        List<WebElement> messages = expectElementExists(By.id("messages"))
+        List<WebElement> messages = existingElement(By.id("messages"))
                         .findElements(By.tagName("li"));
         return messages.size() > 0 ? messages.get(0).getText() : "";
     }
@@ -201,7 +201,8 @@ public class CorePage extends AbstractPage {
     public void defocus(By elementBy) {
         log.info("Force unfocus");
         WebElement element = getDriver().findElement(elementBy);
-        ((JavascriptExecutor) getDriver()).executeScript("arguments[0].blur()", element);
+        ((JavascriptExecutor) getDriver()).executeScript("arguments[0].blur()",
+                element);
         waitForPageSilence();
     }
 

--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -30,7 +30,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.utility.HomePage;
 import org.zanata.util.WebElementUtil;
 
@@ -62,7 +61,7 @@ public class CorePage extends AbstractPage {
     public HomePage goToHomePage() {
         log.info("Click Zanata home icon");
         scrollToTop();
-        waitForWebElement(homeLink).click();
+        expectWebElement(homeLink).click();
         return new HomePage(getDriver());
     }
 
@@ -139,7 +138,7 @@ public class CorePage extends AbstractPage {
 
     public String getNotificationMessage() {
         log.info("Query notification message");
-        List<WebElement> messages = waitForElementExists(By.id("messages"))
+        List<WebElement> messages = expectElementExists(By.id("messages"))
                         .findElements(By.tagName("li"));
         return messages.size() > 0 ? messages.get(0).getText() : "";
     }

--- a/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
@@ -65,7 +65,6 @@ public enum WebDriverFactory {
         WebDriver driver = createPlainDriver();
         webdriverWait = Integer.parseInt(PropertiesHolder
                 .getProperty(webDriverWait.value()));
-        driver.manage().timeouts().implicitlyWait(3, TimeUnit.SECONDS);
         Runtime.getRuntime().addShutdownHook(new ShutdownHook());
         return driver;
     }

--- a/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
@@ -45,36 +45,36 @@ public class EditProfilePage extends BasePage {
 
     public EditProfilePage enterName(String name) {
         log.info("Enter name {}", name);
-        expectWebElement(nameField).clear();
-        expectWebElement(nameField).sendKeys(name);
+        readyElement(nameField).clear();
+        readyElement(nameField).sendKeys(name);
         defocus(nameField);
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        expectWebElement(usernameField).clear();
-        expectWebElement(usernameField).sendKeys(userName);
+        readyElement(usernameField).clear();
+        readyElement(usernameField).sendKeys(userName);
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterEmail(String email) {
         log.info("Enter email {}", email);
-        expectWebElement(emailField).clear();
-        expectWebElement(emailField).sendKeys(email);
+        readyElement(emailField).clear();
+        readyElement(emailField).sendKeys(email);
         defocus(emailField);
         return new EditProfilePage(getDriver());
     }
 
     public HomePage clickSave() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new HomePage(getDriver());
     }
 
     public EditProfilePage clickSaveAndExpectErrors() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new EditProfilePage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/EditProfilePage.java
@@ -45,36 +45,36 @@ public class EditProfilePage extends BasePage {
 
     public EditProfilePage enterName(String name) {
         log.info("Enter name {}", name);
-        waitForWebElement(nameField).clear();
-        waitForWebElement(nameField).sendKeys(name);
+        expectWebElement(nameField).clear();
+        expectWebElement(nameField).sendKeys(name);
         defocus(nameField);
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        waitForWebElement(usernameField).clear();
-        waitForWebElement(usernameField).sendKeys(userName);
+        expectWebElement(usernameField).clear();
+        expectWebElement(usernameField).sendKeys(userName);
         return new EditProfilePage(getDriver());
     }
 
     public EditProfilePage enterEmail(String email) {
         log.info("Enter email {}", email);
-        waitForWebElement(emailField).clear();
-        waitForWebElement(emailField).sendKeys(email);
+        expectWebElement(emailField).clear();
+        expectWebElement(emailField).sendKeys(email);
         defocus(emailField);
         return new EditProfilePage(getDriver());
     }
 
     public HomePage clickSave() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new HomePage(getDriver());
     }
 
     public EditProfilePage clickSaveAndExpectErrors() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new EditProfilePage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
@@ -66,47 +66,47 @@ public class RegisterPage extends CorePage {
 
     public RegisterPage enterName(String name) {
         log.info("Enter name {}", name);
-        waitForWebElement(nameField).sendKeys(name);
+        expectWebElement(nameField).sendKeys(name);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        waitForWebElement(usernameField).sendKeys(userName);
+        expectWebElement(usernameField).sendKeys(userName);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        waitForWebElement(emailField).sendKeys(email);
+        expectWebElement(emailField).sendKeys(email);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        waitForWebElement(passwordField).sendKeys(password);
+        expectWebElement(passwordField).sendKeys(password);
         return new RegisterPage(getDriver());
     }
 
     // TODO: Add a "signup success" page
     public HomePage register() {
         log.info("Click Sign Up");
-        waitForWebElement(signUpButton).click();
+        expectWebElement(signUpButton).click();
         return new HomePage(getDriver());
     }
 
     public RegisterPage registerFailure() {
         log.info("Click Sign Up");
-        waitForWebElement(signUpButton).click();
+        expectWebElement(signUpButton).click();
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage clearFields() {
         log.info("Clear fields");
-        waitForWebElement(nameField).clear();
-        waitForWebElement(emailField).clear();
-        waitForWebElement(usernameField).clear();
-        waitForWebElement(passwordField).clear();
+        expectWebElement(nameField).clear();
+        expectWebElement(emailField).clear();
+        expectWebElement(usernameField).clear();
+        expectWebElement(passwordField).clear();
         return new RegisterPage(getDriver());
     }
 
@@ -124,28 +124,28 @@ public class RegisterPage extends CorePage {
 
     public String getPageTitle() {
         log.info("Query page title");
-        return waitForWebElement(titleLabel).getText();
+        return expectWebElement(titleLabel).getText();
     }
 
     public SignInPage goToSignIn() {
         log.info("Click Log In");
-        waitForWebElement(loginLink).click();
+        expectWebElement(loginLink).click();
         return new SignInPage(getDriver());
     }
 
     public RegisterPage clickPasswordShowToggle() {
         log.info("Click Show/Hide");
-        waitForWebElement(showHideToggleButton).click();
+        expectWebElement(showHideToggleButton).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPassword() {
         log.info("Query password");
-        return waitForWebElement(passwordField).getAttribute("value");
+        return expectWebElement(passwordField).getAttribute("value");
     }
 
     public String getPasswordFieldType() {
         log.info("Query password field type");
-        return waitForWebElement(passwordField).getAttribute("type");
+        return expectWebElement(passwordField).getAttribute("type");
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/RegisterPage.java
@@ -20,14 +20,12 @@
  */
 package org.zanata.page.account;
 
-import com.google.common.collect.ImmutableList;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.zanata.page.CorePage;
 import org.zanata.page.utility.HomePage;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,47 +64,47 @@ public class RegisterPage extends CorePage {
 
     public RegisterPage enterName(String name) {
         log.info("Enter name {}", name);
-        expectWebElement(nameField).sendKeys(name);
+        readyElement(nameField).sendKeys(name);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterUserName(String userName) {
         log.info("Enter username {}", userName);
-        expectWebElement(usernameField).sendKeys(userName);
+        readyElement(usernameField).sendKeys(userName);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        expectWebElement(emailField).sendKeys(email);
+        readyElement(emailField).sendKeys(email);
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        expectWebElement(passwordField).sendKeys(password);
+        readyElement(passwordField).sendKeys(password);
         return new RegisterPage(getDriver());
     }
 
     // TODO: Add a "signup success" page
     public HomePage register() {
         log.info("Click Sign Up");
-        expectWebElement(signUpButton).click();
+        readyElement(signUpButton).click();
         return new HomePage(getDriver());
     }
 
     public RegisterPage registerFailure() {
         log.info("Click Sign Up");
-        expectWebElement(signUpButton).click();
+        readyElement(signUpButton).click();
         return new RegisterPage(getDriver());
     }
 
     public RegisterPage clearFields() {
         log.info("Clear fields");
-        expectWebElement(nameField).clear();
-        expectWebElement(emailField).clear();
-        expectWebElement(usernameField).clear();
-        expectWebElement(passwordField).clear();
+        readyElement(nameField).clear();
+        readyElement(emailField).clear();
+        readyElement(usernameField).clear();
+        readyElement(passwordField).clear();
         return new RegisterPage(getDriver());
     }
 
@@ -124,28 +122,28 @@ public class RegisterPage extends CorePage {
 
     public String getPageTitle() {
         log.info("Query page title");
-        return expectWebElement(titleLabel).getText();
+        return readyElement(titleLabel).getText();
     }
 
     public SignInPage goToSignIn() {
         log.info("Click Log In");
-        expectWebElement(loginLink).click();
+        readyElement(loginLink).click();
         return new SignInPage(getDriver());
     }
 
     public RegisterPage clickPasswordShowToggle() {
         log.info("Click Show/Hide");
-        expectWebElement(showHideToggleButton).click();
+        readyElement(showHideToggleButton).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPassword() {
         log.info("Query password");
-        return expectWebElement(passwordField).getAttribute("value");
+        return readyElement(passwordField).getAttribute("value");
     }
 
     public String getPasswordFieldType() {
         log.info("Query password field type");
-        return expectWebElement(passwordField).getAttribute("type");
+        return readyElement(passwordField).getAttribute("type");
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
@@ -42,32 +42,32 @@ public class ResetPasswordPage extends BasePage {
 
     public ResetPasswordPage enterUserName(String username) {
         log.info("Enter username {}", username);
-        expectWebElement(usernameField).sendKeys(username);
+        readyElement(usernameField).sendKeys(username);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        expectWebElement(emailField).sendKeys(email);
+        readyElement(emailField).sendKeys(email);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage clearFields() {
         log.info("Clear fields");
-        expectWebElement(usernameField).clear();
-        expectWebElement(emailField).clear();
+        readyElement(usernameField).clear();
+        readyElement(emailField).clear();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetPassword() {
         log.info("Click Submit");
-        expectWebElement(submitButton).click();
+        readyElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetFailure() {
         log.info("Click Submit");
-        expectWebElement(submitButton).click();
+        readyElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/ResetPasswordPage.java
@@ -42,32 +42,32 @@ public class ResetPasswordPage extends BasePage {
 
     public ResetPasswordPage enterUserName(String username) {
         log.info("Enter username {}", username);
-        waitForWebElement(usernameField).sendKeys(username);
+        expectWebElement(usernameField).sendKeys(username);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage enterEmail(String email) {
         log.info("Enter email {}", email);
-        waitForWebElement(emailField).sendKeys(email);
+        expectWebElement(emailField).sendKeys(email);
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage clearFields() {
         log.info("Clear fields");
-        waitForWebElement(usernameField).clear();
-        waitForWebElement(emailField).clear();
+        expectWebElement(usernameField).clear();
+        expectWebElement(emailField).clear();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetPassword() {
         log.info("Click Submit");
-        waitForWebElement(submitButton).click();
+        expectWebElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public ResetPasswordPage resetFailure() {
         log.info("Click Submit");
-        waitForWebElement(submitButton).click();
+        expectWebElement(submitButton).click();
         return new ResetPasswordPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
@@ -47,48 +47,48 @@ public class SignInPage extends CorePage {
 
     public SignInPage enterUsername(String username) {
         log.info("Enter username {}", username);
-        expectWebElement(usernameField).sendKeys(username);
+        readyElement(usernameField).sendKeys(username);
         return new SignInPage(getDriver());
     }
 
     public SignInPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        expectWebElement(passwordField).sendKeys(password);
+        readyElement(passwordField).sendKeys(password);
         return new SignInPage(getDriver());
     }
 
     public DashboardBasePage clickSignIn() {
         log.info("Click Sign In");
-        expectWebElement(signInButton).click();
+        readyElement(signInButton).click();
         return new DashboardBasePage(getDriver());
     }
 
     public SignInPage clickSignInExpectError() {
         log.info("Click Sign In");
-        expectWebElement(signInButton).click();
+        readyElement(signInButton).click();
         return new SignInPage(getDriver());
     }
 
     public GoogleAccountPage selectGoogleOpenID() {
         log.info("Click 'Google'");
-        expectWebElement(googleButton).click();
+        readyElement(googleButton).click();
         return new GoogleAccountPage(getDriver());
     }
 
     public ResetPasswordPage goToResetPassword() {
         log.info("Click Forgot Password");
-        expectWebElement(forgotPasswordLink).click();
+        readyElement(forgotPasswordLink).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public RegisterPage goToRegister() {
         log.info("Click Sign Up");
-        expectWebElement(signUpLink).click();
+        readyElement(signUpLink).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPageTitle() {
         log.info("Query page title");
-        return expectWebElement(titleLabel).getText();
+        return readyElement(titleLabel).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
+++ b/functional-test/src/main/java/org/zanata/page/account/SignInPage.java
@@ -47,48 +47,48 @@ public class SignInPage extends CorePage {
 
     public SignInPage enterUsername(String username) {
         log.info("Enter username {}", username);
-        waitForWebElement(usernameField).sendKeys(username);
+        expectWebElement(usernameField).sendKeys(username);
         return new SignInPage(getDriver());
     }
 
     public SignInPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        waitForWebElement(passwordField).sendKeys(password);
+        expectWebElement(passwordField).sendKeys(password);
         return new SignInPage(getDriver());
     }
 
     public DashboardBasePage clickSignIn() {
         log.info("Click Sign In");
-        waitForWebElement(signInButton).click();
+        expectWebElement(signInButton).click();
         return new DashboardBasePage(getDriver());
     }
 
     public SignInPage clickSignInExpectError() {
         log.info("Click Sign In");
-        waitForWebElement(signInButton).click();
+        expectWebElement(signInButton).click();
         return new SignInPage(getDriver());
     }
 
     public GoogleAccountPage selectGoogleOpenID() {
         log.info("Click 'Google'");
-        waitForWebElement(googleButton).click();
+        expectWebElement(googleButton).click();
         return new GoogleAccountPage(getDriver());
     }
 
     public ResetPasswordPage goToResetPassword() {
         log.info("Click Forgot Password");
-        waitForWebElement(forgotPasswordLink).click();
+        expectWebElement(forgotPasswordLink).click();
         return new ResetPasswordPage(getDriver());
     }
 
     public RegisterPage goToRegister() {
         log.info("Click Sign Up");
-        waitForWebElement(signUpLink).click();
+        expectWebElement(signUpLink).click();
         return new RegisterPage(getDriver());
     }
 
     public String getPageTitle() {
         log.info("Query page title");
-        return waitForWebElement(titleLabel).getText();
+        return expectWebElement(titleLabel).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
@@ -59,7 +59,7 @@ public class AddLanguagePage extends BasePage {
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver driver) {
-                List < WebElement > searchResults =
+                List<WebElement> searchResults =
                         WebElementUtil.getSearchAutocompleteResults(
                                 driver,
                                 "addLanguageForm",
@@ -81,22 +81,22 @@ public class AddLanguagePage extends BasePage {
     public AddLanguagePage expectPluralsWarning() {
         log.info("Expect plurals warning");
         waitForPageSilence();
-        expectWebElement(pluralsWarning);
+        readyElement(pluralsWarning);
         return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage enableLanguageByDefault() {
         log.info("Click Enable by default");
-        if (!expectWebElement(enabledByDefaultCheckbox).isSelected()) {
-            expectWebElement(enabledByDefaultCheckbox).click();
+        if (!readyElement(enabledByDefaultCheckbox).isSelected()) {
+            readyElement(enabledByDefaultCheckbox).click();
         }
         return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage disableLanguageByDefault() {
         log.info("Click Disable by default");
-        if (expectWebElement(enabledByDefaultCheckbox).isSelected()) {
-            expectWebElement(enabledByDefaultCheckbox).click();
+        if (readyElement(enabledByDefaultCheckbox).isSelected()) {
+            readyElement(enabledByDefaultCheckbox).click();
         }
         return new AddLanguagePage(getDriver());
     }
@@ -108,13 +108,13 @@ public class AddLanguagePage extends BasePage {
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                return !expectElementExists(languageInfo)
+                return !existingElement(languageInfo)
                         .findElements(By.className("l--push-top-half"))
                         .get(0).findElement(languageInfoItem)
                         .getText().isEmpty();
             }
         });
-        for (WebElement item : expectElementExists(languageInfo)
+        for (WebElement item : existingElement(languageInfo)
                 .findElements(By.className("l--push-top-half"))) {
             String name = item.getText();
             String value = item.findElement(languageInfoItem).getText();
@@ -128,7 +128,7 @@ public class AddLanguagePage extends BasePage {
 
     public ManageLanguagePage saveLanguage() {
         log.info("Click Save");
-        clickAndCheckErrors(expectWebElement(saveButton));
+        clickAndCheckErrors(readyElement(saveButton));
         return new ManageLanguagePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
@@ -78,24 +78,25 @@ public class AddLanguagePage extends BasePage {
         return new AddLanguagePage(getDriver());
     }
 
-    public AddLanguagePage waitForPluralsWarning() {
+    public AddLanguagePage expectPluralsWarning() {
         log.info("Expect plurals warning");
-        waitForWebElement(pluralsWarning);
+        waitForPageSilence();
+        expectWebElement(pluralsWarning);
         return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage enableLanguageByDefault() {
         log.info("Click Enable by default");
-        if (!waitForWebElement(enabledByDefaultCheckbox).isSelected()) {
-            waitForWebElement(enabledByDefaultCheckbox).click();
+        if (!expectWebElement(enabledByDefaultCheckbox).isSelected()) {
+            expectWebElement(enabledByDefaultCheckbox).click();
         }
         return new AddLanguagePage(getDriver());
     }
 
     public AddLanguagePage disableLanguageByDefault() {
         log.info("Click Disable by default");
-        if (waitForWebElement(enabledByDefaultCheckbox).isSelected()) {
-            waitForWebElement(enabledByDefaultCheckbox).click();
+        if (expectWebElement(enabledByDefaultCheckbox).isSelected()) {
+            expectWebElement(enabledByDefaultCheckbox).click();
         }
         return new AddLanguagePage(getDriver());
     }
@@ -107,13 +108,13 @@ public class AddLanguagePage extends BasePage {
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                return !waitForElementExists(languageInfo)
+                return !expectElementExists(languageInfo)
                         .findElements(By.className("l--push-top-half"))
                         .get(0).findElement(languageInfoItem)
                         .getText().isEmpty();
             }
         });
-        for (WebElement item : waitForElementExists(languageInfo)
+        for (WebElement item : expectElementExists(languageInfo)
                 .findElements(By.className("l--push-top-half"))) {
             String name = item.getText();
             String value = item.findElement(languageInfoItem).getText();
@@ -127,7 +128,7 @@ public class AddLanguagePage extends BasePage {
 
     public ManageLanguagePage saveLanguage() {
         log.info("Click Save");
-        clickAndCheckErrors(waitForWebElement(saveButton));
+        clickAndCheckErrors(expectWebElement(saveButton));
         return new ManageLanguagePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
@@ -43,19 +43,19 @@ public class EditHomeCodePage extends BasePage {
 
     public EditHomeCodePage enterText(String text) {
         log.info("Enter homepage text\n{}", text);
-        expectWebElement(textEdit).sendKeys(text);
+        readyElement(textEdit).sendKeys(text);
         return new EditHomeCodePage(getDriver());
     }
 
     public HomePage update() {
         log.info("Click Update");
-        expectWebElement(updateButton).click();
+        readyElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        expectWebElement(cancelButton).click();
+        readyElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeCodePage.java
@@ -43,19 +43,19 @@ public class EditHomeCodePage extends BasePage {
 
     public EditHomeCodePage enterText(String text) {
         log.info("Enter homepage text\n{}", text);
-        waitForWebElement(textEdit).sendKeys(text);
+        expectWebElement(textEdit).sendKeys(text);
         return new EditHomeCodePage(getDriver());
     }
 
     public HomePage update() {
         log.info("Click Update");
-        waitForWebElement(updateButton).click();
+        expectWebElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        waitForWebElement(cancelButton).click();
+        expectWebElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
@@ -20,12 +20,9 @@
  */
 package org.zanata.page.administration;
 
-import com.google.common.base.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.BasePage;
 import org.zanata.page.utility.HomePage;
 
@@ -46,10 +43,10 @@ public class EditHomeContentPage extends BasePage {
     public EditHomeContentPage enterText(String text) {
         log.info("Enter homepage code\n{}", text);
         // Switch to the CKEditor frame
-        getDriver().switchTo().frame(waitForWebElement(By
+        getDriver().switchTo().frame(expectWebElement(By
                 .id("cke_homeContentForm:homeContent:inp"))
                 .findElement(By.tagName("iframe")));
-        waitForWebElement(By.tagName("body")).sendKeys(text);
+        expectWebElement(By.tagName("body")).sendKeys(text);
         // Switch back!
         getDriver().switchTo().defaultContent();
         return new EditHomeContentPage(getDriver());
@@ -57,13 +54,13 @@ public class EditHomeContentPage extends BasePage {
 
     public HomePage update() {
         log.info("Click Update");
-        waitForWebElement(updateButton).click();
+        expectWebElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        waitForWebElement(cancelButton).click();
+        expectWebElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditHomeContentPage.java
@@ -43,10 +43,10 @@ public class EditHomeContentPage extends BasePage {
     public EditHomeContentPage enterText(String text) {
         log.info("Enter homepage code\n{}", text);
         // Switch to the CKEditor frame
-        getDriver().switchTo().frame(expectWebElement(By
+        getDriver().switchTo().frame(readyElement(By
                 .id("cke_homeContentForm:homeContent:inp"))
                 .findElement(By.tagName("iframe")));
-        expectWebElement(By.tagName("body")).sendKeys(text);
+        readyElement(By.tagName("body")).sendKeys(text);
         // Switch back!
         getDriver().switchTo().defaultContent();
         return new EditHomeContentPage(getDriver());
@@ -54,13 +54,13 @@ public class EditHomeContentPage extends BasePage {
 
     public HomePage update() {
         log.info("Click Update");
-        expectWebElement(updateButton).click();
+        readyElement(updateButton).click();
         return new HomePage(getDriver());
     }
 
     public HomePage cancelUpdate() {
         log.info("Click Cancel");
-        expectWebElement(cancelButton).click();
+        readyElement(cancelButton).click();
         return new HomePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
@@ -44,32 +44,32 @@ public class EditRoleAssignmentPage extends BasePage {
 
     public EditRoleAssignmentPage selectPolicy(String policy) {
         log.info("Select policy {}", policy);
-        new Select(waitForWebElement(policySelect)).selectByValue(policy);
+        new Select(expectWebElement(policySelect)).selectByValue(policy);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage enterIdentityPattern(String pattern) {
         log.info("Enter identity pattern {}", pattern);
-        waitForWebElement(patternField).clear();
-        waitForWebElement(patternField).sendKeys(pattern);
+        expectWebElement(patternField).clear();
+        expectWebElement(patternField).sendKeys(pattern);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage selectRole(String role) {
         log.info("Select role {}", role);
-        new Select(waitForWebElement(roleSelect)).selectByValue(role);
+        new Select(expectWebElement(roleSelect)).selectByValue(role);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public RoleAssignmentsPage saveRoleAssignment() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new RoleAssignmentsPage(getDriver());
     }
 
     public RoleAssignmentsPage cancelEditRoleAssignment() {
         log.info("Click Cancel");
-        waitForWebElement(cancelButton).click();
+        expectWebElement(cancelButton).click();
         return new RoleAssignmentsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/EditRoleAssignmentPage.java
@@ -44,32 +44,32 @@ public class EditRoleAssignmentPage extends BasePage {
 
     public EditRoleAssignmentPage selectPolicy(String policy) {
         log.info("Select policy {}", policy);
-        new Select(expectWebElement(policySelect)).selectByValue(policy);
+        new Select(readyElement(policySelect)).selectByValue(policy);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage enterIdentityPattern(String pattern) {
         log.info("Enter identity pattern {}", pattern);
-        expectWebElement(patternField).clear();
-        expectWebElement(patternField).sendKeys(pattern);
+        readyElement(patternField).clear();
+        readyElement(patternField).sendKeys(pattern);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public EditRoleAssignmentPage selectRole(String role) {
         log.info("Select role {}", role);
-        new Select(expectWebElement(roleSelect)).selectByValue(role);
+        new Select(readyElement(roleSelect)).selectByValue(role);
         return new EditRoleAssignmentPage(getDriver());
     }
 
     public RoleAssignmentsPage saveRoleAssignment() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new RoleAssignmentsPage(getDriver());
     }
 
     public RoleAssignmentsPage cancelEditRoleAssignment() {
         log.info("Click Cancel");
-        expectWebElement(cancelButton).click();
+        readyElement(cancelButton).click();
         return new RoleAssignmentsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
@@ -66,14 +66,18 @@ public class ManageLanguagePage extends BasePage {
     }
 
     public ManageLanguagePage clickOptions(String localeId) {
-        findRowByLocale(localeId).findElement(By.className("dropdown__toggle"))
+        readyElement(findRowByLocale(localeId), By.className("dropdown__toggle"))
                 .click();
         return new ManageLanguagePage(getDriver());
     }
 
     public ManageLanguagePage enableLanguageByDefault(String localeId) {
         log.info("Click to enable {}", localeId);
-        findRowByLocale(localeId).findElement(enableByDefault).click();
+        if (findRowByLocale(localeId).findElements(disableByDefault).size() > 0) {
+            log.warn("Language already enabled!");
+            return new ManageLanguagePage(getDriver());
+        }
+        readyElement(findRowByLocale(localeId), enableByDefault).click();
         switchToAlert().accept();
         return new ManageLanguagePage(getDriver());
     }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
@@ -48,13 +48,13 @@ public class ManageLanguagePage extends BasePage {
 
     public ManageLanguagePage clickMoreActions() {
         log.info("Click More Actions dropdown");
-        waitForWebElement(moreActions).click();
+        expectWebElement(moreActions).click();
         return new ManageLanguagePage(getDriver());
     }
 
     public AddLanguagePage addNewLanguage() {
         log.info("Click Add New Language");
-        waitForWebElement(addLanguageButton).click();
+        expectWebElement(addLanguageButton).click();
         return new AddLanguagePage(getDriver());
     }
 
@@ -110,7 +110,7 @@ public class ManageLanguagePage extends BasePage {
     }
 
     private List<WebElement> getRows() {
-        return waitForWebElement(waitForElementExists(By.id("languageForm")),
+        return expectWebElement(expectElementExists(By.id("languageForm")),
                 By.className("list--stats"))
                 .findElements(By.className("list__item--actionable"));
     }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguagePage.java
@@ -48,13 +48,13 @@ public class ManageLanguagePage extends BasePage {
 
     public ManageLanguagePage clickMoreActions() {
         log.info("Click More Actions dropdown");
-        expectWebElement(moreActions).click();
+        readyElement(moreActions).click();
         return new ManageLanguagePage(getDriver());
     }
 
     public AddLanguagePage addNewLanguage() {
         log.info("Click Add New Language");
-        expectWebElement(addLanguageButton).click();
+        readyElement(addLanguageButton).click();
         return new AddLanguagePage(getDriver());
     }
 
@@ -110,7 +110,7 @@ public class ManageLanguagePage extends BasePage {
     }
 
     private List<WebElement> getRows() {
-        return expectWebElement(expectElementExists(By.id("languageForm")),
+        return readyElement(existingElement(By.id("languageForm")),
                 By.className("list--stats"))
                 .findElements(By.className("list__item--actionable"));
     }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
@@ -63,13 +63,13 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickMoreActions() {
         log.info("Click More Actions dropdown");
-        waitForWebElement(moreActions).click();
+        expectWebElement(moreActions).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     private String getMemberCount() {
         log.info("Query members info");
-        return waitForWebElement(By.className("panel__heading"))
+        return expectWebElement(By.className("panel__heading"))
                 .findElement(By.className("i--users")).getText().trim();
     }
 
@@ -80,7 +80,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
             return Collections.emptyList();
         }
         List<String> names = new ArrayList<>();
-        for (WebElement listEntry : waitForWebElement(memberPanel)
+        for (WebElement listEntry : expectWebElement(memberPanel)
                 .findElements(By.className("list__item--actionable"))) {
             names.add(listEntry.findElement(By.tagName("h3")).getText().trim());
         }
@@ -89,7 +89,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage joinLanguageTeam() {
         log.info("Click Join");
-        waitForWebElement(joinLanguageTeamButton).click();
+        expectWebElement(joinLanguageTeamButton).click();
         // we need to wait for this join to finish before returning the page
         waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
@@ -102,19 +102,19 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickAddTeamMember() {
         log.info("Click Add Team Member");
-        waitForWebElement(addTeamMemberButton).click();
+        expectWebElement(addTeamMemberButton).click();
         return this;
     }
 
     public ManageLanguageTeamMemberPage enterUsername(String username) {
         log.info("Enter username search {}", username);
-        waitForWebElement(addUserSearchInput).sendKeys(username);
+        expectWebElement(addUserSearchInput).sendKeys(username);
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     public ManageLanguageTeamMemberPage clickSearch() {
         log.info("Click Search");
-        waitForWebElement(addUserSearchButton).click();
+        expectWebElement(addUserSearchButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
@@ -122,7 +122,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
         return waitForAMoment().until(new Function<WebDriver, WebElement>() {
             @Override
             public WebElement apply(WebDriver input) {
-                WebElement list = waitForWebElement(personTable)
+                WebElement list = expectWebElement(personTable)
                         .findElement(By.className("list--slat"));
                 List<WebElement> rows = list
                         .findElements(By.className("txt--meta"));
@@ -172,13 +172,13 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickAddSelectedButton() {
         log.info("Click Add Selected");
-        waitForWebElement(addSelectedButton).click();
+        expectWebElement(addSelectedButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     public ManageLanguageTeamMemberPage clickCloseSearchDialog() {
         log.info("Click Close");
-        waitForWebElement(closeSearchButton).click();
+        expectWebElement(closeSearchButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageLanguageTeamMemberPage.java
@@ -63,13 +63,13 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickMoreActions() {
         log.info("Click More Actions dropdown");
-        expectWebElement(moreActions).click();
+        readyElement(moreActions).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     private String getMemberCount() {
         log.info("Query members info");
-        return expectWebElement(By.className("panel__heading"))
+        return readyElement(By.className("panel__heading"))
                 .findElement(By.className("i--users")).getText().trim();
     }
 
@@ -80,7 +80,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
             return Collections.emptyList();
         }
         List<String> names = new ArrayList<>();
-        for (WebElement listEntry : expectWebElement(memberPanel)
+        for (WebElement listEntry : readyElement(memberPanel)
                 .findElements(By.className("list__item--actionable"))) {
             names.add(listEntry.findElement(By.tagName("h3")).getText().trim());
         }
@@ -89,7 +89,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage joinLanguageTeam() {
         log.info("Click Join");
-        expectWebElement(joinLanguageTeamButton).click();
+        readyElement(joinLanguageTeamButton).click();
         // we need to wait for this join to finish before returning the page
         waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
@@ -102,19 +102,19 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickAddTeamMember() {
         log.info("Click Add Team Member");
-        expectWebElement(addTeamMemberButton).click();
+        readyElement(addTeamMemberButton).click();
         return this;
     }
 
     public ManageLanguageTeamMemberPage enterUsername(String username) {
         log.info("Enter username search {}", username);
-        expectWebElement(addUserSearchInput).sendKeys(username);
+        readyElement(addUserSearchInput).sendKeys(username);
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     public ManageLanguageTeamMemberPage clickSearch() {
         log.info("Click Search");
-        expectWebElement(addUserSearchButton).click();
+        readyElement(addUserSearchButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
@@ -122,7 +122,7 @@ public class ManageLanguageTeamMemberPage extends BasePage {
         return waitForAMoment().until(new Function<WebDriver, WebElement>() {
             @Override
             public WebElement apply(WebDriver input) {
-                WebElement list = expectWebElement(personTable)
+                WebElement list = readyElement(personTable)
                         .findElement(By.className("list--slat"));
                 List<WebElement> rows = list
                         .findElements(By.className("txt--meta"));
@@ -172,13 +172,13 @@ public class ManageLanguageTeamMemberPage extends BasePage {
 
     public ManageLanguageTeamMemberPage clickAddSelectedButton() {
         log.info("Click Add Selected");
-        expectWebElement(addSelectedButton).click();
+        readyElement(addSelectedButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 
     public ManageLanguageTeamMemberPage clickCloseSearchDialog() {
         log.info("Click Close");
-        expectWebElement(closeSearchButton).click();
+        readyElement(closeSearchButton).click();
         return new ManageLanguageTeamMemberPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
@@ -57,7 +57,7 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage selectAllActionsFor(String clazz) {
         List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
-                expectWebElement(classesTable));
+                readyElement(classesTable));
         for (TableRow tableRow : tableRows) {
             if (tableRow.getCellContents().contains(clazz)) {
                 WebElement allActionsChkBox =
@@ -71,7 +71,7 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage clickSelectAll() {
         log.info("Click Select All");
-        expectWebElement(selectAllButton).click();
+        readyElement(selectAllButton).click();
         // It seems that if the Select All and Perform buttons are clicked too
         // quickly in succession, the operation will fail
         try {
@@ -85,7 +85,7 @@ public class ManageSearchPage extends BasePage {
     public boolean allActionsSelected() {
         log.info("Query all actions selected");
         List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
-                expectWebElement(expectElementExists(classesTable),
+                readyElement(existingElement(classesTable),
                         By.tagName("table")));
         for (TableRow tableRow : tableRows) {
             // column 2, 3, 4 are checkboxes for purge, reindex and optimize
@@ -101,12 +101,12 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage performSelectedActions() {
         log.info("Click Perform Actions");
-        expectWebElement(performButton).click();
+        readyElement(performButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 // The Abort button will display
-                return expectWebElement(cancelButton).isDisplayed();
+                return readyElement(cancelButton).isDisplayed();
             }
         });
         return new ManageSearchPage(getDriver());
@@ -115,30 +115,30 @@ public class ManageSearchPage extends BasePage {
     public ManageSearchPage expectActionsToFinish() {
         log.info("Wait: all actions are finished");
         // once the button re-appears, it means the reindex is done.
-        expectWebElement(performButton);
+        readyElement(performButton);
         return new ManageSearchPage(getDriver());
     }
 
     public ManageSearchPage abort() {
         log.info("Click Abort");
-        expectWebElement(abortButton).click();
+        readyElement(abortButton).click();
         return new ManageSearchPage(getDriver());
     }
 
 
     public boolean noOperationsRunningIsDisplayed() {
         log.info("Query No Operations");
-        return expectWebElement(noOpsLabel).isDisplayed();
+        return readyElement(noOpsLabel).isDisplayed();
     }
 
     public boolean completedIsDisplayed() {
         log.info("Query is action completed");
-        return expectWebElement(completedLabel).isDisplayed();
+        return readyElement(completedLabel).isDisplayed();
     }
 
     public boolean abortedIsDisplayed() {
         log.info("Query is action aborted");
-        return expectWebElement(abortedLabel).isDisplayed();
+        return readyElement(abortedLabel).isDisplayed();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageSearchPage.java
@@ -57,7 +57,7 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage selectAllActionsFor(String clazz) {
         List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
-                waitForWebElement(classesTable));
+                expectWebElement(classesTable));
         for (TableRow tableRow : tableRows) {
             if (tableRow.getCellContents().contains(clazz)) {
                 WebElement allActionsChkBox =
@@ -71,7 +71,7 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage clickSelectAll() {
         log.info("Click Select All");
-        waitForWebElement(selectAllButton).click();
+        expectWebElement(selectAllButton).click();
         // It seems that if the Select All and Perform buttons are clicked too
         // quickly in succession, the operation will fail
         try {
@@ -85,7 +85,7 @@ public class ManageSearchPage extends BasePage {
     public boolean allActionsSelected() {
         log.info("Query all actions selected");
         List<TableRow> tableRows = WebElementUtil.getTableRows(getDriver(),
-                waitForWebElement(waitForElementExists(classesTable),
+                expectWebElement(expectElementExists(classesTable),
                         By.tagName("table")));
         for (TableRow tableRow : tableRows) {
             // column 2, 3, 4 are checkboxes for purge, reindex and optimize
@@ -101,49 +101,44 @@ public class ManageSearchPage extends BasePage {
 
     public ManageSearchPage performSelectedActions() {
         log.info("Click Perform Actions");
-        waitForWebElement(performButton).click();
+        expectWebElement(performButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 // The Abort button will display
-                return waitForWebElement(cancelButton).isDisplayed();
+                return expectWebElement(cancelButton).isDisplayed();
             }
         });
         return new ManageSearchPage(getDriver());
     }
 
-    public ManageSearchPage waitForActionsToFinish() {
+    public ManageSearchPage expectActionsToFinish() {
         log.info("Wait: all actions are finished");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                // once the button re-appears, it means the reindex is done.
-                return waitForWebElement(performButton).isDisplayed();
-            }
-        });
+        // once the button re-appears, it means the reindex is done.
+        expectWebElement(performButton);
         return new ManageSearchPage(getDriver());
     }
 
     public ManageSearchPage abort() {
         log.info("Click Abort");
-        waitForWebElement(abortButton).click();
+        expectWebElement(abortButton).click();
         return new ManageSearchPage(getDriver());
     }
 
 
     public boolean noOperationsRunningIsDisplayed() {
         log.info("Query No Operations");
-        return waitForWebElement(noOpsLabel).isDisplayed();
+        return expectWebElement(noOpsLabel).isDisplayed();
     }
 
     public boolean completedIsDisplayed() {
         log.info("Query is action completed");
-        return waitForWebElement(completedLabel).isDisplayed();
+        return expectWebElement(completedLabel).isDisplayed();
     }
 
     public boolean abortedIsDisplayed() {
         log.info("Query is action aborted");
-        return waitForWebElement(abortedLabel).isDisplayed();
+        return expectWebElement(abortedLabel).isDisplayed();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
@@ -58,50 +58,50 @@ public class ManageUserAccountPage extends BasePage {
 
     public ManageUserAccountPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        expectWebElement(passwordField).sendKeys(password);
+        readyElement(passwordField).sendKeys(password);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage enterConfirmPassword(String confirmPassword) {
         log.info("Enter confirm password {}", confirmPassword);
-        expectWebElement(passwordConfirmField).sendKeys(confirmPassword);
+        readyElement(passwordConfirmField).sendKeys(confirmPassword);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickEnabled() {
         log.info("Click Enabled");
-        expectWebElement(enabledField).click();
+        readyElement(enabledField).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickRole(String role) {
         log.info("Click role {}", role);
-        expectWebElement(By.id("userdetailForm:rolesField:roles:"
+        readyElement(By.id("userdetailForm:rolesField:roles:"
                 .concat(roleMap.get(role)))).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public boolean isRoleChecked(String role) {
         log.info("Query is role {} checked", role);
-        return expectWebElement(By.id("userdetailForm:rolesField:roles:"
+        return readyElement(By.id("userdetailForm:rolesField:roles:"
                 .concat(roleMap.get(role)))).isSelected();
     }
 
     public ManageUserPage saveUser() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new ManageUserPage(getDriver());
     }
 
     public ManageUserAccountPage saveUserExpectFailure() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserPage cancelEditUser() {
         log.info("Click Cancel");
-        expectWebElement(cancelButton).click();
+        readyElement(cancelButton).click();
         return new ManageUserPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageUserAccountPage.java
@@ -58,50 +58,50 @@ public class ManageUserAccountPage extends BasePage {
 
     public ManageUserAccountPage enterPassword(String password) {
         log.info("Enter password {}", password);
-        waitForWebElement(passwordField).sendKeys(password);
+        expectWebElement(passwordField).sendKeys(password);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage enterConfirmPassword(String confirmPassword) {
         log.info("Enter confirm password {}", confirmPassword);
-        waitForWebElement(passwordConfirmField).sendKeys(confirmPassword);
+        expectWebElement(passwordConfirmField).sendKeys(confirmPassword);
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickEnabled() {
         log.info("Click Enabled");
-        waitForWebElement(enabledField).click();
+        expectWebElement(enabledField).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserAccountPage clickRole(String role) {
         log.info("Click role {}", role);
-        waitForWebElement(By.id("userdetailForm:rolesField:roles:"
+        expectWebElement(By.id("userdetailForm:rolesField:roles:"
                 .concat(roleMap.get(role)))).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public boolean isRoleChecked(String role) {
         log.info("Query is role {} checked", role);
-        return waitForWebElement(By.id("userdetailForm:rolesField:roles:"
+        return expectWebElement(By.id("userdetailForm:rolesField:roles:"
                 .concat(roleMap.get(role)))).isSelected();
     }
 
     public ManageUserPage saveUser() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new ManageUserPage(getDriver());
     }
 
     public ManageUserAccountPage saveUserExpectFailure() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new ManageUserAccountPage(getDriver());
     }
 
     public ManageUserPage cancelEditUser() {
         log.info("Click Cancel");
-        waitForWebElement(cancelButton).click();
+        expectWebElement(cancelButton).click();
         return new ManageUserPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
@@ -20,17 +20,11 @@
  */
 package org.zanata.page.administration;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zanata.page.BasePage;
-import org.zanata.util.TableRow;
-import org.zanata.util.WebElementUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +58,7 @@ public class ManageUserPage extends BasePage {
     }
 
     public List<WebElement> getRows() {
-        return waitForWebElement(userTable)
+        return expectWebElement(userTable)
                 .findElements(By.className("list__item--actionable"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
@@ -58,7 +58,7 @@ public class ManageUserPage extends BasePage {
     }
 
     public List<WebElement> getRows() {
-        return expectWebElement(userTable)
+        return readyElement(userTable)
                 .findElements(By.className("list__item--actionable"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
@@ -35,11 +35,18 @@ import java.util.List;
 @Slf4j
 public class RoleAssignmentsPage extends BasePage {
 
+    private By moreActions = By.id("roleassign-more-actions");
     private By newRuleButton = By.linkText("New Rule");
     private By roleTable = By.className("list--stats");
 
     public RoleAssignmentsPage(WebDriver driver) {
         super(driver);
+    }
+
+    public RoleAssignmentsPage clickMoreActions() {
+        log.info("Click More Actions dropdown");
+        expectWebElement(moreActions).click();
+        return new RoleAssignmentsPage(getDriver());
     }
 
     public EditRoleAssignmentPage clickCreateNew() {

--- a/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
@@ -45,13 +45,13 @@ public class RoleAssignmentsPage extends BasePage {
 
     public RoleAssignmentsPage clickMoreActions() {
         log.info("Click More Actions dropdown");
-        expectWebElement(moreActions).click();
+        readyElement(moreActions).click();
         return new RoleAssignmentsPage(getDriver());
     }
 
     public EditRoleAssignmentPage clickCreateNew() {
         log.info("Click Create New");
-        expectWebElement(newRuleButton).click();
+        readyElement(newRuleButton).click();
         return new EditRoleAssignmentPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/RoleAssignmentsPage.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.zanata.page.BasePage;
-import org.zanata.util.TableRow;
 import org.zanata.util.WebElementUtil;
 
 import java.util.ArrayList;
@@ -45,7 +44,7 @@ public class RoleAssignmentsPage extends BasePage {
 
     public EditRoleAssignmentPage clickCreateNew() {
         log.info("Click Create New");
-        waitForWebElement(newRuleButton).click();
+        expectWebElement(newRuleButton).click();
         return new EditRoleAssignmentPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
@@ -43,31 +43,31 @@ public class ServerConfigurationPage extends BasePage {
 
     public ServerConfigurationPage inputMaxConcurrent(int max) {
         log.info("Enter maximum concurrent API requests {}", max);
-        expectWebElement(maxConcurrentField).clear();
-        expectWebElement(maxConcurrentField).sendKeys(max + "");
+        readyElement(maxConcurrentField).clear();
+        readyElement(maxConcurrentField).sendKeys(max + "");
         return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxConcurrentRequestsPerApiKey() {
         log.info("Query maximum concurrent API requests");
-        return expectWebElement(maxConcurrentField).getAttribute("value");
+        return readyElement(maxConcurrentField).getAttribute("value");
     }
 
     public ServerConfigurationPage inputMaxActive(int max) {
         log.info("Enter maximum active API requests {}", max);
-        expectWebElement(maxActiveField).clear();
-        expectWebElement(maxActiveField).sendKeys(max + "");
+        readyElement(maxActiveField).clear();
+        readyElement(maxActiveField).sendKeys(max + "");
         return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxActiveRequestsPerApiKey() {
         log.info("Query maximum active API requests");
-        return expectWebElement(maxActiveField).getAttribute("value");
+        return readyElement(maxActiveField).getAttribute("value");
     }
 
     public AdministrationPage save() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new AdministrationPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/ServerConfigurationPage.java
@@ -43,31 +43,31 @@ public class ServerConfigurationPage extends BasePage {
 
     public ServerConfigurationPage inputMaxConcurrent(int max) {
         log.info("Enter maximum concurrent API requests {}", max);
-        waitForWebElement(maxConcurrentField).clear();
-        waitForWebElement(maxConcurrentField).sendKeys(max + "");
+        expectWebElement(maxConcurrentField).clear();
+        expectWebElement(maxConcurrentField).sendKeys(max + "");
         return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxConcurrentRequestsPerApiKey() {
         log.info("Query maximum concurrent API requests");
-        return waitForWebElement(maxConcurrentField).getAttribute("value");
+        return expectWebElement(maxConcurrentField).getAttribute("value");
     }
 
     public ServerConfigurationPage inputMaxActive(int max) {
         log.info("Enter maximum active API requests {}", max);
-        waitForWebElement(maxActiveField).clear();
-        waitForWebElement(maxActiveField).sendKeys(max + "");
+        expectWebElement(maxActiveField).clear();
+        expectWebElement(maxActiveField).sendKeys(max + "");
         return new ServerConfigurationPage(getDriver());
     }
 
     public String getMaxActiveRequestsPerApiKey() {
         log.info("Query maximum active API requests");
-        return waitForWebElement(maxActiveField).getAttribute("value");
+        return expectWebElement(maxActiveField).getAttribute("value");
     }
 
     public AdministrationPage save() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new AdministrationPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
@@ -43,31 +43,31 @@ public class TranslationMemoryEditPage extends BasePage {
 
     public TranslationMemoryEditPage enterMemoryID(String id) {
         log.info("Enter TM ID {}", id);
-        expectWebElement(idField).sendKeys(id);
+        readyElement(idField).sendKeys(id);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryEditPage enterMemoryDescription(String description) {
         log.info("Enter TM description {}", description);
-        expectWebElement(descriptionField).sendKeys(description);
+        readyElement(descriptionField).sendKeys(description);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage saveTM() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryEditPage clickSaveAndExpectFailure() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage cancelTM() {
         log.info("Click Cancel");
-        expectWebElement(cancelButton).click();
+        readyElement(cancelButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryEditPage.java
@@ -43,31 +43,31 @@ public class TranslationMemoryEditPage extends BasePage {
 
     public TranslationMemoryEditPage enterMemoryID(String id) {
         log.info("Enter TM ID {}", id);
-        waitForWebElement(idField).sendKeys(id);
+        expectWebElement(idField).sendKeys(id);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryEditPage enterMemoryDescription(String description) {
         log.info("Enter TM description {}", description);
-        waitForWebElement(descriptionField).sendKeys(description);
+        expectWebElement(descriptionField).sendKeys(description);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage saveTM() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryEditPage clickSaveAndExpectFailure() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage cancelTM() {
         log.info("Click Cancel");
-        waitForWebElement(cancelButton).click();
+        expectWebElement(cancelButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryPage.java
@@ -59,66 +59,66 @@ public class TranslationMemoryPage extends BasePage {
 
     public TranslationMemoryEditPage clickCreateNew() {
         log.info("Click Create New");
-        expectWebElement(dropDownMenu).click();
+        readyElement(dropDownMenu).click();
         clickLinkAfterAnimation(createTmLink);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage clickOptions(String tmName) {
         log.info("Click Options dropdown for {}", tmName);
-        expectWebElement(findRowByTMName(tmName), listDropDownMenu).click();
+        readyElement(findRowByTMName(tmName), listDropDownMenu).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickImport(String tmName) {
         log.info("Click Import");
-        expectWebElement(findRowByTMName(tmName), listImportButton).click();
+        readyElement(findRowByTMName(tmName), listImportButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage enterImportFileName(String importFileName) {
         log.info("Enter import TM filename {}", importFileName);
-        expectWebElement(filenameInput).sendKeys(importFileName);
+        readyElement(filenameInput).sendKeys(importFileName);
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickUploadButtonAndAcknowledge() {
         log.info("Click and accept Upload button");
-        expectWebElement(uploadButton).click();
+        readyElement(uploadButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public Alert expectFailedUpload() {
         log.info("Click Upload");
-        expectWebElement(uploadButton).click();
+        readyElement(uploadButton).click();
         return switchToAlert();
     }
 
     public TranslationMemoryPage clickClearTMAndAccept(String tmName) {
         log.info("Click and accept Clear {}", tmName);
-        expectWebElement(findRowByTMName(tmName), listClearButton).click();
+        readyElement(findRowByTMName(tmName), listClearButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickClearTMAndCancel(String tmName) {
         log.info("Click and Cancel Clear {}", tmName);
-        expectWebElement(findRowByTMName(tmName), listClearButton).click();
+        readyElement(findRowByTMName(tmName), listClearButton).click();
         switchToAlert().dismiss();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickDeleteTmAndAccept(String tmName) {
         log.info("Click and accept Delete {}", tmName);
-        expectWebElement(findRowByTMName(tmName), listDeleteButton).click();
+        readyElement(findRowByTMName(tmName), listDeleteButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickDeleteTmAndCancel(String tmName) {
         log.info("Click and cancel Delete {}", tmName);
-        expectWebElement(findRowByTMName(tmName), listDeleteButton).click();
+        readyElement(findRowByTMName(tmName), listDeleteButton).click();
         switchToAlert().dismiss();
         return new TranslationMemoryPage(getDriver());
     }
@@ -151,7 +151,7 @@ public class TranslationMemoryPage extends BasePage {
 
     public boolean canDelete(String tmName) {
         log.info("Query can delete {}", tmName);
-        String disabled = expectWebElement(
+        String disabled = readyElement(
                 findRowByTMName(tmName), listDeleteButton)
                 .getAttribute("disabled");
 
@@ -162,7 +162,7 @@ public class TranslationMemoryPage extends BasePage {
      * Check to see if the TM list is empty
      */
     private boolean noTmsCreated() {
-        for (WebElement element : expectWebElement(tmList)
+        for (WebElement element : readyElement(tmList)
                 .findElements(By.tagName("p"))) {
             if (element.getText().equals(NO_MEMORIES)) {
                 return true;
@@ -187,7 +187,7 @@ public class TranslationMemoryPage extends BasePage {
             log.info("TM list is empty");
             return new ArrayList<>();
         }
-        return expectWebElement(expectWebElement(tmList),
+        return readyElement(readyElement(tmList),
                 By.className("list--stats"))
                 .findElements(By.className("list__item--actionable"));
     }
@@ -198,7 +198,7 @@ public class TranslationMemoryPage extends BasePage {
     }
 
     private String getListEntryDescription(WebElement listElement) {
-        return expectWebElement(listElement, listItemDescription).getText();
+        return readyElement(listElement, listItemDescription).getText();
     }
 
     private String getListEntryCount(WebElement listElement) {

--- a/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryPage.java
+++ b/functional-test/src/main/java/org/zanata/page/administration/TranslationMemoryPage.java
@@ -20,15 +20,9 @@
  */
 package org.zanata.page.administration;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.*;
 import org.zanata.page.BasePage;
-import org.zanata.util.TableRow;
-import org.zanata.util.WebElementUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,66 +59,66 @@ public class TranslationMemoryPage extends BasePage {
 
     public TranslationMemoryEditPage clickCreateNew() {
         log.info("Click Create New");
-        waitForWebElement(dropDownMenu).click();
+        expectWebElement(dropDownMenu).click();
         clickLinkAfterAnimation(createTmLink);
         return new TranslationMemoryEditPage(getDriver());
     }
 
     public TranslationMemoryPage clickOptions(String tmName) {
         log.info("Click Options dropdown for {}", tmName);
-        waitForWebElement(findRowByTMName(tmName), listDropDownMenu).click();
+        expectWebElement(findRowByTMName(tmName), listDropDownMenu).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickImport(String tmName) {
         log.info("Click Import");
-        waitForWebElement(findRowByTMName(tmName), listImportButton).click();
+        expectWebElement(findRowByTMName(tmName), listImportButton).click();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage enterImportFileName(String importFileName) {
         log.info("Enter import TM filename {}", importFileName);
-        waitForWebElement(filenameInput).sendKeys(importFileName);
+        expectWebElement(filenameInput).sendKeys(importFileName);
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickUploadButtonAndAcknowledge() {
         log.info("Click and accept Upload button");
-        waitForWebElement(uploadButton).click();
+        expectWebElement(uploadButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public Alert expectFailedUpload() {
         log.info("Click Upload");
-        waitForWebElement(uploadButton).click();
+        expectWebElement(uploadButton).click();
         return switchToAlert();
     }
 
     public TranslationMemoryPage clickClearTMAndAccept(String tmName) {
         log.info("Click and accept Clear {}", tmName);
-        waitForWebElement(findRowByTMName(tmName), listClearButton).click();
+        expectWebElement(findRowByTMName(tmName), listClearButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickClearTMAndCancel(String tmName) {
         log.info("Click and Cancel Clear {}", tmName);
-        waitForWebElement(findRowByTMName(tmName), listClearButton).click();
+        expectWebElement(findRowByTMName(tmName), listClearButton).click();
         switchToAlert().dismiss();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickDeleteTmAndAccept(String tmName) {
         log.info("Click and accept Delete {}", tmName);
-        waitForWebElement(findRowByTMName(tmName), listDeleteButton).click();
+        expectWebElement(findRowByTMName(tmName), listDeleteButton).click();
         switchToAlert().accept();
         return new TranslationMemoryPage(getDriver());
     }
 
     public TranslationMemoryPage clickDeleteTmAndCancel(String tmName) {
         log.info("Click and cancel Delete {}", tmName);
-        waitForWebElement(findRowByTMName(tmName), listDeleteButton).click();
+        expectWebElement(findRowByTMName(tmName), listDeleteButton).click();
         switchToAlert().dismiss();
         return new TranslationMemoryPage(getDriver());
     }
@@ -151,24 +145,13 @@ public class TranslationMemoryPage extends BasePage {
 
     public String getNumberOfEntries(String tmName) {
         log.info("Query number of entries {}", tmName);
+        waitForPageSilence();
         return getListEntryCount(findRowByTMName(tmName));
-    }
-
-    public String waitForExpectedNumberOfEntries(final String tmName,
-            final String expected) {
-        log.info("Waiting for {} entries in {}", expected, tmName);
-        return waitForAMoment().until(new Function<WebDriver, String>() {
-            @Override
-            public String apply(WebDriver driver) {
-                return expected.equals(getNumberOfEntries(tmName)) ? getNumberOfEntries(tmName)
-                        : null;
-            }
-        });
     }
 
     public boolean canDelete(String tmName) {
         log.info("Query can delete {}", tmName);
-        String disabled = waitForWebElement(
+        String disabled = expectWebElement(
                 findRowByTMName(tmName), listDeleteButton)
                 .getAttribute("disabled");
 
@@ -179,7 +162,7 @@ public class TranslationMemoryPage extends BasePage {
      * Check to see if the TM list is empty
      */
     private boolean noTmsCreated() {
-        for (WebElement element : waitForWebElement(tmList)
+        for (WebElement element : expectWebElement(tmList)
                 .findElements(By.tagName("p"))) {
             if (element.getText().equals(NO_MEMORIES)) {
                 return true;
@@ -204,7 +187,7 @@ public class TranslationMemoryPage extends BasePage {
             log.info("TM list is empty");
             return new ArrayList<>();
         }
-        return waitForWebElement(waitForWebElement(tmList),
+        return expectWebElement(expectWebElement(tmList),
                 By.className("list--stats"))
                 .findElements(By.className("list__item--actionable"));
     }
@@ -215,7 +198,7 @@ public class TranslationMemoryPage extends BasePage {
     }
 
     private String getListEntryDescription(WebElement listElement) {
-        return waitForWebElement(listElement, listItemDescription).getText();
+        return expectWebElement(listElement, listItemDescription).getText();
     }
 
     private String getListEntryCount(WebElement listElement) {

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
@@ -21,12 +21,10 @@
 package org.zanata.page.dashboard;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.zanata.util.WebElementUtil;
 
 import java.util.List;
 
@@ -45,7 +43,7 @@ public class DashboardActivityTab extends DashboardBasePage {
 
     public List<WebElement> getMyActivityList() {
         log.info("Query activity list");
-        return waitForWebElement(activityList).findElements(By.xpath("./li"));
+        return expectWebElement(activityList).findElements(By.xpath("./li"));
     }
 
     /**
@@ -55,7 +53,7 @@ public class DashboardActivityTab extends DashboardBasePage {
     public boolean clickMoreActivity() {
         log.info("Click More Activity button");
         final int activityListOrigSize = getMyActivityList().size();
-        waitForWebElement(moreActivityButton).click();
+        expectWebElement(moreActivityButton).click();
         return waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
             public Boolean apply(WebDriver input) {

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardActivityTab.java
@@ -43,7 +43,7 @@ public class DashboardActivityTab extends DashboardBasePage {
 
     public List<WebElement> getMyActivityList() {
         log.info("Query activity list");
-        return expectWebElement(activityList).findElements(By.xpath("./li"));
+        return readyElement(activityList).findElements(By.xpath("./li"));
     }
 
     /**
@@ -53,7 +53,7 @@ public class DashboardActivityTab extends DashboardBasePage {
     public boolean clickMoreActivity() {
         log.info("Click More Activity button");
         final int activityListOrigSize = getMyActivityList().size();
-        expectWebElement(moreActivityButton).click();
+        readyElement(moreActivityButton).click();
         return waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
             public Boolean apply(WebDriver input) {

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
@@ -20,7 +20,6 @@
  */
 package org.zanata.page.dashboard;
 
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -28,6 +27,8 @@ import org.zanata.page.BasePage;
 import org.zanata.page.dashboard.dashboardsettings.DashboardAccountTab;
 import org.zanata.page.dashboard.dashboardsettings.DashboardClientTab;
 import org.zanata.page.dashboard.dashboardsettings.DashboardProfileTab;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 public class DashboardBasePage extends BasePage {
@@ -61,14 +62,14 @@ public class DashboardBasePage extends BasePage {
 
     public String getUserFullName() {
         log.info("Query user full name");
-        return waitForWebElement(profileOverview)
+        return expectWebElement(profileOverview)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public DashboardActivityTab gotoActivityTab() {
         log.info("Click Activity tab");
-        waitForElementExists(activityTabBody);
-        clickWhenTabEnabled(waitForWebElement(activityTab));
+        expectElementExists(activityTabBody);
+        clickWhenTabEnabled(expectWebElement(activityTab));
         return new DashboardActivityTab(getDriver());
     }
 
@@ -81,44 +82,40 @@ public class DashboardBasePage extends BasePage {
 
     public DashboardProjectsTab gotoProjectsTab() {
         log.info("Click Projects tab");
-        waitForElementExists(projectsTabBody);
-        clickWhenTabEnabled(waitForWebElement(projectsTab));
+        expectElementExists(projectsTabBody);
+        clickWhenTabEnabled(expectWebElement(projectsTab));
         return new DashboardProjectsTab(getDriver());
     }
 
     public DashboardBasePage goToSettingsTab() {
         log.info("Click Settings tab");
-        waitForElementExists(settingsTabBody);
-        clickWhenTabEnabled(waitForWebElement(settingsTab));
+        expectElementExists(settingsTabBody);
+        clickWhenTabEnabled(expectWebElement(settingsTab));
         return new DashboardBasePage(getDriver());
     }
 
     public DashboardAccountTab gotoSettingsAccountTab() {
         log.info("Click Account settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsAccountTab));
+        clickWhenTabEnabled(expectWebElement(settingsAccountTab));
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardProfileTab goToSettingsProfileTab() {
         log.info("Click Profile settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsProfileTab));
+        clickWhenTabEnabled(expectWebElement(settingsProfileTab));
         return new DashboardProfileTab(getDriver());
     }
 
     public DashboardClientTab goToSettingsClientTab() {
         log.info("Click Client settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsClientTab));
+        clickWhenTabEnabled(expectWebElement(settingsClientTab));
         return new DashboardClientTab(getDriver());
     }
 
-    public void waitForUsernameChanged(final String current) {
+    public void expectUsernameChanged(final String current) {
         log.info("Wait for username change from {}", current);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return !getUserFullName().equals(current);
-            }
-        });
+        waitForPageSilence();
+        assertThat(getUserFullName()).isNotEqualTo(current);
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardBasePage.java
@@ -62,14 +62,14 @@ public class DashboardBasePage extends BasePage {
 
     public String getUserFullName() {
         log.info("Query user full name");
-        return expectWebElement(profileOverview)
+        return readyElement(profileOverview)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public DashboardActivityTab gotoActivityTab() {
         log.info("Click Activity tab");
-        expectElementExists(activityTabBody);
-        clickWhenTabEnabled(expectWebElement(activityTab));
+        existingElement(activityTabBody);
+        clickWhenTabEnabled(readyElement(activityTab));
         return new DashboardActivityTab(getDriver());
     }
 
@@ -82,33 +82,33 @@ public class DashboardBasePage extends BasePage {
 
     public DashboardProjectsTab gotoProjectsTab() {
         log.info("Click Projects tab");
-        expectElementExists(projectsTabBody);
-        clickWhenTabEnabled(expectWebElement(projectsTab));
+        existingElement(projectsTabBody);
+        clickWhenTabEnabled(readyElement(projectsTab));
         return new DashboardProjectsTab(getDriver());
     }
 
     public DashboardBasePage goToSettingsTab() {
         log.info("Click Settings tab");
-        expectElementExists(settingsTabBody);
-        clickWhenTabEnabled(expectWebElement(settingsTab));
+        existingElement(settingsTabBody);
+        clickWhenTabEnabled(readyElement(settingsTab));
         return new DashboardBasePage(getDriver());
     }
 
     public DashboardAccountTab gotoSettingsAccountTab() {
         log.info("Click Account settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsAccountTab));
+        clickWhenTabEnabled(readyElement(settingsAccountTab));
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardProfileTab goToSettingsProfileTab() {
         log.info("Click Profile settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsProfileTab));
+        clickWhenTabEnabled(readyElement(settingsProfileTab));
         return new DashboardProfileTab(getDriver());
     }
 
     public DashboardClientTab goToSettingsClientTab() {
         log.info("Click Client settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsClientTab));
+        clickWhenTabEnabled(readyElement(settingsClientTab));
         return new DashboardClientTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
@@ -43,14 +43,14 @@ public class DashboardProjectsTab extends DashboardBasePage {
 
     public List<WebElement> getMaintainedProjectList() {
         log.info("Query maintained projects list");
-        return waitForWebElement(maintainedProjectsList)
+        return expectWebElement(maintainedProjectsList)
                 .findElement(By.tagName("ul"))
                 .findElements(By.xpath("./li"));
     }
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        waitForWebElement(createProjectLink).click();
+        expectWebElement(createProjectLink).click();
         return new CreateProjectPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/DashboardProjectsTab.java
@@ -43,14 +43,14 @@ public class DashboardProjectsTab extends DashboardBasePage {
 
     public List<WebElement> getMaintainedProjectList() {
         log.info("Query maintained projects list");
-        return expectWebElement(maintainedProjectsList)
+        return readyElement(maintainedProjectsList)
                 .findElement(By.tagName("ul"))
                 .findElements(By.xpath("./li"));
     }
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        expectWebElement(createProjectLink).click();
+        readyElement(createProjectLink).click();
         return new CreateProjectPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
@@ -54,34 +54,34 @@ public class DashboardAccountTab extends DashboardBasePage {
 
     public DashboardAccountTab typeNewAccountEmailAddress(String emailAddress) {
         log.info("Enter email {}", emailAddress);
-        expectWebElement(emailField).clear();
-        expectWebElement(emailField).sendKeys(emailAddress);
+        readyElement(emailField).clear();
+        readyElement(emailField).sendKeys(emailAddress);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdateEmailButton() {
         log.info("Click Update Email");
-        expectWebElement(updateEmailButton).click();
+        readyElement(updateEmailButton).click();
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeOldPassword(String oldPassword) {
         log.info("Enter old password {}", oldPassword);
-        expectWebElement(oldPasswordField).clear();
-        expectWebElement(oldPasswordField).sendKeys(oldPassword);
+        readyElement(oldPasswordField).clear();
+        readyElement(oldPasswordField).sendKeys(oldPassword);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeNewPassword(String newPassword) {
         log.info("Enter new password {}", newPassword);
-        expectWebElement(newPasswordField).clear();
-        expectWebElement(newPasswordField).sendKeys(newPassword);
+        readyElement(newPasswordField).clear();
+        readyElement(newPasswordField).sendKeys(newPassword);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdatePasswordButton() {
         log.info("Click Update Password");
-        expectWebElement(changePasswordButton).click();
+        readyElement(changePasswordButton).click();
         return new DashboardAccountTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
@@ -54,34 +54,34 @@ public class DashboardAccountTab extends DashboardBasePage {
 
     public DashboardAccountTab typeNewAccountEmailAddress(String emailAddress) {
         log.info("Enter email {}", emailAddress);
-        waitForWebElement(emailField).clear();
-        waitForWebElement(emailField).sendKeys(emailAddress);
+        expectWebElement(emailField).clear();
+        expectWebElement(emailField).sendKeys(emailAddress);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdateEmailButton() {
         log.info("Click Update Email");
-        waitForWebElement(updateEmailButton).click();
+        expectWebElement(updateEmailButton).click();
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeOldPassword(String oldPassword) {
         log.info("Enter old password {}", oldPassword);
-        waitForWebElement(oldPasswordField).clear();
-        waitForWebElement(oldPasswordField).sendKeys(oldPassword);
+        expectWebElement(oldPasswordField).clear();
+        expectWebElement(oldPasswordField).sendKeys(oldPassword);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab typeNewPassword(String newPassword) {
         log.info("Enter new password {}", newPassword);
-        waitForWebElement(newPasswordField).clear();
-        waitForWebElement(newPasswordField).sendKeys(newPassword);
+        expectWebElement(newPasswordField).clear();
+        expectWebElement(newPasswordField).sendKeys(newPassword);
         return new DashboardAccountTab(getDriver());
     }
 
     public DashboardAccountTab clickUpdatePasswordButton() {
         log.info("Click Update Password");
-        waitForWebElement(changePasswordButton).click();
+        expectWebElement(changePasswordButton).click();
         return new DashboardAccountTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
@@ -20,11 +20,12 @@
  */
 package org.zanata.page.dashboard.dashboardsettings;
 
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.zanata.page.dashboard.DashboardBasePage;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Carlos Munoz <a href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
@@ -42,28 +43,24 @@ public class DashboardClientTab extends DashboardBasePage {
 
     public DashboardClientTab pressApiKeyGenerateButton() {
         log.info("Press Generate API Key");
-        waitForWebElement(generateApiKeyButton).click();
+        expectWebElement(generateApiKeyButton).click();
         getDriver().switchTo().alert().accept();
         return new DashboardClientTab(getDriver());
     }
 
     public String getApiKey() {
         log.info("Query API Key");
-        return waitForWebElement(apiKeyLabel).getAttribute("value");
+        return expectWebElement(apiKeyLabel).getAttribute("value");
     }
 
     public String getConfigurationDetails() {
         log.info("Query configuration details");
-        return waitForWebElement(configurationTextArea).getText();
+        return expectWebElement(configurationTextArea).getText();
     }
 
-    public void waitForApiKeyChanged(final String current) {
+    public void expectApiKeyChanged(final String current) {
         log.info("Wait for API key changed from {}", current);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return !getApiKey().equals(current);
-            }
-        });
+        waitForPageSilence();
+        assertThat(getApiKey()).isNotEqualTo(current);
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardClientTab.java
@@ -43,19 +43,19 @@ public class DashboardClientTab extends DashboardBasePage {
 
     public DashboardClientTab pressApiKeyGenerateButton() {
         log.info("Press Generate API Key");
-        expectWebElement(generateApiKeyButton).click();
+        readyElement(generateApiKeyButton).click();
         getDriver().switchTo().alert().accept();
         return new DashboardClientTab(getDriver());
     }
 
     public String getApiKey() {
         log.info("Query API Key");
-        return expectWebElement(apiKeyLabel).getAttribute("value");
+        return readyElement(apiKeyLabel).getAttribute("value");
     }
 
     public String getConfigurationDetails() {
         log.info("Query configuration details");
-        return expectWebElement(configurationTextArea).getText();
+        return readyElement(configurationTextArea).getText();
     }
 
     public void expectApiKeyChanged(final String current) {

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
@@ -41,21 +41,21 @@ public class DashboardProfileTab extends DashboardBasePage {
 
     public String getUsername() {
         log.info("Query user name");
-        return waitForWebElement(By.id("profileForm"))
+        return expectWebElement(By.id("profileForm"))
                 .findElement(By.className("l--push-bottom-0"))
                 .getText();
     }
 
     public DashboardProfileTab enterName(String name) {
         log.info("Enter name {}", name);
-        waitForWebElement(accountNameField).clear();
-        waitForWebElement(accountNameField).sendKeys(name);
+        expectWebElement(accountNameField).clear();
+        expectWebElement(accountNameField).sendKeys(name);
         return new DashboardProfileTab(getDriver());
     }
 
     public DashboardProfileTab clickUpdateProfileButton() {
         log.info("Click Update");
-        waitForWebElement(updateProfileButton).click();
+        expectWebElement(updateProfileButton).click();
         return new DashboardProfileTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardProfileTab.java
@@ -41,21 +41,21 @@ public class DashboardProfileTab extends DashboardBasePage {
 
     public String getUsername() {
         log.info("Query user name");
-        return expectWebElement(By.id("profileForm"))
+        return readyElement(By.id("profileForm"))
                 .findElement(By.className("l--push-bottom-0"))
                 .getText();
     }
 
     public DashboardProfileTab enterName(String name) {
         log.info("Enter name {}", name);
-        expectWebElement(accountNameField).clear();
-        expectWebElement(accountNameField).sendKeys(name);
+        readyElement(accountNameField).clear();
+        readyElement(accountNameField).sendKeys(name);
         return new DashboardProfileTab(getDriver());
     }
 
     public DashboardProfileTab clickUpdateProfileButton() {
         log.info("Click Update");
-        expectWebElement(updateProfileButton).click();
+        readyElement(updateProfileButton).click();
         return new DashboardProfileTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
+++ b/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
@@ -29,7 +29,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zanata.page.BasePage;
-import org.zanata.util.WebElementUtil;
 
 /**
  * @author Carlos Munoz <a
@@ -70,9 +69,9 @@ public class GlossaryPage extends BasePage {
     }
 
     private List<WebElement> getListItems() {
-        return waitForElementExists(
-                waitForElementExists(glossaryMain),
-                        By.className("list--stats"))
+        return expectElementExists(
+                expectElementExists(glossaryMain),
+                By.className("list--stats"))
                 .findElements(listItem);
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
+++ b/functional-test/src/main/java/org/zanata/page/glossary/GlossaryPage.java
@@ -69,8 +69,8 @@ public class GlossaryPage extends BasePage {
     }
 
     private List<WebElement> getListItems() {
-        return expectElementExists(
-                expectElementExists(glossaryMain),
+        return existingElement(
+                existingElement(glossaryMain),
                 By.className("list--stats"))
                 .findElements(listItem);
     }

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
@@ -45,31 +45,31 @@ public class GoogleAccountPage extends AbstractPage {
 
     public GoogleAccountPage enterGoogleEmail(String email) {
         log.info("Enter email {}", email);
-        expectWebElement(emailField).sendKeys(email);
+        readyElement(emailField).sendKeys(email);
         return new GoogleAccountPage(getDriver());
     }
 
     public GoogleAccountPage enterGooglePassword(String password) {
         log.info("Enter password {}", password);
-        expectWebElement(passwordField).sendKeys(password);
+        readyElement(passwordField).sendKeys(password);
         return new GoogleAccountPage(getDriver());
     }
 
     public GooglePermissionsPage clickSignIn() {
         log.info("Click account Sign In");
-        expectWebElement(signInButton).click();
+        readyElement(signInButton).click();
         return new GooglePermissionsPage(getDriver());
     }
 
     public GoogleManagePermissionsPage clickPermissionsSignIn() {
         log.info("Click account management Sign In");
-        expectWebElement(signInButton).click();
+        readyElement(signInButton).click();
         return new GoogleManagePermissionsPage(getDriver());
     }
 
     public String rememberedUser() {
         log.info("Query remembered user email");
-        return expectWebElement(emailLabelField).getText();
+        return readyElement(emailLabelField).getText();
     }
 
     public boolean hasRememberedAuthentication() {
@@ -79,7 +79,7 @@ public class GoogleAccountPage extends AbstractPage {
 
     public GoogleAccountPage removeSavedAuthentication() {
         log.info("Click Sign in with different account");
-        expectWebElement(signInDifferent).click();
+        readyElement(signInDifferent).click();
         return new GoogleAccountPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GoogleAccountPage.java
@@ -45,31 +45,31 @@ public class GoogleAccountPage extends AbstractPage {
 
     public GoogleAccountPage enterGoogleEmail(String email) {
         log.info("Enter email {}", email);
-        waitForWebElement(emailField).sendKeys(email);
+        expectWebElement(emailField).sendKeys(email);
         return new GoogleAccountPage(getDriver());
     }
 
     public GoogleAccountPage enterGooglePassword(String password) {
         log.info("Enter password {}", password);
-        waitForWebElement(passwordField).sendKeys(password);
+        expectWebElement(passwordField).sendKeys(password);
         return new GoogleAccountPage(getDriver());
     }
 
     public GooglePermissionsPage clickSignIn() {
         log.info("Click account Sign In");
-        waitForWebElement(signInButton).click();
+        expectWebElement(signInButton).click();
         return new GooglePermissionsPage(getDriver());
     }
 
     public GoogleManagePermissionsPage clickPermissionsSignIn() {
         log.info("Click account management Sign In");
-        waitForWebElement(signInButton).click();
+        expectWebElement(signInButton).click();
         return new GoogleManagePermissionsPage(getDriver());
     }
 
     public String rememberedUser() {
         log.info("Query remembered user email");
-        return waitForWebElement(emailLabelField).getText();
+        return expectWebElement(emailLabelField).getText();
     }
 
     public boolean hasRememberedAuthentication() {
@@ -79,7 +79,7 @@ public class GoogleAccountPage extends AbstractPage {
 
     public GoogleAccountPage removeSavedAuthentication() {
         log.info("Click Sign in with different account");
-        waitForWebElement(signInDifferent).click();
+        expectWebElement(signInDifferent).click();
         return new GoogleAccountPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
@@ -50,7 +50,7 @@ public class GooglePermissionsPage extends AbstractPage {
                         .isEnabled();
             }
         });
-        expectWebElement(approveAccessButton).click();
+        readyElement(approveAccessButton).click();
         return new EditProfilePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/googleaccount/GooglePermissionsPage.java
@@ -50,7 +50,7 @@ public class GooglePermissionsPage extends AbstractPage {
                         .isEnabled();
             }
         });
-        waitForWebElement(approveAccessButton).click();
+        expectWebElement(approveAccessButton).click();
         return new EditProfilePage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
@@ -53,48 +53,48 @@ public class CreateVersionGroupPage extends BasePage {
 
     public CreateVersionGroupPage inputGroupId(String groupId) {
         log.info("Enter Group ID {}", groupId);
-        expectWebElement(groupIdField).sendKeys(groupId);
+        readyElement(groupIdField).sendKeys(groupId);
         return new CreateVersionGroupPage(getDriver());
     }
 
     public String getGroupIdValue() {
         log.info("Query Group ID");
-        return expectWebElement(groupIdField).getAttribute("value");
+        return readyElement(groupIdField).getAttribute("value");
     }
 
     public CreateVersionGroupPage inputGroupName(String groupName) {
         log.info("Enter Group name {}", groupName);
-        expectWebElement(groupNameField).sendKeys(groupName);
+        readyElement(groupNameField).sendKeys(groupName);
         return new CreateVersionGroupPage(getDriver());
     }
 
     public CreateVersionGroupPage inputGroupDescription(String desc) {
         log.info("Enter Group description {}", desc);
-        expectWebElement(groupDescriptionField).sendKeys(desc);
+        readyElement(groupDescriptionField).sendKeys(desc);
         return this;
     }
 
     public VersionGroupsPage saveGroup() {
         log.info("Click Save");
-        clickAndCheckErrors(expectWebElement(saveButton));
+        clickAndCheckErrors(readyElement(saveButton));
         return new VersionGroupsPage(getDriver());
     }
 
     public CreateVersionGroupPage saveGroupFailure() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public CreateVersionGroupPage clearFields() {
-        expectWebElement(groupIdField).clear();
-        expectWebElement(groupNameField).clear();
-        expectWebElement(groupDescriptionField).clear();
+        readyElement(groupIdField).clear();
+        readyElement(groupNameField).clear();
+        readyElement(groupDescriptionField).clear();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 return getGroupIdValue().equals("") &&
-                        expectWebElement(groupNameField).getAttribute("value")
+                        readyElement(groupNameField).getAttribute("value")
                                 .equals("");
             }
         });

--- a/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/CreateVersionGroupPage.java
@@ -53,48 +53,48 @@ public class CreateVersionGroupPage extends BasePage {
 
     public CreateVersionGroupPage inputGroupId(String groupId) {
         log.info("Enter Group ID {}", groupId);
-        waitForWebElement(groupIdField).sendKeys(groupId);
+        expectWebElement(groupIdField).sendKeys(groupId);
         return new CreateVersionGroupPage(getDriver());
     }
 
     public String getGroupIdValue() {
         log.info("Query Group ID");
-        return waitForWebElement(groupIdField).getAttribute("value");
+        return expectWebElement(groupIdField).getAttribute("value");
     }
 
     public CreateVersionGroupPage inputGroupName(String groupName) {
         log.info("Enter Group name {}", groupName);
-        waitForWebElement(groupNameField).sendKeys(groupName);
+        expectWebElement(groupNameField).sendKeys(groupName);
         return new CreateVersionGroupPage(getDriver());
     }
 
     public CreateVersionGroupPage inputGroupDescription(String desc) {
         log.info("Enter Group description {}", desc);
-        waitForWebElement(groupDescriptionField).sendKeys(desc);
+        expectWebElement(groupDescriptionField).sendKeys(desc);
         return this;
     }
 
     public VersionGroupsPage saveGroup() {
         log.info("Click Save");
-        clickAndCheckErrors(waitForWebElement(saveButton));
+        clickAndCheckErrors(expectWebElement(saveButton));
         return new VersionGroupsPage(getDriver());
     }
 
     public CreateVersionGroupPage saveGroupFailure() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public CreateVersionGroupPage clearFields() {
-        waitForWebElement(groupIdField).clear();
-        waitForWebElement(groupNameField).clear();
-        waitForWebElement(groupDescriptionField).clear();
+        expectWebElement(groupIdField).clear();
+        expectWebElement(groupNameField).clear();
+        expectWebElement(groupDescriptionField).clear();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
                 return getGroupIdValue().equals("") &&
-                        waitForWebElement(groupNameField).getAttribute("value")
+                        expectWebElement(groupNameField).getAttribute("value")
                                 .equals("");
             }
         });

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
@@ -70,13 +70,13 @@ public class VersionGroupPage extends BasePage {
     }
 
     public String getGroupName() {
-        return waitForWebElement(groupNameLabel)
+        return expectWebElement(groupNameLabel)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public List<WebElement> searchProject(final String projectName,
             final int expectedResultNum) {
-        waitForWebElement(projectSearchField).sendKeys(projectName);
+        expectWebElement(projectSearchField).sendKeys(projectName);
 
         return refreshPageUntil(this,
                 new Function<WebDriver, List<WebElement>>() {
@@ -106,7 +106,7 @@ public class VersionGroupPage extends BasePage {
     public VersionGroupPage addToGroup(int rowIndex) {
         WebElementUtil.getListItems(getDriver(), newVersionList)
                 .get(rowIndex).click();
-        waitForWebElement(projectAddButton).click();
+        expectWebElement(projectAddButton).click();
         return new VersionGroupPage(getDriver());
     }
 
@@ -155,48 +155,48 @@ public class VersionGroupPage extends BasePage {
     public VersionGroupPage clickAddProjectVersionsButton() {
         log.info("Click Add Project Version");
         // parent
-        waitForWebElement(waitForElementExists(projectForm),
+        expectWebElement(expectElementExists(projectForm),
                 By.className("button--primary")).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesTab() {
         log.info("Click Languages tab");
-        waitForElementExists(languagesTabBody);
-        clickWhenTabEnabled(waitForWebElement(languagesTab));
+        expectElementExists(languagesTabBody);
+        clickWhenTabEnabled(expectWebElement(languagesTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickProjectsTab() {
         log.info("Click Projects tab");
-        waitForElementExists(projectsTabBody);
-        clickWhenTabEnabled(waitForWebElement(projectsTab));
+        expectElementExists(projectsTabBody);
+        clickWhenTabEnabled(expectWebElement(projectsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickMaintainersTab() {
         log.info("Click Maintainers tab");
-        waitForElementExists(maintainersTabBody);
-        clickWhenTabEnabled(waitForWebElement(maintainersTab));
+        expectElementExists(maintainersTabBody);
+        clickWhenTabEnabled(expectWebElement(maintainersTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickSettingsTab() {
         log.info("Click Settings tab");
-        waitForElementExists(settingsTabBody);
-        clickWhenTabEnabled(waitForWebElement(settingsTab));
+        expectElementExists(settingsTabBody);
+        clickWhenTabEnabled(expectWebElement(settingsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesSettingsTab() {
         clickSettingsTab();
-        waitForWebElement(settingsLanguagesTab).click();
+        expectWebElement(settingsLanguagesTab).click();
         return new VersionGroupPage(getDriver());
     }
 
     public Boolean isLanguagesTabActive() {
         log.info("Query is languages tab displayed");
-        final WebElement languagesTab = waitForWebElement(By.id("languages"));
+        final WebElement languagesTab = expectWebElement(By.id("languages"));
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver webDriver) {
@@ -207,7 +207,7 @@ public class VersionGroupPage extends BasePage {
     }
 
     public Boolean isProjectsTabActive() {
-        final WebElement languagesTab = waitForElementExists(By.id("projects"));
+        final WebElement languagesTab = expectElementExists(By.id("projects"));
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver webDriver) {
@@ -224,7 +224,7 @@ public class VersionGroupPage extends BasePage {
      */
     public VersionGroupPage enterProjectVersion(String projectVersion) {
         log.info("Enter project version {}", projectVersion);
-        waitForWebElement(By.id("versionAutocomplete-autocomplete__input"))
+        expectWebElement(By.id("versionAutocomplete-autocomplete__input"))
                 .sendKeys(projectVersion);
         return new VersionGroupPage(getDriver());
     }

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupPage.java
@@ -70,13 +70,13 @@ public class VersionGroupPage extends BasePage {
     }
 
     public String getGroupName() {
-        return expectWebElement(groupNameLabel)
+        return readyElement(groupNameLabel)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public List<WebElement> searchProject(final String projectName,
             final int expectedResultNum) {
-        expectWebElement(projectSearchField).sendKeys(projectName);
+        readyElement(projectSearchField).sendKeys(projectName);
 
         return refreshPageUntil(this,
                 new Function<WebDriver, List<WebElement>>() {
@@ -106,7 +106,7 @@ public class VersionGroupPage extends BasePage {
     public VersionGroupPage addToGroup(int rowIndex) {
         WebElementUtil.getListItems(getDriver(), newVersionList)
                 .get(rowIndex).click();
-        expectWebElement(projectAddButton).click();
+        readyElement(projectAddButton).click();
         return new VersionGroupPage(getDriver());
     }
 
@@ -155,48 +155,48 @@ public class VersionGroupPage extends BasePage {
     public VersionGroupPage clickAddProjectVersionsButton() {
         log.info("Click Add Project Version");
         // parent
-        expectWebElement(expectElementExists(projectForm),
+        readyElement(existingElement(projectForm),
                 By.className("button--primary")).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesTab() {
         log.info("Click Languages tab");
-        expectElementExists(languagesTabBody);
-        clickWhenTabEnabled(expectWebElement(languagesTab));
+        existingElement(languagesTabBody);
+        clickWhenTabEnabled(readyElement(languagesTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickProjectsTab() {
         log.info("Click Projects tab");
-        expectElementExists(projectsTabBody);
-        clickWhenTabEnabled(expectWebElement(projectsTab));
+        existingElement(projectsTabBody);
+        clickWhenTabEnabled(readyElement(projectsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickMaintainersTab() {
         log.info("Click Maintainers tab");
-        expectElementExists(maintainersTabBody);
-        clickWhenTabEnabled(expectWebElement(maintainersTab));
+        existingElement(maintainersTabBody);
+        clickWhenTabEnabled(readyElement(maintainersTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickSettingsTab() {
         log.info("Click Settings tab");
-        expectElementExists(settingsTabBody);
-        clickWhenTabEnabled(expectWebElement(settingsTab));
+        existingElement(settingsTabBody);
+        clickWhenTabEnabled(readyElement(settingsTab));
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupPage clickLanguagesSettingsTab() {
         clickSettingsTab();
-        expectWebElement(settingsLanguagesTab).click();
+        readyElement(settingsLanguagesTab).click();
         return new VersionGroupPage(getDriver());
     }
 
     public Boolean isLanguagesTabActive() {
         log.info("Query is languages tab displayed");
-        final WebElement languagesTab = expectWebElement(By.id("languages"));
+        final WebElement languagesTab = readyElement(By.id("languages"));
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver webDriver) {
@@ -207,7 +207,7 @@ public class VersionGroupPage extends BasePage {
     }
 
     public Boolean isProjectsTabActive() {
-        final WebElement languagesTab = expectElementExists(By.id("projects"));
+        final WebElement languagesTab = existingElement(By.id("projects"));
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver webDriver) {
@@ -224,7 +224,7 @@ public class VersionGroupPage extends BasePage {
      */
     public VersionGroupPage enterProjectVersion(String projectVersion) {
         log.info("Enter project version {}", projectVersion);
-        expectWebElement(By.id("versionAutocomplete-autocomplete__input"))
+        readyElement(By.id("versionAutocomplete-autocomplete__input"))
                 .sendKeys(projectVersion);
         return new VersionGroupPage(getDriver());
     }

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
@@ -58,25 +58,25 @@ public class VersionGroupsPage extends BasePage {
 
     public CreateVersionGroupPage createNewGroup() {
         log.info("Click New Group button");
-        expectWebElement(createGroupButton).click();
+        readyElement(createGroupButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public VersionGroupPage goToGroup(String groupName) {
         log.info("Click group {}", groupName);
-        expectWebElement(groupTable).findElement(By.linkText(groupName)).click();
+        readyElement(groupTable).findElement(By.linkText(groupName)).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupsPage toggleObsolete(final boolean show) {
-        WebElement showObsolete = expectWebElement(toggleObsolete);
+        WebElement showObsolete = readyElement(toggleObsolete);
         if (show != showObsolete.isSelected()) {
             showObsolete.click();
         }
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                return expectWebElement(groupTable)
+                return readyElement(groupTable)
                         .findElements(obsoleteLink)
                         .isEmpty() == !show;
             }
@@ -86,8 +86,8 @@ public class VersionGroupsPage extends BasePage {
 
     public String getInfoMessage() {
         log.info("Test info msg");
-        log.info(expectWebElement(infomsg).getText());
-        return expectWebElement(infomsg).getText();
+        log.info(readyElement(infomsg).getText());
+        return readyElement(infomsg).getText();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/groups/VersionGroupsPage.java
@@ -58,25 +58,25 @@ public class VersionGroupsPage extends BasePage {
 
     public CreateVersionGroupPage createNewGroup() {
         log.info("Click New Group button");
-        waitForWebElement(createGroupButton).click();
+        expectWebElement(createGroupButton).click();
         return new CreateVersionGroupPage(getDriver());
     }
 
     public VersionGroupPage goToGroup(String groupName) {
         log.info("Click group {}", groupName);
-        waitForWebElement(groupTable).findElement(By.linkText(groupName)).click();
+        expectWebElement(groupTable).findElement(By.linkText(groupName)).click();
         return new VersionGroupPage(getDriver());
     }
 
     public VersionGroupsPage toggleObsolete(final boolean show) {
-        WebElement showObsolete = waitForWebElement(toggleObsolete);
+        WebElement showObsolete = expectWebElement(toggleObsolete);
         if (show != showObsolete.isSelected()) {
             showObsolete.click();
         }
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                return waitForWebElement(groupTable)
+                return expectWebElement(groupTable)
                         .findElements(obsoleteLink)
                         .isEmpty() == !show;
             }
@@ -86,8 +86,8 @@ public class VersionGroupsPage extends BasePage {
 
     public String getInfoMessage() {
         log.info("Test info msg");
-        log.info(waitForWebElement(infomsg).getText());
-        return waitForWebElement(infomsg).getText();
+        log.info(expectWebElement(infomsg).getText());
+        return expectWebElement(infomsg).getText();
     }
 
 }

--- a/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
@@ -41,19 +41,19 @@ public class ContactTeamPage extends BasePage {
 
     public ContactTeamPage enterSubject(String subject) {
         log.info("Enter subject {}", subject);
-        waitForWebElement(subjectField).sendKeys(subject);
+        expectWebElement(subjectField).sendKeys(subject);
         return new ContactTeamPage(getDriver());
     }
 
     public ContactTeamPage enterMessage(String message) {
         log.info("Enter message {}", message);
-        waitForWebElement(messageField).sendKeys(message);
+        expectWebElement(messageField).sendKeys(message);
         return new ContactTeamPage(getDriver());
     }
 
     public LanguagesPage clickSend() {
         log.info("Click the Send Message button");
-        waitForWebElement(sendButton).click();
+        expectWebElement(sendButton).click();
         return new LanguagesPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/ContactTeamPage.java
@@ -41,19 +41,19 @@ public class ContactTeamPage extends BasePage {
 
     public ContactTeamPage enterSubject(String subject) {
         log.info("Enter subject {}", subject);
-        expectWebElement(subjectField).sendKeys(subject);
+        readyElement(subjectField).sendKeys(subject);
         return new ContactTeamPage(getDriver());
     }
 
     public ContactTeamPage enterMessage(String message) {
         log.info("Enter message {}", message);
-        expectWebElement(messageField).sendKeys(message);
+        readyElement(messageField).sendKeys(message);
         return new ContactTeamPage(getDriver());
     }
 
     public LanguagesPage clickSend() {
         log.info("Click the Send Message button");
-        expectWebElement(sendButton).click();
+        readyElement(sendButton).click();
         return new LanguagesPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
@@ -41,13 +41,13 @@ public class LanguagePage extends BasePage {
 
     public LanguagePage clickMoreActions() {
         log.info("Click More Actions");
-        expectWebElement(moreActions).click();
+        readyElement(moreActions).click();
         return new LanguagePage(getDriver());
     }
 
     public ContactTeamPage clickContactCoordinatorsButton() {
         log.info("Click Contact Coordinators button");
-        expectWebElement(contactCoordinatorsButton).click();
+        readyElement(contactCoordinatorsButton).click();
         return new ContactTeamPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagePage.java
@@ -41,13 +41,13 @@ public class LanguagePage extends BasePage {
 
     public LanguagePage clickMoreActions() {
         log.info("Click More Actions");
-        waitForWebElement(moreActions).click();
+        expectWebElement(moreActions).click();
         return new LanguagePage(getDriver());
     }
 
     public ContactTeamPage clickContactCoordinatorsButton() {
         log.info("Click Contact Coordinators button");
-        waitForWebElement(contactCoordinatorsButton).click();
+        expectWebElement(contactCoordinatorsButton).click();
         return new ContactTeamPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
@@ -25,8 +25,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.zanata.page.BasePage;
-import org.zanata.util.TableRow;
-import org.zanata.util.WebElementUtil;
 
 import java.util.List;
 
@@ -63,7 +61,7 @@ public class LanguagesPage extends BasePage {
     }
 
     private List<WebElement> getRows() {
-        return waitForWebElement(waitForElementExists(By.id("languageForm")),
+        return expectWebElement(expectElementExists(By.id("languageForm")),
                 By.className("list--stats"))
                 .findElements(By.tagName("li"));
     }

--- a/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/languages/LanguagesPage.java
@@ -61,7 +61,7 @@ public class LanguagesPage extends BasePage {
     }
 
     private List<WebElement> getRows() {
-        return expectWebElement(expectElementExists(By.id("languageForm")),
+        return readyElement(existingElement(By.id("languageForm")),
                 By.className("list--stats"))
                 .findElements(By.tagName("li"));
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
@@ -43,25 +43,25 @@ public class CreateProjectPage extends BasePage {
 
     public CreateProjectPage enterProjectId(String projectId) {
         log.info("Enter project ID {}", projectId);
-        waitForWebElement(idField).sendKeys(projectId);
+        expectWebElement(idField).sendKeys(projectId);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        waitForWebElement(nameField).sendKeys(projectName);
+        expectWebElement(nameField).sendKeys(projectName);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        waitForWebElement(descriptionField).sendKeys(projectDescription);
+        expectWebElement(descriptionField).sendKeys(projectDescription);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage selectProjectType(String projectType) {
         log.info("Click project type {}", projectType);
-        List<WebElement> projectTypes = waitForWebElement(projectTypeList)
+        List<WebElement> projectTypes = expectWebElement(projectTypeList)
                 .findElements(By.tagName("li"));
 
         for (WebElement projectTypeLi : projectTypes) {
@@ -76,7 +76,7 @@ public class CreateProjectPage extends BasePage {
 
     public ProjectVersionsPage pressCreateProject() {
         log.info("Click Create");
-        clickAndCheckErrors(waitForWebElement(createButton));
+        clickAndCheckErrors(expectWebElement(createButton));
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/CreateProjectPage.java
@@ -43,25 +43,25 @@ public class CreateProjectPage extends BasePage {
 
     public CreateProjectPage enterProjectId(String projectId) {
         log.info("Enter project ID {}", projectId);
-        expectWebElement(idField).sendKeys(projectId);
+        readyElement(idField).sendKeys(projectId);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        expectWebElement(nameField).sendKeys(projectName);
+        readyElement(nameField).sendKeys(projectName);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        expectWebElement(descriptionField).sendKeys(projectDescription);
+        readyElement(descriptionField).sendKeys(projectDescription);
         return new CreateProjectPage(getDriver());
     }
 
     public CreateProjectPage selectProjectType(String projectType) {
         log.info("Click project type {}", projectType);
-        List<WebElement> projectTypes = expectWebElement(projectTypeList)
+        List<WebElement> projectTypes = readyElement(projectTypeList)
                 .findElements(By.tagName("li"));
 
         for (WebElement projectTypeLi : projectTypes) {
@@ -76,7 +76,7 @@ public class CreateProjectPage extends BasePage {
 
     public ProjectVersionsPage pressCreateProject() {
         log.info("Click Create");
-        clickAndCheckErrors(expectWebElement(createButton));
+        clickAndCheckErrors(readyElement(createButton));
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
@@ -39,6 +39,6 @@ public class ProjectAboutPage extends ProjectBasePage {
 
     public String getAboutText() {
         log.info("Query About content");
-        return waitForWebElement(aboutText).getText();
+        return expectWebElement(aboutText).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectAboutPage.java
@@ -39,6 +39,6 @@ public class ProjectAboutPage extends ProjectBasePage {
 
     public String getAboutText() {
         log.info("Query About content");
-        return expectWebElement(aboutText).getText();
+        return readyElement(aboutText).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
@@ -32,7 +32,6 @@ import org.zanata.page.projects.projectsettings.ProjectGeneralTab;
 import org.zanata.page.projects.projectsettings.ProjectLanguagesTab;
 import org.zanata.page.projects.projectsettings.ProjectPermissionsTab;
 import org.zanata.page.projects.projectsettings.ProjectTranslationTab;
-import com.google.common.base.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
 import org.zanata.page.projects.projectsettings.ProjectWebHooksTab;
@@ -65,93 +64,93 @@ public class ProjectBasePage extends BasePage {
 
     public String getProjectName() {
         log.info("Query Project name");
-        return waitForWebElement(projectInfo)
+        return expectWebElement(projectInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage gotoVersionsTab() {
         log.info("Click Versions tab");
-        waitForElementExists(versionsTabBody);
-        clickWhenTabEnabled(waitForWebElement(versionsTab));
-        waitForWebElement(By.id("versions"));
+        expectElementExists(versionsTabBody);
+        clickWhenTabEnabled(expectWebElement(versionsTab));
+        expectWebElement(By.id("versions"));
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectMaintainersPage gotoMaintainersTab() {
         log.info("Click Maintainers tab");
-        waitForElementExists(maintainersTabBody);
-        clickWhenTabEnabled(waitForWebElement(maintainersTab));
-        waitForWebElement(By.id("maintainers"));
+        expectElementExists(maintainersTabBody);
+        clickWhenTabEnabled(expectWebElement(maintainersTab));
+        expectWebElement(By.id("maintainers"));
         return new ProjectMaintainersPage(getDriver());
     }
 
     public ProjectAboutPage gotoAboutTab() {
         log.info("Click About tab");
-        waitForElementExists(aboutTabBody);
-        clickWhenTabEnabled(waitForWebElement(aboutTab));
-        waitForWebElement(By.id("about"));
+        expectElementExists(aboutTabBody);
+        clickWhenTabEnabled(expectWebElement(aboutTab));
+        expectWebElement(By.id("about"));
         return new ProjectAboutPage(getDriver());
     }
 
     public boolean settingsTabIsDisplayed() {
         log.info("Query Settings tab is displayed");
-        return waitForElementExists(settingsTab).isDisplayed();
+        return expectElementExists(settingsTab).isDisplayed();
     }
 
     public ProjectBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
-        waitForElementExists(settingsTabBody);
-        clickWhenTabEnabled(waitForWebElement(settingsTab));
-        waitForWebElement(settingsTab);
+        expectElementExists(settingsTabBody);
+        clickWhenTabEnabled(expectWebElement(settingsTab));
+        expectWebElement(settingsTab);
         return new ProjectBasePage(getDriver());
     }
 
     public ProjectGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsGeneralTab));
-        waitForWebElement(By.id("settings-general"));
+        clickWhenTabEnabled(expectWebElement(settingsGeneralTab));
+        expectWebElement(By.id("settings-general"));
         return new ProjectGeneralTab(getDriver());
     }
 
     public ProjectPermissionsTab gotoSettingsPermissionsTab() {
         log.info("Click Permissions settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsPermissionTab));
-        waitForWebElement(By.id("settings-permissions"));
+        clickWhenTabEnabled(expectWebElement(settingsPermissionTab));
+        expectWebElement(By.id("settings-permissions"));
         return new ProjectPermissionsTab(getDriver());
     }
 
     public ProjectTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsTranslationTab));
-        waitForWebElement(By.id("settings-translation"));
+        clickWhenTabEnabled(expectWebElement(settingsTranslationTab));
+        expectWebElement(By.id("settings-translation"));
         return new ProjectTranslationTab(getDriver());
     }
 
     public ProjectLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsLanguagesTab));
-        waitForWebElement(By.id("settings-languages"));
+        clickWhenTabEnabled(expectWebElement(settingsLanguagesTab));
+        expectWebElement(By.id("settings-languages"));
         return new ProjectLanguagesTab(getDriver());
     }
 
     public ProjectWebHooksTab gotoSettingsWebHooksTab() {
         log.info("Click WebHooks settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsWebHooksTab));
-        waitForWebElement(By.id("settings-webhooks"));
+        clickWhenTabEnabled(expectWebElement(settingsWebHooksTab));
+        expectWebElement(By.id("settings-webhooks"));
         return new ProjectWebHooksTab(getDriver());
     }
 
     public ProjectAboutTab gotoSettingsAboutTab() {
         log.info("Click About settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsAboutTab));
-        waitForWebElement(By.id("settings-about"));
+        clickWhenTabEnabled(expectWebElement(settingsAboutTab));
+        expectWebElement(By.id("settings-about"));
         return new ProjectAboutTab(getDriver());
     }
 
     public List<String> getContentAreaParagraphs() {
         log.info("Query Project info");
         List<String> paragraphTexts = new ArrayList<String>();
-        List<WebElement> paragraphs = waitForWebElement(projectInfo)
+        List<WebElement> paragraphs = expectWebElement(projectInfo)
                         .findElements(By.tagName("p"));
         for (WebElement element : paragraphs) {
             paragraphTexts.add(element.getText());
@@ -161,7 +160,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getHomepage() {
         log.info("Query Project homepage");
-        for (WebElement element : waitForWebElement(projectInfo)
+        for (WebElement element : expectWebElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title"))
                     .getText().trim()
@@ -174,7 +173,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getGitUrl() {
         log.info("Query Project repo");
-        for (WebElement element : waitForWebElement(projectInfo)
+        for (WebElement element : expectWebElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title")).getText()
                     .trim().equals("Repository:")) {

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectBasePage.java
@@ -64,93 +64,93 @@ public class ProjectBasePage extends BasePage {
 
     public String getProjectName() {
         log.info("Query Project name");
-        return expectWebElement(projectInfo)
+        return readyElement(projectInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage gotoVersionsTab() {
         log.info("Click Versions tab");
-        expectElementExists(versionsTabBody);
-        clickWhenTabEnabled(expectWebElement(versionsTab));
-        expectWebElement(By.id("versions"));
+        existingElement(versionsTabBody);
+        clickWhenTabEnabled(readyElement(versionsTab));
+        readyElement(By.id("versions"));
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectMaintainersPage gotoMaintainersTab() {
         log.info("Click Maintainers tab");
-        expectElementExists(maintainersTabBody);
-        clickWhenTabEnabled(expectWebElement(maintainersTab));
-        expectWebElement(By.id("maintainers"));
+        existingElement(maintainersTabBody);
+        clickWhenTabEnabled(readyElement(maintainersTab));
+        readyElement(By.id("maintainers"));
         return new ProjectMaintainersPage(getDriver());
     }
 
     public ProjectAboutPage gotoAboutTab() {
         log.info("Click About tab");
-        expectElementExists(aboutTabBody);
-        clickWhenTabEnabled(expectWebElement(aboutTab));
-        expectWebElement(By.id("about"));
+        existingElement(aboutTabBody);
+        clickWhenTabEnabled(readyElement(aboutTab));
+        readyElement(By.id("about"));
         return new ProjectAboutPage(getDriver());
     }
 
     public boolean settingsTabIsDisplayed() {
         log.info("Query Settings tab is displayed");
-        return expectElementExists(settingsTab).isDisplayed();
+        return existingElement(settingsTab).isDisplayed();
     }
 
     public ProjectBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
-        expectElementExists(settingsTabBody);
-        clickWhenTabEnabled(expectWebElement(settingsTab));
-        expectWebElement(settingsTab);
+        existingElement(settingsTabBody);
+        clickWhenTabEnabled(readyElement(settingsTab));
+        readyElement(settingsTab);
         return new ProjectBasePage(getDriver());
     }
 
     public ProjectGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsGeneralTab));
-        expectWebElement(By.id("settings-general"));
+        clickWhenTabEnabled(readyElement(settingsGeneralTab));
+        readyElement(By.id("settings-general"));
         return new ProjectGeneralTab(getDriver());
     }
 
     public ProjectPermissionsTab gotoSettingsPermissionsTab() {
         log.info("Click Permissions settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsPermissionTab));
-        expectWebElement(By.id("settings-permissions"));
+        clickWhenTabEnabled(readyElement(settingsPermissionTab));
+        readyElement(By.id("settings-permissions"));
         return new ProjectPermissionsTab(getDriver());
     }
 
     public ProjectTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsTranslationTab));
-        expectWebElement(By.id("settings-translation"));
+        clickWhenTabEnabled(readyElement(settingsTranslationTab));
+        readyElement(By.id("settings-translation"));
         return new ProjectTranslationTab(getDriver());
     }
 
     public ProjectLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsLanguagesTab));
-        expectWebElement(By.id("settings-languages"));
+        clickWhenTabEnabled(readyElement(settingsLanguagesTab));
+        readyElement(By.id("settings-languages"));
         return new ProjectLanguagesTab(getDriver());
     }
 
     public ProjectWebHooksTab gotoSettingsWebHooksTab() {
         log.info("Click WebHooks settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsWebHooksTab));
-        expectWebElement(By.id("settings-webhooks"));
+        clickWhenTabEnabled(readyElement(settingsWebHooksTab));
+        readyElement(By.id("settings-webhooks"));
         return new ProjectWebHooksTab(getDriver());
     }
 
     public ProjectAboutTab gotoSettingsAboutTab() {
         log.info("Click About settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsAboutTab));
-        expectWebElement(By.id("settings-about"));
+        clickWhenTabEnabled(readyElement(settingsAboutTab));
+        readyElement(By.id("settings-about"));
         return new ProjectAboutTab(getDriver());
     }
 
     public List<String> getContentAreaParagraphs() {
         log.info("Query Project info");
         List<String> paragraphTexts = new ArrayList<String>();
-        List<WebElement> paragraphs = expectWebElement(projectInfo)
+        List<WebElement> paragraphs = readyElement(projectInfo)
                         .findElements(By.tagName("p"));
         for (WebElement element : paragraphs) {
             paragraphTexts.add(element.getText());
@@ -160,7 +160,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getHomepage() {
         log.info("Query Project homepage");
-        for (WebElement element : expectWebElement(projectInfo)
+        for (WebElement element : readyElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title"))
                     .getText().trim()
@@ -173,7 +173,7 @@ public class ProjectBasePage extends BasePage {
 
     public String getGitUrl() {
         log.info("Query Project repo");
-        for (WebElement element : expectWebElement(projectInfo)
+        for (WebElement element : readyElement(projectInfo)
                 .findElements(By.tagName("li"))) {
             if (element.findElement(By.className("list__title")).getText()
                     .trim().equals("Repository:")) {

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
@@ -43,7 +43,7 @@ public class ProjectMaintainersPage extends ProjectBasePage {
     public List<String> getMaintainers() {
         log.info("Query maintainers list");
         List<String> names = new ArrayList<String>();
-        for (WebElement row : waitForWebElement(maintainersList)
+        for (WebElement row : expectWebElement(maintainersList)
                 .findElements(By.tagName("li"))) {
             names.add(row.getText());
         }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectMaintainersPage.java
@@ -43,7 +43,7 @@ public class ProjectMaintainersPage extends ProjectBasePage {
     public List<String> getMaintainers() {
         log.info("Query maintainers list");
         List<String> names = new ArrayList<String>();
-        for (WebElement row : expectWebElement(maintainersList)
+        for (WebElement row : readyElement(maintainersList)
                 .findElements(By.tagName("li"))) {
             names.add(row.getText());
         }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
@@ -104,6 +104,13 @@ public class ProjectVersionsPage extends ProjectBasePage {
     public ProjectVersionsPage expectDisplayedVersions(final int expected) {
         log.info("Wait for number of displayed versions to be {}", expected);
         waitForPageSilence();
+        waitForAMoment().withMessage("Waiting for versions").until(
+                new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return getNumberOfDisplayedVersions() == expected;
+            }
+        });
         assertThat(getNumberOfDisplayedVersions()).isEqualTo(expected);
         assertThat(getVersions()).hasSize(expected);
         return new ProjectVersionsPage(getDriver());

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
@@ -98,7 +98,7 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public int getNumberOfDisplayedVersions() {
         log.info("Query number of displayed versions");
-        return Integer.parseInt(expectWebElement(versionCount).getText());
+        return Integer.parseInt(readyElement(versionCount).getText());
     }
 
     public ProjectVersionsPage expectDisplayedVersions(final int expected) {
@@ -111,16 +111,16 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public ProjectVersionsPage clickSearchIcon() {
         log.info("Click Search icon");
-        expectWebElement(expectElementExists(versions), searchIcon).click();
+        readyElement(existingElement(versions), searchIcon).click();
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectVersionsPage clearVersionSearch() {
         log.info("Clear version search field");
         int maxKeys = 500;
-        while (!expectWebElement(versionSearchInput)
+        while (!readyElement(versionSearchInput)
                 .getAttribute("value").isEmpty() && maxKeys > 0) {
-            expectWebElement(versionSearchInput).sendKeys(Keys.BACK_SPACE);
+            readyElement(versionSearchInput).sendKeys(Keys.BACK_SPACE);
             maxKeys = maxKeys - 1;
         }
         if (maxKeys == 0) {
@@ -131,7 +131,7 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public ProjectVersionsPage enterVersionSearch(String searchTerm) {
         log.info("Enter version search {}", searchTerm);
-        expectWebElement(versionSearchInput).sendKeys(searchTerm);
+        readyElement(versionSearchInput).sendKeys(searchTerm);
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectVersionsPage.java
@@ -28,12 +28,13 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
 import org.zanata.page.projectversion.CreateVersionPage;
 import org.zanata.page.projectversion.VersionLanguagesPage;
 import org.zanata.util.WebElementUtil;
 
 import com.google.common.base.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Damian Jansen
@@ -97,33 +98,29 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public int getNumberOfDisplayedVersions() {
         log.info("Query number of displayed versions");
-        return Integer.parseInt(waitForWebElement(versionCount).getText());
+        return Integer.parseInt(expectWebElement(versionCount).getText());
     }
 
-    public ProjectVersionsPage waitForDisplayedVersions(final int expected) {
+    public ProjectVersionsPage expectDisplayedVersions(final int expected) {
         log.info("Wait for number of displayed versions to be {}", expected);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getNumberOfDisplayedVersions() == expected &&
-                        getVersions().size() == expected;
-            }
-        });
+        waitForPageSilence();
+        assertThat(getNumberOfDisplayedVersions()).isEqualTo(expected);
+        assertThat(getVersions()).hasSize(expected);
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectVersionsPage clickSearchIcon() {
         log.info("Click Search icon");
-        waitForWebElement(waitForElementExists(versions), searchIcon).click();
+        expectWebElement(expectElementExists(versions), searchIcon).click();
         return new ProjectVersionsPage(getDriver());
     }
 
     public ProjectVersionsPage clearVersionSearch() {
         log.info("Clear version search field");
         int maxKeys = 500;
-        while (!waitForWebElement(versionSearchInput)
+        while (!expectWebElement(versionSearchInput)
                 .getAttribute("value").isEmpty() && maxKeys > 0) {
-            waitForWebElement(versionSearchInput).sendKeys(Keys.BACK_SPACE);
+            expectWebElement(versionSearchInput).sendKeys(Keys.BACK_SPACE);
             maxKeys = maxKeys - 1;
         }
         if (maxKeys == 0) {
@@ -134,7 +131,7 @@ public class ProjectVersionsPage extends ProjectBasePage {
 
     public ProjectVersionsPage enterVersionSearch(String searchTerm) {
         log.info("Enter version search {}", searchTerm);
-        waitForWebElement(versionSearchInput).sendKeys(searchTerm);
+        expectWebElement(versionSearchInput).sendKeys(searchTerm);
         return new ProjectVersionsPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
@@ -51,7 +51,7 @@ public class ProjectsPage extends BasePage {
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        expectWebElement(createProjectButton).click();
+        readyElement(createProjectButton).click();
         return new CreateProjectPage(getDriver());
     }
 
@@ -74,7 +74,7 @@ public class ProjectsPage extends BasePage {
 
     public List<String> getProjectNamesOnCurrentPage() {
         log.info("Query Projects list");
-        if (expectWebElement(mainContentDiv)
+        if (readyElement(mainContentDiv)
                 .getText().contains("No project exists")) {
             return Collections.emptyList();
         }
@@ -110,7 +110,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setActiveFilterEnabled(boolean enabled) {
         log.info("Click to set Active filter enabled to {}", enabled);
-        WebElement activeCheckbox = expectWebElement(activeCheckBox);
+        WebElement activeCheckbox = readyElement(activeCheckBox);
         if (activeCheckbox.isSelected() != enabled) {
             activeCheckbox.click();
         }
@@ -119,7 +119,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setReadOnlyFilterEnabled(final boolean enabled) {
         log.info("Click to set Read-only filter enabled to {}", enabled);
-        WebElement readOnlyCheckbox = expectWebElement(readOnlyCheckBox);
+        WebElement readOnlyCheckbox = readyElement(readOnlyCheckBox);
         if (readOnlyCheckbox.isSelected() != enabled) {
             readOnlyCheckbox.click();
         }
@@ -128,7 +128,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setObsoleteFilterEnabled(boolean enabled) {
         log.info("Click to set Obsolete filter enabled to {}", enabled);
-        WebElement obsoleteCheckbox = expectWebElement(obsoleteCheckBox);
+        WebElement obsoleteCheckbox = readyElement(obsoleteCheckBox);
         if (obsoleteCheckbox.isSelected() != enabled) {
             obsoleteCheckbox.click();
         }

--- a/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/ProjectsPage.java
@@ -21,7 +21,6 @@
 package org.zanata.page.projects;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -31,6 +30,8 @@ import org.zanata.util.WebElementUtil;
 
 import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 public class ProjectsPage extends BasePage {
@@ -50,7 +51,7 @@ public class ProjectsPage extends BasePage {
 
     public CreateProjectPage clickOnCreateProjectLink() {
         log.info("Click Create Project");
-        waitForWebElement(createProjectButton).click();
+        expectWebElement(createProjectButton).click();
         return new CreateProjectPage(getDriver());
     }
 
@@ -73,7 +74,7 @@ public class ProjectsPage extends BasePage {
 
     public List<String> getProjectNamesOnCurrentPage() {
         log.info("Query Projects list");
-        if (waitForWebElement(mainContentDiv)
+        if (expectWebElement(mainContentDiv)
                 .getText().contains("No project exists")) {
             return Collections.emptyList();
         }
@@ -83,27 +84,33 @@ public class ProjectsPage extends BasePage {
     }
 
     /**
-     * Wait for a project name to be shown or hidden in the list.
+     * Wait for a project name to be shown in the list.
      * The list may take several seconds to reload.
      * @param projectName name of the desired project
-     * @param visible is or is not visible
      */
-    public ProjectsPage waitForProjectVisibility(final String projectName,
-                                            final boolean visible) {
-        log.info("Wait for project {} visibility is {}", projectName, visible);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getProjectNamesOnCurrentPage()
-                        .contains(projectName) == visible;
-            }
-        });
+    public ProjectsPage expectProjectVisible(final String projectName) {
+        log.info("Wait for project {} visible", projectName);
+        waitForPageSilence();
+        assertThat(getProjectNamesOnCurrentPage()).contains(projectName);
+        return new ProjectsPage(getDriver());
+    }
+
+    /**
+     * Wait for a project name to be hidden in the list.
+     * The list may take several seconds to reload.
+     * @param projectName name of the desired project
+     */
+    public ProjectsPage expectProjectNotVisible(final String projectName) {
+        log.info("Wait for project {} not visible", projectName);
+        waitForPageSilence();
+        assertThat(getProjectNamesOnCurrentPage()).doesNotContain(
+                projectName);
         return new ProjectsPage(getDriver());
     }
 
     public ProjectsPage setActiveFilterEnabled(boolean enabled) {
         log.info("Click to set Active filter enabled to {}", enabled);
-        WebElement activeCheckbox = waitForWebElement(activeCheckBox);
+        WebElement activeCheckbox = expectWebElement(activeCheckBox);
         if (activeCheckbox.isSelected() != enabled) {
             activeCheckbox.click();
         }
@@ -112,7 +119,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setReadOnlyFilterEnabled(final boolean enabled) {
         log.info("Click to set Read-only filter enabled to {}", enabled);
-        WebElement readOnlyCheckbox = waitForWebElement(readOnlyCheckBox);
+        WebElement readOnlyCheckbox = expectWebElement(readOnlyCheckBox);
         if (readOnlyCheckbox.isSelected() != enabled) {
             readOnlyCheckbox.click();
         }
@@ -121,7 +128,7 @@ public class ProjectsPage extends BasePage {
 
     public ProjectsPage setObsoleteFilterEnabled(boolean enabled) {
         log.info("Click to set Obsolete filter enabled to {}", enabled);
-        WebElement obsoleteCheckbox = waitForWebElement(obsoleteCheckBox);
+        WebElement obsoleteCheckbox = expectWebElement(obsoleteCheckBox);
         if (obsoleteCheckbox.isSelected() != enabled) {
             obsoleteCheckbox.click();
         }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
@@ -42,19 +42,19 @@ public class ProjectAboutTab extends ProjectBasePage {
 
     public ProjectAboutTab enterAboutText(String aboutText) {
         log.info("Enter About text {}", aboutText);
-        expectWebElement(aboutTextField).sendKeys(aboutText);
+        readyElement(aboutTextField).sendKeys(aboutText);
         return new ProjectAboutTab(getDriver());
     }
 
     public ProjectAboutTab clearAboutText() {
         log.info("Clear About textedit");
-        expectWebElement(aboutTextField).clear();
+        readyElement(aboutTextField).clear();
         return new ProjectAboutTab(getDriver());
     }
 
     public String getAboutText() {
         log.info("Query About text");
-        return expectWebElement(aboutTextField).getText();
+        return readyElement(aboutTextField).getText();
     }
 
     public ProjectAboutTab pressSave() {

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectAboutTab.java
@@ -42,19 +42,19 @@ public class ProjectAboutTab extends ProjectBasePage {
 
     public ProjectAboutTab enterAboutText(String aboutText) {
         log.info("Enter About text {}", aboutText);
-        waitForWebElement(aboutTextField).sendKeys(aboutText);
+        expectWebElement(aboutTextField).sendKeys(aboutText);
         return new ProjectAboutTab(getDriver());
     }
 
     public ProjectAboutTab clearAboutText() {
         log.info("Clear About textedit");
-        waitForWebElement(aboutTextField).clear();
+        expectWebElement(aboutTextField).clear();
         return new ProjectAboutTab(getDriver());
     }
 
     public String getAboutText() {
         log.info("Query About text");
-        return waitForWebElement(aboutTextField).getText();
+        return expectWebElement(aboutTextField).getText();
     }
 
     public ProjectAboutTab pressSave() {

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
@@ -60,7 +60,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      * @return project ID string
      */
     public String getProjectId() {
-        return waitForWebElement(projectIdField).getAttribute("value");
+        return expectWebElement(projectIdField).getAttribute("value");
     }
 
     /**
@@ -71,8 +71,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        waitForWebElement(projectNameField).clear();
-        waitForWebElement(projectNameField).sendKeys(projectName);
+        expectWebElement(projectNameField).clear();
+        expectWebElement(projectNameField).sendKeys(projectName);
         defocus(projectNameField);
         return new ProjectGeneralTab(getDriver());
     }
@@ -84,8 +84,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        waitForWebElement(descriptionField).clear();
-        waitForWebElement(descriptionField).sendKeys(projectDescription);
+        expectWebElement(descriptionField).clear();
+        expectWebElement(descriptionField).sendKeys(projectDescription);
         defocus(descriptionField);
         return new ProjectGeneralTab(getDriver());
     }
@@ -126,7 +126,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
     // Return a map of project type to div container
     private Map<String, WebElement> getProjectTypes() {
         Map<String, WebElement> types = new HashMap<String, WebElement>();
-        for (WebElement projectTypeRow : waitForWebElement(projectTypeList)
+        for (WebElement projectTypeRow : expectWebElement(projectTypeList)
                 .findElements(By.tagName("li"))) {
             String label = projectTypeRow.findElement(By.tagName("label"))
                     .getText();
@@ -195,8 +195,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterHomePage(String homepage) {
         log.info("Enter home page {}", homepage);
-        waitForWebElement(homepageField).clear();
-        waitForWebElement(homepageField).sendKeys(homepage);
+        expectWebElement(homepageField).clear();
+        expectWebElement(homepageField).sendKeys(homepage);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -207,8 +207,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterRepository(String repo) {
         log.info("Enter repository {}", repo);
-        waitForWebElement(repoField).clear();
-        waitForWebElement(repoField).sendKeys(repo);
+        expectWebElement(repoField).clear();
+        expectWebElement(repoField).sendKeys(repo);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -218,8 +218,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab updateProject() {
         log.info("Click Update general settings");
-        scrollIntoView(waitForWebElement(updateButton));
-        clickAndCheckErrors(waitForWebElement(updateButton));
+        scrollIntoView(expectWebElement(updateButton));
+        clickAndCheckErrors(expectWebElement(updateButton));
         return new ProjectGeneralTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectGeneralTab.java
@@ -60,7 +60,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
      * @return project ID string
      */
     public String getProjectId() {
-        return expectWebElement(projectIdField).getAttribute("value");
+        return readyElement(projectIdField).getAttribute("value");
     }
 
     /**
@@ -71,8 +71,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterProjectName(final String projectName) {
         log.info("Enter project name {}", projectName);
-        expectWebElement(projectNameField).clear();
-        expectWebElement(projectNameField).sendKeys(projectName);
+        readyElement(projectNameField).clear();
+        readyElement(projectNameField).sendKeys(projectName);
         defocus(projectNameField);
         return new ProjectGeneralTab(getDriver());
     }
@@ -84,8 +84,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterDescription(String projectDescription) {
         log.info("Enter project description {}", projectDescription);
-        expectWebElement(descriptionField).clear();
-        expectWebElement(descriptionField).sendKeys(projectDescription);
+        readyElement(descriptionField).clear();
+        readyElement(descriptionField).sendKeys(projectDescription);
         defocus(descriptionField);
         return new ProjectGeneralTab(getDriver());
     }
@@ -126,7 +126,7 @@ public class ProjectGeneralTab extends ProjectBasePage {
     // Return a map of project type to div container
     private Map<String, WebElement> getProjectTypes() {
         Map<String, WebElement> types = new HashMap<String, WebElement>();
-        for (WebElement projectTypeRow : expectWebElement(projectTypeList)
+        for (WebElement projectTypeRow : readyElement(projectTypeList)
                 .findElements(By.tagName("li"))) {
             String label = projectTypeRow.findElement(By.tagName("label"))
                     .getText();
@@ -195,8 +195,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterHomePage(String homepage) {
         log.info("Enter home page {}", homepage);
-        expectWebElement(homepageField).clear();
-        expectWebElement(homepageField).sendKeys(homepage);
+        readyElement(homepageField).clear();
+        readyElement(homepageField).sendKeys(homepage);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -207,8 +207,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab enterRepository(String repo) {
         log.info("Enter repository {}", repo);
-        expectWebElement(repoField).clear();
-        expectWebElement(repoField).sendKeys(repo);
+        readyElement(repoField).clear();
+        readyElement(repoField).sendKeys(repo);
         return new ProjectGeneralTab(getDriver());
     }
 
@@ -218,8 +218,8 @@ public class ProjectGeneralTab extends ProjectBasePage {
      */
     public ProjectGeneralTab updateProject() {
         log.info("Click Update general settings");
-        scrollIntoView(expectWebElement(updateButton));
-        clickAndCheckErrors(expectWebElement(updateButton));
+        scrollIntoView(readyElement(updateButton));
+        clickAndCheckErrors(readyElement(updateButton));
         return new ProjectGeneralTab(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
@@ -86,9 +86,7 @@ public class ProjectLanguagesTab extends ProjectBasePage {
     public ProjectLanguagesTab expectLocaleListVisible() {
         log.info("Wait for locale list visible");
         waitForPageSilence();
-        WebElement el = getDriver().findElement(settingsLanguagesForm)
-                .findElement(By.className("list--slat"));
-        assertThat(el).as("displayed").isEqualTo(true);
+        readyElement(existingElement(settingsLanguagesForm), By.className("list--slat"));
         return new ProjectLanguagesTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
@@ -78,7 +78,7 @@ public class ProjectLanguagesTab extends ProjectBasePage {
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return expectWebElement(settingsLanguagesForm)
+        return readyElement(settingsLanguagesForm)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("reveal--list-item"));
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectLanguagesTab.java
@@ -31,8 +31,9 @@ import org.openqa.selenium.WebElement;
 import org.zanata.page.projects.ProjectBasePage;
 import org.zanata.util.WebElementUtil;
 
-import javax.annotation.Nullable;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class represents the project language settings page.
@@ -77,21 +78,17 @@ public class ProjectLanguagesTab extends ProjectBasePage {
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return waitForWebElement(settingsLanguagesForm)
+        return expectWebElement(settingsLanguagesForm)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("reveal--list-item"));
     }
 
-    public ProjectLanguagesTab waitForLocaleListVisible() {
+    public ProjectLanguagesTab expectLocaleListVisible() {
         log.info("Wait for locale list visible");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver driver) {
-                return driver.findElement(settingsLanguagesForm)
-                        .findElement(By.className("list--slat"))
-                        .isDisplayed();
-            }
-        });
+        waitForPageSilence();
+        WebElement el = getDriver().findElement(settingsLanguagesForm)
+                .findElement(By.className("list--slat"));
+        assertThat(el).as("displayed").isEqualTo(true);
         return new ProjectLanguagesTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
@@ -131,7 +131,7 @@ public class ProjectPermissionsTab extends ProjectBasePage {
     }
 
     private List<WebElement> getSettingsMaintainersElement() {
-        return expectWebElement(maintainersForm)
+        return readyElement(maintainersForm)
                 .findElement(By.id("maintainers-list"))
                 .findElements(By.className("reveal--list-item"));
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectPermissionsTab.java
@@ -33,6 +33,8 @@ import org.zanata.util.WebElementUtil;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Damian Jansen
  * <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
@@ -112,30 +114,24 @@ public class ProjectPermissionsTab extends ProjectBasePage {
         });
     }
 
-    public ProjectPermissionsTab waitForMaintainersContains(
+    public ProjectPermissionsTab expectMaintainersContains(
             final String username) {
         log.info("Wait for maintainers contains {}", username);
-        return refreshPageUntil(this, new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver driver) {
-                return getSettingsMaintainersList().contains(username);
-            }
-        });
+        waitForPageSilence();
+        assertThat(getSettingsMaintainersList()).contains(username);
+        return this;
     }
 
-    public ProjectPermissionsTab waitForMaintainersNotContains(
+    public ProjectPermissionsTab expectMaintainersNotContains(
             final String username) {
         log.info("Wait for maintainers does not contain {}", username);
-        return refreshPageUntil(this, new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver driver) {
-                return !getSettingsMaintainersList().contains(username);
-            }
-        });
+        waitForPageSilence();
+        assertThat(getSettingsMaintainersList()).doesNotContain(username);
+        return this;
     }
 
     private List<WebElement> getSettingsMaintainersElement() {
-        return waitForWebElement(maintainersForm)
+        return expectWebElement(maintainersForm)
                 .findElement(By.id("maintainers-list"))
                 .findElements(By.className("reveal--list-item"));
     }

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
@@ -50,8 +50,8 @@ public class ProjectTranslationTab extends ProjectBasePage {
         log.info("Query is {} validation level {}", optionName, level);
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-        WebElement option = expectElementExists(
-                expectElementExists(validationsList),
+        WebElement option = existingElement(
+                existingElement(validationsList),
                 By.id(optionElementID));
         return option.getAttribute("checked").equals("true");
     }
@@ -61,8 +61,8 @@ public class ProjectTranslationTab extends ProjectBasePage {
         log.info("Click {} validation level {}", optionName, level);
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-        WebElement option =  expectElementExists(
-                expectElementExists(validationsList),
+        WebElement option =  existingElement(
+                existingElement(validationsList),
                 By.id(optionElementID));
 
         ((JavascriptExecutor) getDriver())

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectTranslationTab.java
@@ -50,8 +50,8 @@ public class ProjectTranslationTab extends ProjectBasePage {
         log.info("Query is {} validation level {}", optionName, level);
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-        WebElement option = waitForElementExists(
-                waitForElementExists(validationsList),
+        WebElement option = expectElementExists(
+                expectElementExists(validationsList),
                 By.id(optionElementID));
         return option.getAttribute("checked").equals("true");
     }
@@ -61,8 +61,8 @@ public class ProjectTranslationTab extends ProjectBasePage {
         log.info("Click {} validation level {}", optionName, level);
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
-        WebElement option =  waitForElementExists(
-                waitForElementExists(validationsList),
+        WebElement option =  expectElementExists(
+                expectElementExists(validationsList),
                 By.id(optionElementID));
 
         ((JavascriptExecutor) getDriver())

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectWebHooksTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectWebHooksTab.java
@@ -20,7 +20,6 @@
  */
 package org.zanata.page.projects.projectsettings;
 
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -47,12 +46,12 @@ public class ProjectWebHooksTab extends ProjectBasePage {
     }
 
     public ProjectWebHooksTab enterUrl(String url) {
-        expectWebElement(urlInputField).sendKeys(url + Keys.ENTER);
+        readyElement(urlInputField).sendKeys(url + Keys.ENTER);
         return new ProjectWebHooksTab(getDriver());
     }
 
     public List<String> getWebHooks() {
-        return WebElementUtil.elementsToText(expectWebElement(webHooksList)
+        return WebElementUtil.elementsToText(readyElement(webHooksList)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("list-item")));
     }
@@ -70,7 +69,7 @@ public class ProjectWebHooksTab extends ProjectBasePage {
     }
 
     public ProjectWebHooksTab clickRemoveOn(String url) {
-        List<WebElement> listItems = expectWebElement(webHooksList)
+        List<WebElement> listItems = readyElement(webHooksList)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("list-item"));
         boolean clicked = false;

--- a/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectWebHooksTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projects/projectsettings/ProjectWebHooksTab.java
@@ -31,6 +31,8 @@ import org.zanata.util.WebElementUtil;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Damian Jansen <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
@@ -45,38 +47,30 @@ public class ProjectWebHooksTab extends ProjectBasePage {
     }
 
     public ProjectWebHooksTab enterUrl(String url) {
-        waitForWebElement(urlInputField).sendKeys(url + Keys.ENTER);
+        expectWebElement(urlInputField).sendKeys(url + Keys.ENTER);
         return new ProjectWebHooksTab(getDriver());
     }
 
     public List<String> getWebHooks() {
-        return WebElementUtil.elementsToText(waitForWebElement(webHooksList)
+        return WebElementUtil.elementsToText(expectWebElement(webHooksList)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("list-item")));
     }
 
-    public ProjectWebHooksTab waitForWebHooksContains(final String url) {
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getWebHooks().contains(url);
-            }
-        });
+    public ProjectWebHooksTab expectWebHooksContains(final String url) {
+        waitForPageSilence();
+        assertThat(getWebHooks()).contains(url);
         return new ProjectWebHooksTab(getDriver());
     }
 
-    public ProjectWebHooksTab waitForWebHooksNotContains(final String url) {
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return !getWebHooks().contains(url);
-            }
-        });
+    public ProjectWebHooksTab expectWebHooksNotContains(final String url) {
+        waitForPageSilence();
+        assertThat(getWebHooks()).doesNotContain(url);
         return new ProjectWebHooksTab(getDriver());
     }
 
     public ProjectWebHooksTab clickRemoveOn(String url) {
-        List<WebElement> listItems = waitForWebElement(webHooksList)
+        List<WebElement> listItems = expectWebElement(webHooksList)
                 .findElement(By.className("list--slat"))
                 .findElements(By.className("list-item"));
         boolean clicked = false;

--- a/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
@@ -81,7 +81,7 @@ public class CreateVersionPage extends BasePage {
     private void clickCopyFromCheckbox() {
         ((JavascriptExecutor) getDriver())
                 .executeScript("arguments[0].click();",
-                expectWebElement(copyFromPreviousVersionChk)
+                readyElement(copyFromPreviousVersionChk)
                         .findElement(By.tagName("span")));
 
     }
@@ -97,7 +97,7 @@ public class CreateVersionPage extends BasePage {
         } else {
             clickCopyFromCheckbox();
         }
-        expectWebElement(previousVersionsList);
+        readyElement(previousVersionsList);
         return this;
     }
 
@@ -112,19 +112,19 @@ public class CreateVersionPage extends BasePage {
         } else {
             clickCopyFromCheckbox();
         }
-        expectWebElement(projectTypesList);
+        readyElement(projectTypesList);
         return this;
     }
 
     public boolean copyFromVersionIsChecked() {
         log.info("Query is Copy from Version checkbox checked");
-        return expectWebElement(copyFromPreviousVersionChk)
+        return readyElement(copyFromPreviousVersionChk)
                 .findElement(By.tagName("input")).isSelected();
     }
 
     private WebElement getVersionIdField() {
         log.info("Query Version ID");
-        return expectWebElement(projectVersionID);
+        return readyElement(projectVersionID);
     }
 
     public CreateVersionPage selectProjectType(final String projectType) {
@@ -133,7 +133,7 @@ public class CreateVersionPage extends BasePage {
                 .until(new Function<WebDriver, WebElement>() {
             @Override
             public WebElement apply(WebDriver input) {
-                for (WebElement item : expectWebElement(projectTypeSelection)
+                for (WebElement item : readyElement(projectTypeSelection)
                         .findElements(By.tagName("li"))) {
                     if (item.findElement(By.tagName("label")).getText()
                             .startsWith(projectType)) {
@@ -149,13 +149,13 @@ public class CreateVersionPage extends BasePage {
 
     public VersionLanguagesPage saveVersion() {
         log.info("Click Save");
-        clickAndCheckErrors(expectWebElement(saveButton));
+        clickAndCheckErrors(readyElement(saveButton));
         return new VersionLanguagesPage(getDriver());
     }
 
     public CreateVersionPage saveExpectingError() {
         log.info("Click Save");
-        expectWebElement(saveButton).click();
+        readyElement(saveButton).click();
         return new CreateVersionPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/CreateVersionPage.java
@@ -30,6 +30,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.zanata.page.BasePage;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Slf4j
 public class CreateVersionPage extends BasePage {
 
@@ -79,7 +81,7 @@ public class CreateVersionPage extends BasePage {
     private void clickCopyFromCheckbox() {
         ((JavascriptExecutor) getDriver())
                 .executeScript("arguments[0].click();",
-                waitForWebElement(copyFromPreviousVersionChk)
+                expectWebElement(copyFromPreviousVersionChk)
                         .findElement(By.tagName("span")));
 
     }
@@ -95,7 +97,7 @@ public class CreateVersionPage extends BasePage {
         } else {
             clickCopyFromCheckbox();
         }
-        waitForWebElement(previousVersionsList);
+        expectWebElement(previousVersionsList);
         return this;
     }
 
@@ -110,19 +112,19 @@ public class CreateVersionPage extends BasePage {
         } else {
             clickCopyFromCheckbox();
         }
-        waitForWebElement(projectTypesList);
+        expectWebElement(projectTypesList);
         return this;
     }
 
     public boolean copyFromVersionIsChecked() {
         log.info("Query is Copy from Version checkbox checked");
-        return waitForWebElement(copyFromPreviousVersionChk)
+        return expectWebElement(copyFromPreviousVersionChk)
                 .findElement(By.tagName("input")).isSelected();
     }
 
     private WebElement getVersionIdField() {
         log.info("Query Version ID");
-        return waitForWebElement(projectVersionID);
+        return expectWebElement(projectVersionID);
     }
 
     public CreateVersionPage selectProjectType(final String projectType) {
@@ -131,7 +133,7 @@ public class CreateVersionPage extends BasePage {
                 .until(new Function<WebDriver, WebElement>() {
             @Override
             public WebElement apply(WebDriver input) {
-                for (WebElement item : waitForWebElement(projectTypeSelection)
+                for (WebElement item : expectWebElement(projectTypeSelection)
                         .findElements(By.tagName("li"))) {
                     if (item.findElement(By.tagName("label")).getText()
                             .startsWith(projectType)) {
@@ -147,24 +149,20 @@ public class CreateVersionPage extends BasePage {
 
     public VersionLanguagesPage saveVersion() {
         log.info("Click Save");
-        clickAndCheckErrors(waitForWebElement(saveButton));
+        clickAndCheckErrors(expectWebElement(saveButton));
         return new VersionLanguagesPage(getDriver());
     }
 
     public CreateVersionPage saveExpectingError() {
         log.info("Click Save");
-        waitForWebElement(saveButton).click();
+        expectWebElement(saveButton).click();
         return new CreateVersionPage(getDriver());
     }
 
-    public CreateVersionPage waitForNumErrors(final int numberOfErrors) {
+    public CreateVersionPage expectNumErrors(final int numberOfErrors) {
         log.info("Wait for number of error to be {}", numberOfErrors);
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return getErrors().size() == numberOfErrors;
-            }
-        });
+        waitForPageSilence();
+        assertThat(getErrors()).hasSize(numberOfErrors);
         return new CreateVersionPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
@@ -54,13 +54,13 @@ public class VersionBasePage extends BasePage {
 
     public String getProjectVersionName() {
         log.info("Query Version name");
-        return expectWebElement(versionInfo)
+        return readyElement(versionInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage clickProjectLink(String projectName) {
         log.info("Click Project link");
-        expectWebElement(versionPage)
+        readyElement(versionPage)
                 .findElement(By.linkText(projectName))
                 .click();
         return new ProjectVersionsPage(getDriver());
@@ -68,54 +68,54 @@ public class VersionBasePage extends BasePage {
 
     public VersionDocumentsPage gotoDocumentTab() {
         log.info("Click Documents tab");
-        expectElementExists(documentsTabBody);
-        clickWhenTabEnabled(expectWebElement(documentsTab));
-        expectWebElement(By.id("documents"));
+        existingElement(documentsTabBody);
+        clickWhenTabEnabled(readyElement(documentsTab));
+        readyElement(By.id("documents"));
         return new VersionDocumentsPage(getDriver());
     }
 
     public VersionLanguagesPage gotoLanguageTab() {
         log.info("Click Languages tab");
-        expectElementExists(languageTabBody);
-        clickWhenTabEnabled(expectWebElement(languageTab));
-        expectWebElement(By.id("languages"));
+        existingElement(languageTabBody);
+        clickWhenTabEnabled(readyElement(languageTab));
+        readyElement(By.id("languages"));
         return new VersionLanguagesPage(getDriver());
     }
 
     public VersionBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
         slightPause();
-        expectElementExists(settingsTabBody);
-        clickWhenTabEnabled(expectWebElement(settingsTab));
-        expectWebElement(settingsTabBody);
+        existingElement(settingsTabBody);
+        clickWhenTabEnabled(readyElement(settingsTab));
+        readyElement(settingsTabBody);
         return new VersionBasePage(getDriver());
     }
 
     public VersionGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsGeneralTab));
-        expectWebElement(By.id("settings-general_form"));
+        clickWhenTabEnabled(readyElement(settingsGeneralTab));
+        readyElement(By.id("settings-general_form"));
         return new VersionGeneralTab(getDriver());
     }
 
     public VersionLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsLanguagesTab));
-        expectWebElement(By.id("settings-languages-form"));
+        clickWhenTabEnabled(readyElement(settingsLanguagesTab));
+        readyElement(By.id("settings-languages-form"));
         return new VersionLanguagesTab(getDriver());
     }
 
     public VersionDocumentsTab gotoSettingsDocumentsTab() {
         log.info("Click Documents settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsDocumentsTab));
-        expectWebElement(By.id("settings-document_form"));
+        clickWhenTabEnabled(readyElement(settingsDocumentsTab));
+        readyElement(By.id("settings-document_form"));
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(expectWebElement(settingsTranslationTab));
-        expectWebElement(By.id("settings-translation-review-form"));
+        clickWhenTabEnabled(readyElement(settingsTranslationTab));
+        readyElement(By.id("settings-translation-review-form"));
         return new VersionTranslationTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionBasePage.java
@@ -54,13 +54,13 @@ public class VersionBasePage extends BasePage {
 
     public String getProjectVersionName() {
         log.info("Query Version name");
-        return waitForWebElement(versionInfo)
+        return expectWebElement(versionInfo)
                 .findElement(By.tagName("h1")).getText();
     }
 
     public ProjectVersionsPage clickProjectLink(String projectName) {
         log.info("Click Project link");
-        waitForWebElement(versionPage)
+        expectWebElement(versionPage)
                 .findElement(By.linkText(projectName))
                 .click();
         return new ProjectVersionsPage(getDriver());
@@ -68,54 +68,54 @@ public class VersionBasePage extends BasePage {
 
     public VersionDocumentsPage gotoDocumentTab() {
         log.info("Click Documents tab");
-        waitForElementExists(documentsTabBody);
-        clickWhenTabEnabled(waitForWebElement(documentsTab));
-        waitForWebElement(By.id("documents"));
+        expectElementExists(documentsTabBody);
+        clickWhenTabEnabled(expectWebElement(documentsTab));
+        expectWebElement(By.id("documents"));
         return new VersionDocumentsPage(getDriver());
     }
 
     public VersionLanguagesPage gotoLanguageTab() {
         log.info("Click Languages tab");
-        waitForElementExists(languageTabBody);
-        clickWhenTabEnabled(waitForWebElement(languageTab));
-        waitForWebElement(By.id("languages"));
+        expectElementExists(languageTabBody);
+        clickWhenTabEnabled(expectWebElement(languageTab));
+        expectWebElement(By.id("languages"));
         return new VersionLanguagesPage(getDriver());
     }
 
     public VersionBasePage gotoSettingsTab() {
         log.info("Click Settings tab");
         slightPause();
-        waitForElementExists(settingsTabBody);
-        clickWhenTabEnabled(waitForWebElement(settingsTab));
-        waitForWebElement(settingsTabBody);
+        expectElementExists(settingsTabBody);
+        clickWhenTabEnabled(expectWebElement(settingsTab));
+        expectWebElement(settingsTabBody);
         return new VersionBasePage(getDriver());
     }
 
     public VersionGeneralTab gotoSettingsGeneral() {
         log.info("Click General settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsGeneralTab));
-        waitForWebElement(By.id("settings-general_form"));
+        clickWhenTabEnabled(expectWebElement(settingsGeneralTab));
+        expectWebElement(By.id("settings-general_form"));
         return new VersionGeneralTab(getDriver());
     }
 
     public VersionLanguagesTab gotoSettingsLanguagesTab() {
         log.info("Click Languages settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsLanguagesTab));
-        waitForWebElement(By.id("settings-languages-form"));
+        clickWhenTabEnabled(expectWebElement(settingsLanguagesTab));
+        expectWebElement(By.id("settings-languages-form"));
         return new VersionLanguagesTab(getDriver());
     }
 
     public VersionDocumentsTab gotoSettingsDocumentsTab() {
         log.info("Click Documents settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsDocumentsTab));
-        waitForWebElement(By.id("settings-document_form"));
+        clickWhenTabEnabled(expectWebElement(settingsDocumentsTab));
+        expectWebElement(By.id("settings-document_form"));
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionTranslationTab gotoSettingsTranslationTab() {
         log.info("Click Translation settings sub-tab");
-        clickWhenTabEnabled(waitForWebElement(settingsTranslationTab));
-        waitForWebElement(By.id("settings-translation-review-form"));
+        clickWhenTabEnabled(expectWebElement(settingsTranslationTab));
+        expectWebElement(By.id("settings-translation-review-form"));
         return new VersionTranslationTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
@@ -21,7 +21,6 @@
 package org.zanata.page.projectversion;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -74,7 +73,7 @@ public class VersionDocumentsPage extends VersionBasePage {
 
     private List<WebElement> getDocumentsTabDocumentList() {
         slightPause();
-        return expectWebElement(By.id("documents-document_list"))
+        return readyElement(By.id("documents-document_list"))
                         .findElements(By.xpath("./li"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionDocumentsPage.java
@@ -30,6 +30,8 @@ import org.openqa.selenium.WebElement;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Damian Jansen
  * <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
@@ -41,14 +43,10 @@ public class VersionDocumentsPage extends VersionBasePage {
         super(driver);
     }
 
-    public VersionDocumentsPage waitForSourceDocsContains(final String document) {
+    public VersionDocumentsPage expectSourceDocsContains(final String document) {
         log.info("Click Project link");
-        waitForAMoment().until(new Predicate<WebDriver>() {
-            @Override
-            public boolean apply(WebDriver input) {
-                return sourceDocumentsContains(document);
-            }
-        });
+        waitForPageSilence();
+        assertThat(getSourceDocumentNames()).contains(document);
         return new VersionDocumentsPage(getDriver());
     }
 
@@ -76,7 +74,7 @@ public class VersionDocumentsPage extends VersionBasePage {
 
     private List<WebElement> getDocumentsTabDocumentList() {
         slightPause();
-        return waitForWebElement(By.id("documents-document_list"))
+        return expectWebElement(By.id("documents-document_list"))
                         .findElements(By.xpath("./li"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
@@ -53,12 +53,12 @@ public class VersionLanguagesPage extends VersionBasePage {
     private By documentListItemTitle = By.className("list__title");
 
     private List<WebElement> getLanguageTabLocaleList() {
-        return expectWebElement(languageList).findElements(By.tagName("li"));
+        return readyElement(languageList).findElements(By.tagName("li"));
     }
 
     private List<WebElement> getLanguageTabDocumentList() {
         log.info("Query documents list");
-        return expectWebElement(expectElementExists(languageDocumentList),
+        return readyElement(existingElement(languageDocumentList),
                 By.className("list--stats"))
                 .findElements(documentListItem);
     }
@@ -96,7 +96,7 @@ public class VersionLanguagesPage extends VersionBasePage {
                     @Override
                     public WebElement apply(WebDriver input) {
                         for (WebElement document : getLanguageTabDocumentList()) {
-                            if (expectElementExists(document,
+                            if (existingElement(document,
                                     documentListItemTitle)
                                     .getText().equals(docName)) {
                                 return document

--- a/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/VersionLanguagesPage.java
@@ -53,12 +53,12 @@ public class VersionLanguagesPage extends VersionBasePage {
     private By documentListItemTitle = By.className("list__title");
 
     private List<WebElement> getLanguageTabLocaleList() {
-        return waitForWebElement(languageList).findElements(By.tagName("li"));
+        return expectWebElement(languageList).findElements(By.tagName("li"));
     }
 
     private List<WebElement> getLanguageTabDocumentList() {
         log.info("Query documents list");
-        return waitForWebElement(waitForElementExists(languageDocumentList),
+        return expectWebElement(expectElementExists(languageDocumentList),
                 By.className("list--stats"))
                 .findElements(documentListItem);
     }
@@ -96,7 +96,7 @@ public class VersionLanguagesPage extends VersionBasePage {
                     @Override
                     public WebElement apply(WebDriver input) {
                         for (WebElement document : getLanguageTabDocumentList()) {
-                            if (waitForElementExists(document,
+                            if (expectElementExists(document,
                                     documentListItemTitle)
                                     .getText().equals(docName)) {
                                 return document

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
@@ -56,7 +56,7 @@ public class VersionDocumentsTab extends VersionBasePage {
 
     public VersionDocumentsTab pressUploadFileButton() {
         log.info("Click Upload file button");
-        clickLinkAfterAnimation(expectWebElement(uploadButton));
+        clickLinkAfterAnimation(readyElement(uploadButton));
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -67,12 +67,12 @@ public class VersionDocumentsTab extends VersionBasePage {
      */
     public boolean canSubmitDocument() {
         log.info("Query can start upload");
-        return expectElementExists(startUploadButton).isEnabled();
+        return existingElement(startUploadButton).isEnabled();
     }
 
     public VersionDocumentsTab cancelUpload() {
         log.info("Click Cancel");
-        expectWebElement(cancelUploadButton).click();
+        readyElement(cancelUploadButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
@@ -93,21 +93,21 @@ public class VersionDocumentsTab extends VersionBasePage {
                         "arguments[0].style.height = '1px'; " +
                         "arguments[0].style.width = '1px'; " +
                         "arguments[0].style.opacity = 1",
-                        expectElementExists(fileUploadInput));
+                        existingElement(fileUploadInput));
 
-        expectWebElement(fileUploadInput).sendKeys(filePath);
+        readyElement(fileUploadInput).sendKeys(filePath);
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab submitUpload() {
         log.info("Click Submit upload");
-        expectWebElement(startUploadButton).click();
+        readyElement(startUploadButton).click();
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab clickUploadDone() {
         log.info("Click upload Done button");
-        expectWebElement(fileUploadDone).click();
+        readyElement(fileUploadDone).click();
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -117,7 +117,7 @@ public class VersionDocumentsTab extends VersionBasePage {
                 .until(new Function<WebDriver, List<String>>() {
                     @Override
                     public List<String> apply(WebDriver input) {
-                        List<WebElement> elements = expectElementExists(
+                        List<WebElement> elements = existingElement(
                                 By.id("settings-document_form"))
                                 .findElement(By.tagName("ul"))
                                 .findElements(By.xpath(".//li/label[@class='" +
@@ -160,13 +160,13 @@ public class VersionDocumentsTab extends VersionBasePage {
     }
 
     private List<WebElement> getUploadListElements() {
-        return expectWebElement(filesListPanel).findElement(By.tagName("ul"))
+        return readyElement(filesListPanel).findElement(By.tagName("ul"))
                 .findElements(By.tagName("li"));
     }
 
     public String getUploadError() {
         log.info("Query upload error message");
-        return expectWebElement(expectElementExists(fileUploadPanel),
+        return readyElement(existingElement(fileUploadPanel),
                 By.className("message--danger")).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionDocumentsTab.java
@@ -56,7 +56,7 @@ public class VersionDocumentsTab extends VersionBasePage {
 
     public VersionDocumentsTab pressUploadFileButton() {
         log.info("Click Upload file button");
-        clickLinkAfterAnimation(waitForWebElement(uploadButton));
+        clickLinkAfterAnimation(expectWebElement(uploadButton));
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -67,12 +67,12 @@ public class VersionDocumentsTab extends VersionBasePage {
      */
     public boolean canSubmitDocument() {
         log.info("Query can start upload");
-        return waitForElementExists(startUploadButton).isEnabled();
+        return expectElementExists(startUploadButton).isEnabled();
     }
 
     public VersionDocumentsTab cancelUpload() {
         log.info("Click Cancel");
-        waitForWebElement(cancelUploadButton).click();
+        expectWebElement(cancelUploadButton).click();
         waitForAMoment().until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
@@ -93,21 +93,21 @@ public class VersionDocumentsTab extends VersionBasePage {
                         "arguments[0].style.height = '1px'; " +
                         "arguments[0].style.width = '1px'; " +
                         "arguments[0].style.opacity = 1",
-                        waitForElementExists(fileUploadInput));
+                        expectElementExists(fileUploadInput));
 
-        waitForWebElement(fileUploadInput).sendKeys(filePath);
+        expectWebElement(fileUploadInput).sendKeys(filePath);
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab submitUpload() {
         log.info("Click Submit upload");
-        waitForWebElement(startUploadButton).click();
+        expectWebElement(startUploadButton).click();
         return new VersionDocumentsTab(getDriver());
     }
 
     public VersionDocumentsTab clickUploadDone() {
         log.info("Click upload Done button");
-        waitForWebElement(fileUploadDone).click();
+        expectWebElement(fileUploadDone).click();
         return new VersionDocumentsTab(getDriver());
     }
 
@@ -117,7 +117,7 @@ public class VersionDocumentsTab extends VersionBasePage {
                 .until(new Function<WebDriver, List<String>>() {
                     @Override
                     public List<String> apply(WebDriver input) {
-                        List<WebElement> elements = waitForElementExists(
+                        List<WebElement> elements = expectElementExists(
                                 By.id("settings-document_form"))
                                 .findElement(By.tagName("ul"))
                                 .findElements(By.xpath(".//li/label[@class='" +
@@ -160,13 +160,13 @@ public class VersionDocumentsTab extends VersionBasePage {
     }
 
     private List<WebElement> getUploadListElements() {
-        return waitForWebElement(filesListPanel).findElement(By.tagName("ul"))
+        return expectWebElement(filesListPanel).findElement(By.tagName("ul"))
                 .findElements(By.tagName("li"));
     }
 
     public String getUploadError() {
         log.info("Query upload error message");
-        return waitForWebElement(waitForElementExists(fileUploadPanel),
+        return expectWebElement(expectElementExists(fileUploadPanel),
                 By.className("message--danger")).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
@@ -58,7 +58,7 @@ public class VersionLanguagesTab extends VersionBasePage {
      */
     public VersionLanguagesTab clickInheritCheckbox() {
         log.info("Click Inherit check box");
-        expectWebElement(expectWebElement(languagesSettingForm),
+        readyElement(readyElement(languagesSettingForm),
                 By.className("form__checkbox"))
                 .click();
         return new VersionLanguagesTab(getDriver());
@@ -67,7 +67,7 @@ public class VersionLanguagesTab extends VersionBasePage {
     public VersionLanguagesTab expectLocaleListVisible() {
         log.info("Wait for locale list visible");
         waitForPageSilence();
-        WebElement el = expectWebElement(languagesSettingForm)
+        WebElement el = readyElement(languagesSettingForm)
                 .findElement(By.className("list--slat"));
         assertThat(el.isDisplayed()).as("displayed").isTrue();
         return new VersionLanguagesTab(getDriver());
@@ -90,7 +90,7 @@ public class VersionLanguagesTab extends VersionBasePage {
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return expectWebElement(languagesSettingForm)
+        return readyElement(languagesSettingForm)
                 .findElements(By.xpath(".//ul/li[@class='reveal--list-item']"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionLanguagesTab.java
@@ -33,6 +33,8 @@ import org.zanata.util.WebElementUtil;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * This class represents the project version settings tab for languages.
  *
@@ -56,22 +58,18 @@ public class VersionLanguagesTab extends VersionBasePage {
      */
     public VersionLanguagesTab clickInheritCheckbox() {
         log.info("Click Inherit check box");
-        waitForWebElement(waitForWebElement(languagesSettingForm),
+        expectWebElement(expectWebElement(languagesSettingForm),
                 By.className("form__checkbox"))
                 .click();
         return new VersionLanguagesTab(getDriver());
     }
 
-    public VersionLanguagesTab waitForLocaleListVisible() {
+    public VersionLanguagesTab expectLocaleListVisible() {
         log.info("Wait for locale list visible");
-        waitForAMoment().until(new Function<WebDriver, Boolean>() {
-            @Override
-            public Boolean apply(WebDriver driver) {
-                return waitForWebElement(languagesSettingForm)
-                        .findElement(By.className("list--slat"))
-                        .isDisplayed();
-            }
-        });
+        waitForPageSilence();
+        WebElement el = expectWebElement(languagesSettingForm)
+                .findElement(By.className("list--slat"));
+        assertThat(el.isDisplayed()).as("displayed").isTrue();
         return new VersionLanguagesTab(getDriver());
     }
 
@@ -92,30 +90,16 @@ public class VersionLanguagesTab extends VersionBasePage {
     }
 
     private List<WebElement> getEnabledLocaleListElement() {
-        return waitForWebElement(languagesSettingForm)
+        return expectWebElement(languagesSettingForm)
                 .findElements(By.xpath(".//ul/li[@class='reveal--list-item']"));
     }
 
-    public VersionLanguagesTab waitForLanguagesContains(String language) {
+    public VersionLanguagesTab expectLanguagesContains(String language) {
         log.info("Wait for languages contains {}", language);
-        waitForLanguageEntryExpected(language, true);
+        waitForPageSilence();
+        assertThat(getEnabledLocaleList()).as("enabled locales list").contains(
+                language);
         return new VersionLanguagesTab(getDriver());
-    }
-
-    public VersionLanguagesTab waitForLanguagesNotContains(String language) {
-        log.info("Wait for languages does not contain {}", language);
-        waitForLanguageEntryExpected(language, false);
-        return new VersionLanguagesTab(getDriver());
-    }
-
-    private void waitForLanguageEntryExpected(final String language,
-                                              final boolean exists) {
-        waitForAMoment().until(new Function<WebDriver, Boolean>() {
-            @Override
-            public Boolean apply(WebDriver driver) {
-                return getEnabledLocaleList().contains(language) == exists;
-            }
-        });
     }
 
     public VersionLanguagesTab enterSearchLanguage(String localeQuery) {

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
@@ -47,7 +47,7 @@ public class VersionTranslationTab extends VersionBasePage {
         String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        return expectElementExists(By.id(optionElementID))
+        return existingElement(By.id(optionElementID))
                 .getAttribute("checked")
                 .equals("true");
     }
@@ -58,7 +58,7 @@ public class VersionTranslationTab extends VersionBasePage {
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        WebElement option = expectWebElement(
+        WebElement option = readyElement(
                 By.id("settings-translation-validation-form"))
                 .findElement(By.id(optionElementID));
 

--- a/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
+++ b/functional-test/src/main/java/org/zanata/page/projectversion/versionsettings/VersionTranslationTab.java
@@ -47,7 +47,7 @@ public class VersionTranslationTab extends VersionBasePage {
         String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        return waitForElementExists(By.id(optionElementID))
+        return expectElementExists(By.id(optionElementID))
                 .getAttribute("checked")
                 .equals("true");
     }
@@ -58,7 +58,7 @@ public class VersionTranslationTab extends VersionBasePage {
         final String optionElementID = validationNames
                 .get(optionName).toString().concat(level);
 
-        WebElement option = waitForWebElement(
+        WebElement option = expectWebElement(
                 By.id("settings-translation-validation-form"))
                 .findElement(By.id(optionElementID));
 

--- a/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.zanata.page.BasePage;
-import org.zanata.util.WebElementUtil;
 
 /**
  * @author Patrick Huang <a
@@ -43,20 +42,20 @@ public class ContactAdminFormPage extends BasePage {
 
     public ContactAdminFormPage inputSubject(String subject) {
         log.info("Enter subject {}", subject);
-        waitForWebElement(subjectField).clear();
-        waitForWebElement(subjectField).sendKeys(subject);
+        expectWebElement(subjectField).clear();
+        expectWebElement(subjectField).sendKeys(subject);
         return new ContactAdminFormPage(getDriver());
     }
 
     public ContactAdminFormPage inputMessage(String message) {
         log.info("Enter message {}", message);
-        waitForWebElement(messageField).sendKeys(message);
+        expectWebElement(messageField).sendKeys(message);
         return new ContactAdminFormPage(getDriver());
     }
 
     public HelpPage send() {
         log.info("Click Send");
-        waitForWebElement(sendButton).click();
+        expectWebElement(sendButton).click();
         return new HelpPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/ContactAdminFormPage.java
@@ -42,20 +42,20 @@ public class ContactAdminFormPage extends BasePage {
 
     public ContactAdminFormPage inputSubject(String subject) {
         log.info("Enter subject {}", subject);
-        expectWebElement(subjectField).clear();
-        expectWebElement(subjectField).sendKeys(subject);
+        readyElement(subjectField).clear();
+        readyElement(subjectField).sendKeys(subject);
         return new ContactAdminFormPage(getDriver());
     }
 
     public ContactAdminFormPage inputMessage(String message) {
         log.info("Enter message {}", message);
-        expectWebElement(messageField).sendKeys(message);
+        readyElement(messageField).sendKeys(message);
         return new ContactAdminFormPage(getDriver());
     }
 
     public HelpPage send() {
         log.info("Click Send");
-        expectWebElement(sendButton).click();
+        readyElement(sendButton).click();
         return new HelpPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
@@ -41,13 +41,13 @@ public class HelpPage extends BasePage {
 
     public HelpPage clickMoreActions() {
         log.info("Click More Actions");
-        waitForWebElement(moreActions).click();
+        expectWebElement(moreActions).click();
         return new HelpPage(getDriver());
     }
 
     public ContactAdminFormPage clickContactAdmin() {
         log.info("Click Contact Admin button");
-        waitForWebElement(contactAdminLink).click();
+        expectWebElement(contactAdminLink).click();
         return new ContactAdminFormPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HelpPage.java
@@ -41,13 +41,13 @@ public class HelpPage extends BasePage {
 
     public HelpPage clickMoreActions() {
         log.info("Click More Actions");
-        expectWebElement(moreActions).click();
+        readyElement(moreActions).click();
         return new HelpPage(getDriver());
     }
 
     public ContactAdminFormPage clickContactAdmin() {
         log.info("Click Contact Admin button");
-        expectWebElement(contactAdminLink).click();
+        readyElement(contactAdminLink).click();
         return new ContactAdminFormPage(getDriver());
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
@@ -44,18 +44,18 @@ public class HomePage extends BasePage {
 
     public EditHomeContentPage goToEditPageContent() {
         log.info("Click Edit Page Content");
-        expectWebElement(editPageContentButton).click();
+        readyElement(editPageContentButton).click();
         return new EditHomeContentPage(getDriver());
     }
 
     public EditHomeCodePage goToEditPageCode() {
         log.info("Click Edit Page Code");
-        expectWebElement(editPageCodeButton).click();
+        readyElement(editPageCodeButton).click();
         return new EditHomeCodePage(getDriver());
     }
 
     public String getMainBodyContent() {
         log.info("Query homepage content");
-        return expectWebElement(mainBodyContent).getText();
+        return readyElement(mainBodyContent).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
+++ b/functional-test/src/main/java/org/zanata/page/utility/HomePage.java
@@ -44,18 +44,18 @@ public class HomePage extends BasePage {
 
     public EditHomeContentPage goToEditPageContent() {
         log.info("Click Edit Page Content");
-        waitForWebElement(editPageContentButton).click();
+        expectWebElement(editPageContentButton).click();
         return new EditHomeContentPage(getDriver());
     }
 
     public EditHomeCodePage goToEditPageCode() {
         log.info("Click Edit Page Code");
-        waitForWebElement(editPageCodeButton).click();
+        expectWebElement(editPageCodeButton).click();
         return new EditHomeCodePage(getDriver());
     }
 
     public String getMainBodyContent() {
         log.info("Query homepage content");
-        return waitForWebElement(mainBodyContent).getText();
+        return expectWebElement(mainBodyContent).getText();
     }
 }

--- a/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
+++ b/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
@@ -48,7 +48,7 @@ public class DocumentsViewPage extends BasePage {
 
     public EditorPage clickDocumentLink(String path, String name) {
         String id = "gwt-debug-docLabel-" + path + name;
-        waitForWebElement(By.id(id)).click();
+        expectWebElement(By.id(id)).click();
         return new EditorPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
+++ b/functional-test/src/main/java/org/zanata/page/webtrans/DocumentsViewPage.java
@@ -48,7 +48,7 @@ public class DocumentsViewPage extends BasePage {
 
     public EditorPage clickDocumentLink(String path, String name) {
         String id = "gwt-debug-docLabel-" + path + name;
-        expectWebElement(By.id(id)).click();
+        readyElement(By.id(id)).click();
         return new EditorPage(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/webtrans/EditorPage.java
+++ b/functional-test/src/main/java/org/zanata/page/webtrans/EditorPage.java
@@ -39,6 +39,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Patrick Huang <a
  *         href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
@@ -88,9 +90,9 @@ public class EditorPage extends BasePage {
                         || input.findElements(glossaryTable).size() == 1;
             }
         });
-        waitForWebElement(glossarySearchInput).clear();
-        waitForWebElement(glossarySearchInput).sendKeys(term);
-        waitForWebElement(By.id("gwt-debug-glossarySearchButton")).click();
+        expectWebElement(glossarySearchInput).clear();
+        expectWebElement(glossarySearchInput).sendKeys(term);
+        expectWebElement(By.id("gwt-debug-glossarySearchButton")).click();
         return new EditorPage(getDriver());
     }
 
@@ -181,7 +183,7 @@ public class EditorPage extends BasePage {
     public EditorPage setSyntaxHighlighting(boolean option) {
         log.info("Set syntax highlight to {}", option);
         openConfigurationPanel();
-        WebElement highlight = waitForWebElement(By.id(EDITOR_SYNTAXHIGHLIGHT));
+        WebElement highlight = expectWebElement(By.id(EDITOR_SYNTAXHIGHLIGHT));
         if (highlight.isSelected() != option) {
             highlight.click();
         }
@@ -199,7 +201,7 @@ public class EditorPage extends BasePage {
             }
         });
         new Actions(getDriver())
-                .click(waitForWebElement(configurationPanel))
+                .click(expectWebElement(configurationPanel))
                 .perform();
         return waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
@@ -240,7 +242,7 @@ public class EditorPage extends BasePage {
     private String getContentAtRowIndex(final long rowIndex,
             final String idFormat,
             final Plurals plural) {
-        return waitForWebElement(By
+        return expectWebElement(By
                 .id(String.format(idFormat, rowIndex, plural.index())))
                 .getAttribute("value");
     }
@@ -259,7 +261,7 @@ public class EditorPage extends BasePage {
 
     private void setTargetContent(final long rowIndex, final String text,
             final String idFormat, final Plurals plural) {
-        WebElement we = waitForWebElement(By
+        WebElement we = expectWebElement(By
                 .id(String.format(idFormat, rowIndex, plural.index())));
         we.click();
         we.clear();
@@ -276,8 +278,8 @@ public class EditorPage extends BasePage {
     public EditorPage pasteIntoRowAtIndex(final long rowIndex,
                                           final String text) {
         log.info("Paste at {} the text {}", rowIndex, text);
-        WebElement we = waitForWebElement(By.id(String.format(TARGET_ID_FMT,
-                        rowIndex, Plurals.SourceSingular.index())));
+        WebElement we = expectWebElement(By.id(String.format(TARGET_ID_FMT,
+                rowIndex, Plurals.SourceSingular.index())));
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(text), null);
         we.click();
@@ -287,7 +289,7 @@ public class EditorPage extends BasePage {
 
     public EditorPage approveTranslationAtRow(int rowIndex) {
         log.info("Click Approve on row {}", rowIndex);
-        waitForWebElement(By
+        expectWebElement(By
                 .id(String.format(APPROVE_BUTTON_ID_FMT, rowIndex)))
                 .click();
         slightPause();
@@ -296,7 +298,7 @@ public class EditorPage extends BasePage {
 
     public EditorPage saveAsFuzzyAtRow(int rowIndex) {
         log.info("Click Fuzzy on row {}", rowIndex);
-        waitForWebElement(By
+        expectWebElement(By
                 .id(String.format(FUZZY_BUTTON_ID_FMT, rowIndex)))
                 .click();
         return new EditorPage(getDriver());
@@ -309,12 +311,12 @@ public class EditorPage extends BasePage {
 
     public String getStatistics() {
         log.info("Query statistics");
-        return waitForWebElement(By.id("gwt-debug-statistics-label")).getText();
+        return expectWebElement(By.id("gwt-debug-statistics-label")).getText();
     }
 
     public List<String> getMessageSources() {
         log.info("Query list of text flow sources");
-        return WebElementUtil.elementsToText(waitForWebElement(transUnitTable)
+        return WebElementUtil.elementsToText(expectWebElement(transUnitTable)
                 .findElements(By.className("gwt-HTML")));
     }
 
@@ -346,14 +348,12 @@ public class EditorPage extends BasePage {
     /**
      * Wait for a delayed validation error panel to display
      */
-    public void waitForValidationErrorsVisible() {
+    public void expectValidationErrorsVisible() {
         log.info("Wait for validation message panel displayed");
-        waitForAMoment().until(new Function<WebDriver, Boolean>() {
-            @Override
-            public Boolean apply(WebDriver driver) {
-                return isValidationMessageCurrentTargetVisible();
-            }
-        });
+        waitForPageSilence();
+        assertThat(isValidationMessageCurrentTargetVisible()).as(
+                "validation message panel displayed")
+                .isTrue();
     }
 
     /**
@@ -382,10 +382,10 @@ public class EditorPage extends BasePage {
      */
     public EditorPage openValidationOptions() {
         log.info("Click to open Validation options panel");
-        new Actions(getDriver()).click(waitForWebElement(
-                waitForElementExists(By.id("container")), validationOptions))
+        new Actions(getDriver()).click(expectWebElement(
+                expectElementExists(By.id("container")), validationOptions))
                 .perform();
-        waitForElementExists(validationOptionsView);
+        expectElementExists(validationOptionsView);
         return new EditorPage(getDriver());
     }
 
@@ -397,8 +397,8 @@ public class EditorPage extends BasePage {
      */
     public boolean isValidationOptionAvailable(Validations validation) {
         log.info("Query is validation option {} available", validation);
-        return waitForWebElement(By.xpath("//*[@title='" +
-                        getValidationTitle(validation) + "']"))
+        return expectWebElement(By.xpath("//*[@title='" +
+                getValidationTitle(validation) + "']"))
                 .findElement(By.tagName("input"))
                 .isEnabled();
     }
@@ -411,7 +411,8 @@ public class EditorPage extends BasePage {
      */
     public boolean isValidationOptionSelected(Validations validation) {
         log.info("Query is validation option {} selected", validation);
-        return waitForElementExists(waitForElementExists(By.xpath("//*[@title='" +
+        return expectElementExists(
+                expectElementExists(By.xpath("//*[@title='" +
                         getValidationTitle(validation) + "']")),
                 By.tagName("input")).isSelected();
     }
@@ -424,8 +425,8 @@ public class EditorPage extends BasePage {
      */
     public EditorPage clickValidationCheckbox(Validations validation) {
         log.info("Click validation checkbox {}", validation);
-        waitForWebElement(waitForElementExists(By.xpath("//*[@title='" +
-                getValidationTitle(validation) + "']")),
+        expectWebElement(expectElementExists(By.xpath("//*[@title='" +
+                        getValidationTitle(validation) + "']")),
                 By.tagName("input")).click();
         return new EditorPage(getDriver());
     }
@@ -455,19 +456,19 @@ public class EditorPage extends BasePage {
 
     public EditorPage inputFilterQuery(String query) {
         log.info("Enter filter query {}", query);
-        waitForWebElement(editorFilterField).clear();
-        waitForWebElement(editorFilterField).sendKeys(query + Keys.ENTER);
+        expectWebElement(editorFilterField).clear();
+        expectWebElement(editorFilterField).sendKeys(query + Keys.ENTER);
         return new EditorPage(getDriver());
     }
 
     public String getFilterQuery() {
         log.info("Query filter text");
-        return waitForWebElement(editorFilterField).getAttribute("value");
+        return expectWebElement(editorFilterField).getAttribute("value");
     }
 
     // Find the right side column for the selected row
     private WebElement getTranslationTargetColumn() {
-        return waitForWebElement(By.className("selected"))
+        return expectWebElement(By.className("selected"))
                 .findElements(By.className("transUnitCol"))
                 // Right column
                 .get(1);
@@ -475,13 +476,13 @@ public class EditorPage extends BasePage {
 
     // Find the validation messages / errors box
     private WebElement getTargetValidationBox() {
-        return waitForElementExists(getTranslationTargetColumn(), validationBox);
+        return expectElementExists(getTranslationTargetColumn(), validationBox);
     }
 
     // Click the History button for the selected row - row id must be known
     public EditorPage clickShowHistoryForRow(int row) {
         log.info("Click history button on row {}", row);
-        waitForWebElement(getTranslationTargetColumn(), By
+        expectWebElement(getTranslationTargetColumn(), By
                 .id("gwt-debug-target-" + row + "-history"))
                 .click();
         waitForAMoment().until(new Predicate<WebDriver>() {
@@ -543,7 +544,7 @@ public class EditorPage extends BasePage {
     public EditorPage clickCompareVersionsTab() {
         log.info("Click on Compare versions tab");
         getCompareTab().click();
-        waitForWebElement(getTranslationHistoryBox(), By.className("html-face"));
+        expectWebElement(getTranslationHistoryBox(), By.className("html-face"));
         return new EditorPage(getDriver());
     }
 
@@ -570,8 +571,8 @@ public class EditorPage extends BasePage {
     }
 
     private WebElement getTranslationHistoryBox() {
-        return waitForElementExists(
-                waitForElementExists(By.id("gwt-debug-transHistory")),
+        return expectElementExists(
+                expectElementExists(By.id("gwt-debug-transHistory")),
                 By.id("gwt-debug-transHistoryTabPanel"));
     }
 

--- a/functional-test/src/main/java/org/zanata/page/webtrans/EditorPage.java
+++ b/functional-test/src/main/java/org/zanata/page/webtrans/EditorPage.java
@@ -90,9 +90,9 @@ public class EditorPage extends BasePage {
                         || input.findElements(glossaryTable).size() == 1;
             }
         });
-        expectWebElement(glossarySearchInput).clear();
-        expectWebElement(glossarySearchInput).sendKeys(term);
-        expectWebElement(By.id("gwt-debug-glossarySearchButton")).click();
+        readyElement(glossarySearchInput).clear();
+        readyElement(glossarySearchInput).sendKeys(term);
+        readyElement(By.id("gwt-debug-glossarySearchButton")).click();
         return new EditorPage(getDriver());
     }
 
@@ -183,7 +183,7 @@ public class EditorPage extends BasePage {
     public EditorPage setSyntaxHighlighting(boolean option) {
         log.info("Set syntax highlight to {}", option);
         openConfigurationPanel();
-        WebElement highlight = expectWebElement(By.id(EDITOR_SYNTAXHIGHLIGHT));
+        WebElement highlight = readyElement(By.id(EDITOR_SYNTAXHIGHLIGHT));
         if (highlight.isSelected() != option) {
             highlight.click();
         }
@@ -201,7 +201,7 @@ public class EditorPage extends BasePage {
             }
         });
         new Actions(getDriver())
-                .click(expectWebElement(configurationPanel))
+                .click(readyElement(configurationPanel))
                 .perform();
         return waitForAMoment().until(new Function<WebDriver, Boolean>() {
             @Override
@@ -242,7 +242,7 @@ public class EditorPage extends BasePage {
     private String getContentAtRowIndex(final long rowIndex,
             final String idFormat,
             final Plurals plural) {
-        return expectWebElement(By
+        return readyElement(By
                 .id(String.format(idFormat, rowIndex, plural.index())))
                 .getAttribute("value");
     }
@@ -261,7 +261,7 @@ public class EditorPage extends BasePage {
 
     private void setTargetContent(final long rowIndex, final String text,
             final String idFormat, final Plurals plural) {
-        WebElement we = expectWebElement(By
+        WebElement we = readyElement(By
                 .id(String.format(idFormat, rowIndex, plural.index())));
         we.click();
         we.clear();
@@ -278,7 +278,7 @@ public class EditorPage extends BasePage {
     public EditorPage pasteIntoRowAtIndex(final long rowIndex,
                                           final String text) {
         log.info("Paste at {} the text {}", rowIndex, text);
-        WebElement we = expectWebElement(By.id(String.format(TARGET_ID_FMT,
+        WebElement we = readyElement(By.id(String.format(TARGET_ID_FMT,
                 rowIndex, Plurals.SourceSingular.index())));
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(text), null);
@@ -289,7 +289,7 @@ public class EditorPage extends BasePage {
 
     public EditorPage approveTranslationAtRow(int rowIndex) {
         log.info("Click Approve on row {}", rowIndex);
-        expectWebElement(By
+        readyElement(By
                 .id(String.format(APPROVE_BUTTON_ID_FMT, rowIndex)))
                 .click();
         slightPause();
@@ -298,7 +298,7 @@ public class EditorPage extends BasePage {
 
     public EditorPage saveAsFuzzyAtRow(int rowIndex) {
         log.info("Click Fuzzy on row {}", rowIndex);
-        expectWebElement(By
+        readyElement(By
                 .id(String.format(FUZZY_BUTTON_ID_FMT, rowIndex)))
                 .click();
         return new EditorPage(getDriver());
@@ -311,12 +311,12 @@ public class EditorPage extends BasePage {
 
     public String getStatistics() {
         log.info("Query statistics");
-        return expectWebElement(By.id("gwt-debug-statistics-label")).getText();
+        return readyElement(By.id("gwt-debug-statistics-label")).getText();
     }
 
     public List<String> getMessageSources() {
         log.info("Query list of text flow sources");
-        return WebElementUtil.elementsToText(expectWebElement(transUnitTable)
+        return WebElementUtil.elementsToText(readyElement(transUnitTable)
                 .findElements(By.className("gwt-HTML")));
     }
 
@@ -382,10 +382,10 @@ public class EditorPage extends BasePage {
      */
     public EditorPage openValidationOptions() {
         log.info("Click to open Validation options panel");
-        new Actions(getDriver()).click(expectWebElement(
-                expectElementExists(By.id("container")), validationOptions))
+        new Actions(getDriver()).click(readyElement(
+                existingElement(By.id("container")), validationOptions))
                 .perform();
-        expectElementExists(validationOptionsView);
+        existingElement(validationOptionsView);
         return new EditorPage(getDriver());
     }
 
@@ -397,7 +397,7 @@ public class EditorPage extends BasePage {
      */
     public boolean isValidationOptionAvailable(Validations validation) {
         log.info("Query is validation option {} available", validation);
-        return expectWebElement(By.xpath("//*[@title='" +
+        return readyElement(By.xpath("//*[@title='" +
                 getValidationTitle(validation) + "']"))
                 .findElement(By.tagName("input"))
                 .isEnabled();
@@ -411,8 +411,8 @@ public class EditorPage extends BasePage {
      */
     public boolean isValidationOptionSelected(Validations validation) {
         log.info("Query is validation option {} selected", validation);
-        return expectElementExists(
-                expectElementExists(By.xpath("//*[@title='" +
+        return existingElement(
+                existingElement(By.xpath("//*[@title='" +
                         getValidationTitle(validation) + "']")),
                 By.tagName("input")).isSelected();
     }
@@ -425,7 +425,7 @@ public class EditorPage extends BasePage {
      */
     public EditorPage clickValidationCheckbox(Validations validation) {
         log.info("Click validation checkbox {}", validation);
-        expectWebElement(expectElementExists(By.xpath("//*[@title='" +
+        readyElement(existingElement(By.xpath("//*[@title='" +
                         getValidationTitle(validation) + "']")),
                 By.tagName("input")).click();
         return new EditorPage(getDriver());
@@ -456,19 +456,19 @@ public class EditorPage extends BasePage {
 
     public EditorPage inputFilterQuery(String query) {
         log.info("Enter filter query {}", query);
-        expectWebElement(editorFilterField).clear();
-        expectWebElement(editorFilterField).sendKeys(query + Keys.ENTER);
+        readyElement(editorFilterField).clear();
+        readyElement(editorFilterField).sendKeys(query + Keys.ENTER);
         return new EditorPage(getDriver());
     }
 
     public String getFilterQuery() {
         log.info("Query filter text");
-        return expectWebElement(editorFilterField).getAttribute("value");
+        return readyElement(editorFilterField).getAttribute("value");
     }
 
     // Find the right side column for the selected row
     private WebElement getTranslationTargetColumn() {
-        return expectWebElement(By.className("selected"))
+        return readyElement(By.className("selected"))
                 .findElements(By.className("transUnitCol"))
                 // Right column
                 .get(1);
@@ -476,13 +476,13 @@ public class EditorPage extends BasePage {
 
     // Find the validation messages / errors box
     private WebElement getTargetValidationBox() {
-        return expectElementExists(getTranslationTargetColumn(), validationBox);
+        return existingElement(getTranslationTargetColumn(), validationBox);
     }
 
     // Click the History button for the selected row - row id must be known
     public EditorPage clickShowHistoryForRow(int row) {
         log.info("Click history button on row {}", row);
-        expectWebElement(getTranslationTargetColumn(), By
+        readyElement(getTranslationTargetColumn(), By
                 .id("gwt-debug-target-" + row + "-history"))
                 .click();
         waitForAMoment().until(new Predicate<WebDriver>() {
@@ -544,7 +544,7 @@ public class EditorPage extends BasePage {
     public EditorPage clickCompareVersionsTab() {
         log.info("Click on Compare versions tab");
         getCompareTab().click();
-        expectWebElement(getTranslationHistoryBox(), By.className("html-face"));
+        readyElement(getTranslationHistoryBox(), By.className("html-face"));
         return new EditorPage(getDriver());
     }
 
@@ -571,8 +571,8 @@ public class EditorPage extends BasePage {
     }
 
     private WebElement getTranslationHistoryBox() {
-        return expectElementExists(
-                expectElementExists(By.id("gwt-debug-transHistory")),
+        return existingElement(
+                existingElement(By.id("gwt-debug-transHistory")),
                 By.id("gwt-debug-transHistoryTabPanel"));
     }
 

--- a/functional-test/src/main/java/org/zanata/util/TestFileGenerator.java
+++ b/functional-test/src/main/java/org/zanata/util/TestFileGenerator.java
@@ -39,6 +39,7 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.google.common.base.Preconditions;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.fedorahosted.openprops.Properties;
 import com.google.common.base.Throwables;
@@ -50,6 +51,7 @@ import lombok.Setter;
  * @author Damian Jansen <a
  *         href="mailto:djansen@redhat.com">djansen@redhat.com</a>
  */
+@Slf4j
 public class TestFileGenerator {
     // Length is maximum filename length - 4 (.xxx) - 19 (for tmp file
     // randomness)
@@ -245,4 +247,5 @@ public class TestFileGenerator {
         Preconditions.checkArgument(testFile.exists(), "%s not found", testFile);
         return testFile;
     }
+
 }

--- a/functional-test/src/main/java/org/zanata/util/WebElementUtil.java
+++ b/functional-test/src/main/java/org/zanata/util/WebElementUtil.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -296,7 +297,14 @@ public class WebElementUtil {
 
     public static void searchAutocomplete(WebDriver driver, String id,
             String query) {
-        driver.findElement(By.id(id + "-autocomplete__input")).sendKeys(query);
+        final String locator = id + "-autocomplete__input";
+        waitForAMoment(driver).until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return input.findElement(By.id(locator)).isDisplayed();
+            }
+        });
+        driver.findElement(By.id(locator)).sendKeys(query);
     }
 
     public static List<WebElement> getSearchAutocompleteResults(

--- a/functional-test/src/main/java/org/zanata/workflow/AbstractWebWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/AbstractWebWorkFlow.java
@@ -43,7 +43,7 @@ public class AbstractWebWorkFlow {
             @Override
             public boolean apply(WebDriver input) {
                 driver.get(hostUrl);
-                return new HomePage(driver).isValid();
+                return new HomePage(driver).isPageValid();
             }
         });
         return new HomePage(driver);

--- a/functional-test/src/main/java/org/zanata/workflow/LanguageWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/LanguageWorkFlow.java
@@ -37,7 +37,7 @@ public class LanguageWorkFlow extends AbstractWebWorkFlow {
             log.warn("admin has already joined the language [{}]", localeId);
             return teamMemberPage;
         }
-        return teamMemberPage.joinLanguageTeam();
+        return teamMemberPage.clickMoreActions().joinLanguageTeam();
     }
 
     public ManageLanguagePage addLanguage(String localeId) {

--- a/functional-test/src/main/java/org/zanata/workflow/ProjectWorkFlow.java
+++ b/functional-test/src/main/java/org/zanata/workflow/ProjectWorkFlow.java
@@ -161,7 +161,7 @@ public class ProjectWorkFlow extends AbstractWebWorkFlow {
                 .gotoSettingsPermissionsTab()
                 .enterSearchMaintainer(username)
                 .selectSearchMaintainer(username);
-        projectPermissionsTab.waitForMaintainersContains(username);
+        projectPermissionsTab.expectMaintainersContains(username);
         return new ProjectPermissionsTab(driver);
     }
 
@@ -175,7 +175,7 @@ public class ProjectWorkFlow extends AbstractWebWorkFlow {
                         .gotoSettingsPermissionsTab();
 
         projectPermissionsTab.clickRemoveOn(username)
-                .waitForMaintainersNotContains(username);
+                .expectMaintainersNotContains(username);
 
         return new ProjectPermissionsTab(driver);
     }

--- a/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
@@ -89,7 +89,7 @@ public class ProfileTest extends ZanataTestCase {
 
         dashboardClientTab.waitForPageSilence();
         dashboardClientTab = dashboardClientTab.pressApiKeyGenerateButton();
-        dashboardClientTab.waitForApiKeyChanged(currentApiKey);
+        dashboardClientTab.expectApiKeyChanged(currentApiKey);
 
         assertThat(dashboardClientTab.getApiKey()).isNotEqualTo(currentApiKey)
                 .as("The user's api key is different");
@@ -114,7 +114,7 @@ public class ProfileTest extends ZanataTestCase {
                 .enterName("Tranny")
                 .clickUpdateProfileButton();
 
-        dashboardProfileTab.waitForUsernameChanged("translator");
+        dashboardProfileTab.expectUsernameChanged("translator");
 
         assertThat(dashboardProfileTab.getUserFullName()).isEqualTo("Tranny")
                 .as("The user's name has been changed");

--- a/functional-test/src/test/java/org/zanata/feature/administration/AutoRoleAssignmentTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/administration/AutoRoleAssignmentTest.java
@@ -51,6 +51,7 @@ public class AutoRoleAssignmentTest extends ZanataTestCase {
                 .signIn("admin", "admin")
                 .goToAdministration()
                 .goToManageRoleAssignments()
+                .clickMoreActions()
                 .clickCreateNew()
                 .enterIdentityPattern(".+ransla.+")
                 .selectRole("admin")

--- a/functional-test/src/test/java/org/zanata/feature/administration/EditTranslationMemoryTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/administration/EditTranslationMemoryTest.java
@@ -138,7 +138,7 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .enterImportFileName(importFile.getAbsolutePath())
                 .clickUploadButtonAndAcknowledge();
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(importTMId, "1"))
+        assertThat(tmMemoryPage.getNumberOfEntries(importTMId))
                 .isEqualTo("1")
                 .as("The Translation Memory has one entry");
     }
@@ -161,7 +161,7 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
 
         tmMemoryPage = tmMemoryPage.dismissError();
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(rejectTMId, "0"))
+        assertThat(tmMemoryPage.getNumberOfEntries(rejectTMId))
                 .isEqualTo("0")
                 .as("No change is recorded");
     }
@@ -226,14 +226,14 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .enterImportFileName(importFile.getAbsolutePath())
                 .clickUploadButtonAndAcknowledge();
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(clearTMId, "1"))
+        assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
                 .isEqualTo("1")
                 .as("The TM has one item");
 
         tmMemoryPage = tmMemoryPage.clickOptions(clearTMId)
                 .clickClearTMAndAccept(clearTMId);
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(clearTMId, "0"))
+        assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
                 .isEqualTo("0")
                 .as("The translation memory entries is empty");
     }
@@ -253,14 +253,14 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .enterImportFileName(importFile.getAbsolutePath())
                 .clickUploadButtonAndAcknowledge();
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(clearTMId, "1"))
+        assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
                 .isEqualTo("1")
                 .as("The TM has one item");
 
         tmMemoryPage = tmMemoryPage.clickOptions(clearTMId)
                 .clickClearTMAndCancel(clearTMId);
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(clearTMId, "1"))
+        assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
                 .isEqualTo("1")
                 .as("The translation memory entries count is the same");
     }
@@ -282,7 +282,7 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .enterImportFileName(importFile.getAbsolutePath())
                 .clickUploadButtonAndAcknowledge();
 
-        assertThat(tmMemoryPage.waitForExpectedNumberOfEntries(forceClear, "1"))
+        assertThat(tmMemoryPage.getNumberOfEntries(forceClear))
                 .isEqualTo("1")
                 .as("The TM has one item");
         assertThat(tmMemoryPage.clickOptions(forceClear).canDelete(forceClear))
@@ -290,7 +290,7 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .as("The item cannot yet be deleted");
 
         tmMemoryPage = tmMemoryPage.clickClearTMAndAccept(forceClear);
-        tmMemoryPage.waitForExpectedNumberOfEntries(forceClear, "0");
+        tmMemoryPage.getNumberOfEntries(forceClear);
 
         assertThat(tmMemoryPage.clickOptions(forceClear).canDelete(forceClear))
                 .isTrue()

--- a/functional-test/src/test/java/org/zanata/feature/administration/ManageSearchTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/administration/ManageSearchTest.java
@@ -80,7 +80,7 @@ public class ManageSearchTest extends ZanataTestCase {
 
         manageSearchPage = manageSearchPage
                 .performSelectedActions()
-                .waitForActionsToFinish();
+                .expectActionsToFinish();
 
         assertThat(manageSearchPage.completedIsDisplayed())
                 .as("Completed is displayed");

--- a/functional-test/src/test/java/org/zanata/feature/document/FileTypeUploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/FileTypeUploadTest.java
@@ -158,7 +158,7 @@ public class FileTypeUploadTest extends ZanataTestCase {
                 .clickUploadDone()
                 .gotoDocumentTab();
 
-        assertThat(versionDocumentsPage.waitForSourceDocsContains(testFileName))
+        assertThat(versionDocumentsPage.expectSourceDocsContains(testFileName))
                 .as("Document shows in table");
     }
 

--- a/functional-test/src/test/java/org/zanata/feature/document/MultiFileUploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/MultiFileUploadTest.java
@@ -115,7 +115,7 @@ public class MultiFileUploadTest extends ZanataTestCase {
 
         VersionDocumentsPage versionDocumentsPage = versionDocumentsTab
                 .gotoDocumentTab()
-                .waitForSourceDocsContains(testFileName);
+                .expectSourceDocsContains(testFileName);
 
         assertThat(versionDocumentsPage.getSourceDocumentNames())
                 .contains(firstFile.getName())

--- a/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
@@ -121,7 +121,7 @@ public class UploadTest extends ZanataTestCase {
                 .as("The contents of the file were also uploaded");
         VersionDocumentsPage versionDocumentsPage = versionDocumentsTab
                 .gotoDocumentTab()
-                .waitForSourceDocsContains(testFileName);
+                .expectSourceDocsContains(testFileName);
 
         assertThat(versionDocumentsPage.sourceDocumentsContains(testFileName))
                 .isTrue()
@@ -232,7 +232,7 @@ public class UploadTest extends ZanataTestCase {
 
         VersionDocumentsPage versionDocumentsPage = versionDocumentsTab
                 .gotoDocumentTab()
-                .waitForSourceDocsContains(longFile.getName());
+                .expectSourceDocsContains(longFile.getName());
 
         assertThat(versionDocumentsPage.sourceDocumentsContains(longFile.getName()))
                 .isTrue()
@@ -261,7 +261,7 @@ public class UploadTest extends ZanataTestCase {
 
         VersionDocumentsPage versionDocumentsPage = versionDocumentsTab
                 .gotoDocumentTab()
-                .waitForSourceDocsContains(emptyFile.getName());
+                .expectSourceDocsContains(emptyFile.getName());
 
         assertThat(versionDocumentsPage.sourceDocumentsContains(emptyFile.getName()))
                 .isTrue()

--- a/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
@@ -108,10 +108,6 @@ public class UploadTest extends ZanataTestCase {
                 .submitUpload()
                 .clickUploadDone();
 
-        assertThat(new File(documentStorageDirectory).list().length)
-                .isEqualTo(1)
-                .as("There is only one uploaded source file");
-
         File newlyCreatedFile = new File(documentStorageDirectory,
                 testFileGenerator
                         .getFirstFileNameInDirectory(documentStorageDirectory));

--- a/functional-test/src/test/java/org/zanata/feature/editor/EditorFilterMessagesTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/editor/EditorFilterMessagesTest.java
@@ -77,13 +77,8 @@ public class EditorFilterMessagesTest extends ZanataTestCase {
                 "hello world", "greetings", "hey");
 
         final EditorPage page = editorPage.inputFilterQuery("resource-id:res2");
-
-        editorPage.waitFor(new Callable<Iterable<? extends String>>() {
-            @Override
-            public List<String> call() throws Exception {
-                return page.getMessageSources();
-            }
-        }, Matchers.contains("greetings"));
+        page.waitForPageSilence();
+        assertThat(page.getMessageSources()).contains("greetings");
     }
 
     @Feature(summary = "The user may save the filter url for later use",

--- a/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
@@ -81,7 +81,7 @@ public class AddLanguageTest extends ZanataTestCase {
                 .clickMoreActions()
                 .addNewLanguage()
                 .enterSearchLanguage(language)
-                .waitForPluralsWarning()
+                .expectPluralsWarning()
                 .saveLanguage();
 
         assertThat(manageLanguagePage.getLanguageLocales())
@@ -98,7 +98,7 @@ public class AddLanguageTest extends ZanataTestCase {
                 .goToProject("about fedora")
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab()
-                .waitForLocaleListVisible()
+                .expectLocaleListVisible()
                 .getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
@@ -126,7 +126,7 @@ public class AddLanguageTest extends ZanataTestCase {
                 .clickMoreActions()
                 .addNewLanguage()
                 .enterSearchLanguage(language)
-                .waitForPluralsWarning()
+                .expectPluralsWarning()
                 .disableLanguageByDefault()
                 .saveLanguage();
 
@@ -142,7 +142,7 @@ public class AddLanguageTest extends ZanataTestCase {
                 .goToProject("about fedora")
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab()
-                .waitForLocaleListVisible()
+                .expectLocaleListVisible()
                 .getEnabledLocaleList();
 
         assertThat(enabledLocaleList)

--- a/functional-test/src/test/java/org/zanata/feature/misc/ObsoleteTextTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/misc/ObsoleteTextTest.java
@@ -37,10 +37,11 @@ import org.zanata.util.ZanataRestCaller;
 import org.zanata.workflow.BasicWorkFlow;
 import org.zanata.workflow.LoginWorkFlow;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.zanata.util.ZanataRestCaller.buildSourceResource;
 import static org.zanata.util.ZanataRestCaller.buildTextFlow;
 import static org.zanata.workflow.BasicWorkFlow.PROJECT_VERSION_TEMPLATE;
+
 
 /**
  * TCMS test case <a
@@ -125,19 +126,14 @@ public class ObsoleteTextTest extends ZanataTestCase {
                         .translateTargetAtRowIndex(2, "translated")
                         .approveTranslationAtRow(2);
 
-        editorPageFinal.waitFor(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return editorPageFinal.getStatistics();
-            }
-        }, Matchers.containsString("100%"));
+        editorPageFinal.waitForPageSilence();
+        assertThat(editorPageFinal.getStatistics()).contains("100%");
 
         VersionLanguagesPage versionPage =
                 new BasicWorkFlow().goToPage(String.format(
                         PROJECT_VERSION_TEMPLATE, "obsolete-test", "master"),
                         VersionLanguagesPage.class);
-        assertThat(versionPage.getStatisticsForLocale("fr"),
-                Matchers.equalTo("100.0%"));
+        assertThat(versionPage.getStatisticsForLocale("fr")).isEqualTo("100.0%");
     }
 
     private static EditorPage openEditor() {

--- a/functional-test/src/test/java/org/zanata/feature/project/EditPermissionsTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/EditPermissionsTest.java
@@ -144,7 +144,7 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .enterSearchMaintainer("glossarist")
                 .selectSearchMaintainer("glossarist");
 
-        projectPermissionsTab.waitForMaintainersContains("glossarist");
+        projectPermissionsTab.expectMaintainersContains("glossarist");
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
                 .contains("glossarist")

--- a/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
@@ -72,7 +72,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .setActiveFilterEnabled(true)
                 .setReadOnlyFilterEnabled(false)
                 .setObsoleteFilterEnabled(false)
-                .waitForProjectVisibility("about fedora", false);
+                .expectProjectNotVisible("about fedora");
 
         assertThat(projectsPage.getProjectNamesOnCurrentPage())
                 .doesNotContain("about fedora")
@@ -81,7 +81,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
         projectsPage = projectsPage.setActiveFilterEnabled(false)
                 .setReadOnlyFilterEnabled(true)
                 .setObsoleteFilterEnabled(false)
-                .waitForProjectVisibility("about fedora", true);
+                .expectProjectVisible("about fedora");
 
         assertThat(projectsPage.getProjectNamesOnCurrentPage())
                 .contains("about fedora")
@@ -102,7 +102,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .setActiveFilterEnabled(false)
                 .setReadOnlyFilterEnabled(true)
                 .setObsoleteFilterEnabled(false)
-                .waitForProjectVisibility("about fedora", true)
+                .expectProjectVisible("about fedora")
                 .getProjectNamesOnCurrentPage())
                 .contains("about fedora")
                 .as("The project is locked");
@@ -118,7 +118,7 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .setActiveFilterEnabled(true)
                 .setReadOnlyFilterEnabled(false)
                 .setObsoleteFilterEnabled(false)
-                .waitForProjectVisibility("about fedora", true);
+                .expectProjectVisible("about fedora");
 
         assertThat(projectsPage.getProjectNamesOnCurrentPage())
                 .contains("about fedora")

--- a/functional-test/src/test/java/org/zanata/feature/project/EditWebHooksTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/EditWebHooksTest.java
@@ -66,7 +66,7 @@ public class EditWebHooksTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsWebHooksTab()
                 .enterUrl(testUrl)
-                .waitForWebHooksContains(testUrl);
+                .expectWebHooksContains(testUrl);
 
         assertThat(projectWebHooksTab.getWebHooks())
                 .contains(testUrl)
@@ -83,9 +83,9 @@ public class EditWebHooksTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsWebHooksTab()
                 .enterUrl(testUrl)
-                .waitForWebHooksContains(testUrl)
+                .expectWebHooksContains(testUrl)
                 .clickRemoveOn(testUrl)
-                .waitForWebHooksNotContains(testUrl);
+                .expectWebHooksNotContains(testUrl);
 
         assertThat(projectWebHooksTab.getWebHooks())
                 .doesNotContain(testUrl)

--- a/functional-test/src/test/java/org/zanata/feature/project/SetProjectVisibilityTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/project/SetProjectVisibilityTest.java
@@ -45,7 +45,7 @@ public class SetProjectVisibilityTest extends ZanataTestCase {
                 .setReadOnlyFilterEnabled(false)
                 .setObsoleteFilterEnabled(true);
 
-        projectsPage.waitForProjectVisibility("about fedora", true);
+        projectsPage.expectProjectVisible("about fedora");
 
         assertThat(projectsPage.getProjectNamesOnCurrentPage())
                 .contains("about fedora")

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
@@ -122,7 +122,7 @@ public class CreateProjectVersionTest extends ZanataTestCase {
 
         createVersionPage = createVersionPage.inputVersionId("_C_");
         createVersionPage.defocus(createVersionPage.projectVersionID);
-        createVersionPage = createVersionPage.waitForNumErrors(1);
+        createVersionPage = createVersionPage.expectNumErrors(1);
 
         assertThat(createVersionPage.expectError(
                     CreateVersionPage.VALIDATION_ERROR))
@@ -131,7 +131,7 @@ public class CreateProjectVersionTest extends ZanataTestCase {
 
         createVersionPage = createVersionPage.inputVersionId("A-B_C");
         createVersionPage.defocus(createVersionPage.projectVersionID);
-        createVersionPage = createVersionPage.waitForNumErrors(0);
+        createVersionPage = createVersionPage.expectNumErrors(0);
 
         assertThat(createVersionPage.getErrors())
                 .doesNotContain(CreateVersionPage.VALIDATION_ERROR)
@@ -154,7 +154,7 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         ProjectVersionsPage projectVersionsPage = new ProjectWorkFlow()
                 .createNewProjectVersion(projectName, "alpha")
                 .clickProjectLink(projectName);
-        projectVersionsPage.waitForDisplayedVersions(1);
+        projectVersionsPage.expectDisplayedVersions(1);
 
         assertThat(projectVersionsPage.getNumberOfDisplayedVersions())
                 .isEqualTo(1)
@@ -163,7 +163,7 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         projectVersionsPage = new ProjectWorkFlow()
                 .createNewProjectVersion("version nums", "bravo")
                 .clickProjectLink(projectName);
-        projectVersionsPage.waitForDisplayedVersions(2);
+        projectVersionsPage.expectDisplayedVersions(2);
 
         assertThat(projectVersionsPage.getNumberOfDisplayedVersions())
                 .isEqualTo(2)

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
@@ -39,6 +39,8 @@ import org.zanata.util.SampleProjectRule;
 import org.zanata.workflow.LoginWorkFlow;
 import org.zanata.workflow.ProjectWorkFlow;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -88,7 +90,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
                 .inputVersionId("");
         createVersionPage.defocus(createVersionPage.projectVersionID);
 
-        assertThat(createVersionPage.getErrors())
+        List<String> errors = createVersionPage.getErrors();
+        assertThat(errors)
                 .contains("value is required")
                 .as("The empty value is rejected");
     }

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
@@ -22,7 +22,6 @@
 package org.zanata.feature.projectversion;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -75,7 +74,7 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab()
                 .clickInheritCheckbox()
-                .waitForLocaleListVisible();
+                .expectLocaleListVisible();
 
         List<String> enabledLocaleList = versionLanguagesTab
                 .getEnabledLocaleList();
@@ -91,7 +90,7 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
         versionLanguagesTab.expectNotification("Language \"English " +
                 "(United States)\" has been added to version.");
         versionLanguagesTab = versionLanguagesTab
-                .waitForLanguagesContains("English (United States)[en-US]");
+                .expectLanguagesContains("English (United States)[en-US]");
 
         versionLanguagesTab = versionLanguagesTab
                 .enterSearchLanguage("fr")
@@ -99,7 +98,7 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
         versionLanguagesTab.expectNotification("Language \"French\" has " +
                 "been added to version.");
         versionLanguagesTab = versionLanguagesTab
-                .waitForLanguagesContains("French[fr]");
+                .expectLanguagesContains("French[fr]");
 
         enabledLocaleList = versionLanguagesTab.getEnabledLocaleList();
 

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
@@ -116,7 +116,7 @@ public class EditVersionValidationsTest extends ZanataTestCase {
                 .as("The text in the translation target is blank");
 
         editorPage.pasteIntoRowAtIndex(0, "\t").saveAsFuzzyAtRow(0);
-        editorPage.waitForValidationErrorsVisible();
+        editorPage.expectValidationErrorsVisible();
 
         assertThat(editorPage.getValidationMessageCurrentTarget())
                 .isEqualTo("Warning: none, Errors: 1")
@@ -225,7 +225,7 @@ public class EditVersionValidationsTest extends ZanataTestCase {
         editorPage = editorPage
                 .openValidationOptions()
                 .clickValidationCheckbox(EditorPage.Validations.TABS);
-        editorPage.waitForValidationErrorsVisible();
+        editorPage.expectValidationErrorsVisible();
 
         assertThat(editorPage.isValidationMessageCurrentTargetVisible())
                 .isTrue()

--- a/functional-test/src/test/java/org/zanata/feature/projectversion/VersionFilteringTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/projectversion/VersionFilteringTest.java
@@ -68,26 +68,26 @@ public class VersionFilteringTest extends ZanataTestCase {
 
         ProjectVersionsPage projectVersionsPage = new ProjectWorkFlow()
                 .goToProjectByName(projectName)
-                .waitForDisplayedVersions(2);
+                .expectDisplayedVersions(2);
 
         assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
 
         projectVersionsPage = projectVersionsPage
                 .clickSearchIcon()
                 .enterVersionSearch("alpha")
-                .waitForDisplayedVersions(1);
+                .expectDisplayedVersions(1);
 
         assertVersions(projectVersionsPage, 1, new String[]{"alpha"});
 
         projectVersionsPage = projectVersionsPage
                 .clearVersionSearch()
-                .waitForDisplayedVersions(2);
+                .expectDisplayedVersions(2);
 
         assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
 
         projectVersionsPage = projectVersionsPage
                 .enterVersionSearch("bravo")
-                .waitForDisplayedVersions(1);
+                .expectDisplayedVersions(1);
 
         assertVersions(projectVersionsPage, 1, new String[]{"bravo"});
 
@@ -95,14 +95,14 @@ public class VersionFilteringTest extends ZanataTestCase {
         projectVersionsPage = projectVersionsPage
                 .clearVersionSearch()
                 .enterVersionSearch("charlie")
-                .waitForDisplayedVersions(0);
+                .expectDisplayedVersions(0);
 
         assertVersions(projectVersionsPage, 0, new String[]{});
 
         projectVersionsPage.waitForPageSilence();
         projectVersionsPage = projectVersionsPage
                 .clearVersionSearch()
-                .waitForDisplayedVersions(2);
+                .expectDisplayedVersions(2);
 
         assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
     }

--- a/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
@@ -53,7 +53,7 @@ public class ProjectSearchTest extends ZanataTestCase {
         BasePage basePage = new BasicWorkFlow()
                 .goToHome()
                 .enterSearch("about")
-                .waitForSearchListContains("about fedora");
+                .expectSearchListContains("about fedora");
 
         assertThat(basePage.getProjectSearchAutocompleteItems())
                 .contains("about fedora")
@@ -75,7 +75,7 @@ public class ProjectSearchTest extends ZanataTestCase {
         ProjectsPage projectsPage = new BasicWorkFlow()
                 .goToHome()
                 .enterSearch("arodef")
-                .waitForSearchListContains("Search Zanata for 'arodef'")
+                .expectSearchListContains("Search Zanata for 'arodef'")
                 .submitSearch();
 
         assertThat(projectsPage.getProjectNamesOnCurrentPage().isEmpty())
@@ -98,7 +98,7 @@ public class ProjectSearchTest extends ZanataTestCase {
         BasePage basePage = new BasicWorkFlow()
                 .goToHome()
                 .enterSearch("about")
-                .waitForSearchListContains("Search Zanata for 'about'");
+                .expectSearchListContains("Search Zanata for 'about'");
 
         assertThat(basePage.getProjectSearchAutocompleteItems())
                 .doesNotContain("About Fedora")

--- a/zanata-war/src/main/webapp/admin/rolemanager.xhtml
+++ b/zanata-war/src/main/webapp/admin/rolemanager.xhtml
@@ -27,11 +27,11 @@
         <div class="panel l--push-top-1">
           <div class="panel__header">
             <div class="panel__header__actions">
-              <div
+              <div id="rolemanage-more-actions"
                 class="dropdown dropdown--header dropdown--small dropdown--right dropdown--inline js-dropdown">
-                <a class="dropdown__toggle js-dropdown__toggle" href="#"
-                  title="#{msgs['jsf.tooltip.MoreActions']}"><i
-                  class="i i--ellipsis"></i>
+                <a  class="dropdown__toggle js-dropdown__toggle" href="#"
+                  title="#{msgs['jsf.tooltip.MoreActions']}">
+                  <i class="i i--ellipsis"></i>
                 </a>
                 <ul class="dropdown__content js-dropdown__content"
                   role="content"

--- a/zanata-war/src/main/webapp/admin/rolerules.xhtml
+++ b/zanata-war/src/main/webapp/admin/rolerules.xhtml
@@ -33,7 +33,7 @@
         <div class="panel l--push-top-1">
           <div class="panel__header">
             <div class="panel__header__actions">
-              <div
+              <div id="roleassign-more-actions"
                 class="dropdown dropdown--header dropdown--small dropdown--right dropdown--inline js-dropdown">
                 <a class="dropdown__toggle js-dropdown__toggle" href="#"
                   title="#{msgs['jsf.tooltip.MoreActions']}"><i


### PR DESCRIPTION
We will have to add some explicit waits (before/around checks) to make this work, but the end result should be a lot more robust.

- [x] Waiting for https://github.com/zanata/zanata-server/pull/779
- [x] Waiting for https://github.com/zanata/zanata-server/pull/782