### PR TITLE
Remove jsessionid and upgrade Undertow for WildFly 8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1220,6 +1220,7 @@
         <mojarra.module.name>wildfly-${module.wildfly.version}-module-mojarra-${mojarra.module.version}.zip</mojarra.module.name>
         <hibernate.module.version>4.2.15.Final</hibernate.module.version>
         <hibernate.module.name>wildfly-${module.wildfly.version}-module-hibernate-main-${hibernate.module.version}.zip</hibernate.module.name>
+        <undertow.module.name>wildfly-9.0.0.Beta2-modules-undertow.zip</undertow.module.name>
       </properties>
 
       <build>
@@ -1240,10 +1241,15 @@
                 <configuration>
                   <target unless="skipITs">
                     <mkdir dir="${download.dir}" />
+
                     <get src="http://sourceforge.net/projects/zanata/files/wildfly/${mojarra.module.name}/download" dest="${download.dir}/${mojarra.module.name}" skipexisting="true" />
-                    <get src="http://sourceforge.net/projects/zanata/files/wildfly/${hibernate.module.name}/download" dest="${download.dir}/${hibernate.module.name}" skipexisting="true" />
                     <unzip src="${download.dir}/${mojarra.module.name}" dest="${appserver.home}" />
+
+                    <get src="http://sourceforge.net/projects/zanata/files/wildfly/${hibernate.module.name}/download" dest="${download.dir}/${hibernate.module.name}" skipexisting="true" />
                     <unzip src="${download.dir}/${hibernate.module.name}" dest="${appserver.home}" />
+
+                    <get src="http://sourceforge.net/projects/zanata/files/wildfly/${undertow.module.name}/download" dest="${download.dir}/${undertow.module.name}" skipexisting="true" />
+                    <unzip src="${download.dir}/${undertow.module.name}" dest="${appserver.home}" />
                   </target>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1203,10 +1203,10 @@
       </activation>
       <properties>
         <cargo.container>wildfly8x</cargo.container>
-        <wildfly.client.version>8.1.0.Final</wildfly.client.version>
+        <wildfly.client.version>8.2.0.Final</wildfly.client.version>
         <!-- used in the wildfly8 profile in zanata-war -->
         <!-- This is the server version -->
-        <wildfly.version>8.1.0.Final</wildfly.version>
+        <wildfly.version>8.2.0.Final</wildfly.version>
         <!-- In case this profile was activated by default: -->
         <appserver>wildfly8</appserver>
         <cargo.installation>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</cargo.installation>

--- a/zanata-war/src/main/java/org/zanata/rest/editor/service/TranslationService.java
+++ b/zanata-war/src/main/java/org/zanata/rest/editor/service/TranslationService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
@@ -52,6 +53,7 @@ import com.google.common.collect.Lists;
  */
 @Name("editor.translationService")
 @Path(TranslationResource.SERVICE_PATH)
+@Slf4j
 @Transactional
 public class TranslationService implements TranslationResource {
     @In
@@ -80,7 +82,10 @@ public class TranslationService implements TranslationResource {
         }
         List<Long> idList = TransUnitUtils.filterAndConvertIdsToList(ids);
         if (idList.size() > TransUnitUtils.MAX_SIZE) {
-            return Response.status(Response.Status.FORBIDDEN).build();
+            String msg = String.format("More than %d results.", TransUnitUtils.MAX_SIZE);
+            log.warn(msg);
+            return Response.status(Response.Status.FORBIDDEN).entity(msg)
+                    .build();
         }
 
         HLocale locale = localeServiceImpl.getByLocaleId(localeId);

--- a/zanata-war/src/main/java/org/zanata/rest/service/FileService.java
+++ b/zanata-war/src/main/java/org/zanata/rest/service/FileService.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
 import org.zanata.adapter.FileFormatAdapter;
@@ -69,6 +70,7 @@ import com.google.common.io.ByteStreams;
 
 @Name("fileService")
 @Path(FileResource.FILE_RESOURCE)
+@Slf4j
 public class FileService implements FileResource {
     private static final String FILE_TYPE_OFFLINE_PO = "offlinepo";
     private static final String FILE_TYPE_OFFLINE_PO_TEMPLATE = "offlinepot";
@@ -148,7 +150,7 @@ public class FileService implements FileResource {
                                 .getRawDocumentContentAsStream(document
                                         .getRawDocument());
             } catch (RawDocumentContentAccessException e) {
-                e.printStackTrace();
+                log.error(e.toString(), e);
                 return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e)
                         .build();
             }
@@ -256,6 +258,7 @@ public class FileService implements FileResource {
                                 .getRawDocumentContentAsStream(hDocument
                                         .getRawDocument());
             } catch (RawDocumentContentAccessException e) {
+                log.error(e.toString(), e);
                 return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e)
                         .build();
             }

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
@@ -4,6 +4,11 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
   version="3.0">
 
+  <session-config>
+    <!-- Prevent jsessionid session tracking (breaks WildFly 9) -->
+    <tracking-mode>COOKIE</tracking-mode>
+  </session-config>
+
   <!-- sso security -->
 
   <!-- Kerberos ticket based authentication settings -->


### PR DESCRIPTION
Based on https://github.com/zanata/zanata-server/pull/784 but using WildFly 8.2 combined with Undertow modules from WildFly 9 (because proper WildFly 9 still has some problems).