### PR TITLE
Wait for page loaders to be finished before proceeding

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -261,7 +261,8 @@ public class AbstractPage {
                 if (outstanding == null) {
                     if (log.isWarnEnabled()) {
                         String url = getDriver().getCurrentUrl();
-                        String pageSource = ShortString.shorten(getDriver().getPageSource(), 2000);
+                        String pageSource = ShortString.shorten(
+                                getDriver().getPageSource(), 2000);
                         log.warn("XMLHttpRequest.active is null. Is AjaxCounterBean missing? URL: {}\nPartial page source follows:\n{}", url, pageSource);
                     }
                     return true;
@@ -275,11 +276,34 @@ public class AbstractPage {
                 }
                 int expected = getExpectedBackgroundRequests();
                 if (outstanding < expected) {
-                    log.warn("Expected at least {} background requests, but actual count is {}", expected, outstanding, new Throwable());
+                    log.warn(
+                            "Expected at least {} background requests, but actual count is {}",
+                            expected, outstanding, new Throwable());
                 } else {
                     log.debug("Waiting: outstanding = {}, expected = {}", outstanding, expected);
                 }
                 return outstanding <= expected;
+            }
+        });
+        waitForLoaders();
+    }
+
+    /**
+     * Wait for all loaders to be inactive
+     */
+    private void waitForLoaders() {
+        waitForAMoment().withMessage("Loader indicator").until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                List<WebElement> loaders = driver
+                        .findElements(By.className("js-loader"));
+                for (WebElement loader : loaders) {
+                    if (loader.getAttribute("class").contains("is-active")) {
+                        log.info("Wait for loader finished");
+                        return false;
+                    }
+                }
+                return true;
             }
         });
     }

--- a/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
@@ -85,8 +85,9 @@ public class ProfileTest extends ZanataTestCase {
                 .goToSettingsTab()
                 .goToSettingsClientTab();
         String currentApiKey = dashboardClientTab.getApiKey();
-        dashboardClientTab = dashboardClientTab.pressApiKeyGenerateButton();
 
+        dashboardClientTab.waitForPageSilence();
+        dashboardClientTab = dashboardClientTab.pressApiKeyGenerateButton();
         dashboardClientTab.waitForApiKeyChanged(currentApiKey);
 
         assertThat(dashboardClientTab.getApiKey()).isNotEqualTo(currentApiKey)


### PR DESCRIPTION
Requires the class 'is-active' to be present in the web element,
as the loader is always present and visible.