### PR TITLE
Update to zanata assets 6.1.1

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -75,6 +75,10 @@ public class AbstractPage {
         return driver;
     }
 
+    public JavascriptExecutor getExecutor() {
+        return (JavascriptExecutor) getDriver();
+    }
+
     public String getUrl() {
         return driver.getCurrentUrl();
     }
@@ -228,8 +232,9 @@ public class AbstractPage {
         waitForAMoment().withMessage("Loader indicator").until(new Predicate<WebDriver>() {
             @Override
             public boolean apply(WebDriver input) {
-                List<WebElement> loaders = driver
-                        .findElements(By.className("js-loader"));
+
+                List<WebElement> loaders = (List<WebElement>) getExecutor()
+                        .executeScript("return (typeof $ == 'undefined') ?  [] : $('.js-loader')");
                 for (WebElement loader : loaders) {
                     if (loader.getAttribute("class").contains("is-active")) {
                         log.info("Wait for loader finished");

--- a/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
@@ -80,7 +80,6 @@ public class ProfileTest extends ZanataTestCase {
     @Feature(summary = "The user can change their API key",
             tcmsTestPlanIds = 5316, tcmsTestCaseIds = 0)
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
-    @Ignore("RHBZ1216304")
     public void changeUsersApiKey() throws Exception {
         DashboardClientTab dashboardClientTab = new LoginWorkFlow()
                 .signIn("translator", "translator")

--- a/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
@@ -163,7 +163,6 @@ public class RegisterTest extends ZanataTestCase {
             "page, and vice versa",
             tcmsTestPlanIds = 5316, tcmsTestCaseIds = 0)
     @Test
-    @Ignore("RHBZ1216304")
     public void signUpToLoginAndBack() {
         RegisterPage registerPage = new BasicWorkFlow()
                 .goToHome()

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -36,7 +36,7 @@
     <lombok.lib>${org.projectlombok:lombok:jar}</lombok.lib>
 
     <groovy.version>2.1.5</groovy.version>
-    <zanata.web.assets.version>6.1</zanata.web.assets.version>
+    <zanata.web.assets.version>6.1.1</zanata.web.assets.version>
   </properties>
 
   <build>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1216304

This should help with the `form__loader` problem seen when testing http://assets-zanata.rhcloud.com/6.1.1/styleguide/

 - [x] Re-enable ignored tests for RHBZ1216304