### PR TITLE
Skip checking of critical errors (too slow due to implicit wait)

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/CorePage.java
+++ b/functional-test/src/main/java/org/zanata/page/CorePage.java
@@ -53,7 +53,9 @@ public class CorePage extends AbstractPage {
 
     public CorePage(WebDriver driver) {
         super(driver);
-        assertNoCriticalErrors();
+        // TODO put this back when implicit waits have been removed
+        // With implicit waits, this adds 3 seconds to almost every page load
+//        assertNoCriticalErrors();
     }
 
     public String getTitle() {


### PR DESCRIPTION
See https://github.com/zanata/zanata-server/commit/25bf1e2dcb5bdc827ad23c89ed04368f7c3a024c#commitcomment-10769838

After this is merged:
- [ ] create a pull request for the branch `check-critical-errors` (to put the check back in, but without implicit wait).
- [ ] re-test #767 