### PR TITLE
rhbz903964 - produce better error message when permission check failed

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,6 +30,7 @@ Example usage in html file: `<link rel="shortcut icon" href="#{assets['img/logo/
 * [1207426](https://bugzilla.redhat.com/show_bug.cgi?id=1207426) - Update request to join group/language page
 * [1165939](https://bugzilla.redhat.com/show_bug.cgi?id=1165939) - The Groups actions panel should not show for a normal user
 * [1205512](https://bugzilla.redhat.com/show_bug.cgi?id=1205512) - Run validation in editor document list is disabled when it should not be
+* [903964](https://bugzilla.redhat.com/show_bug.cgi?id=903964) - Error message not propagated to client when push fails
 
 -----------------------
 

--- a/zanata-model/src/main/java/org/zanata/model/HAccount.java
+++ b/zanata-model/src/main/java/org/zanata/model/HAccount.java
@@ -71,7 +71,8 @@ import org.zanata.rest.dto.Account;
 @ToString(callSuper = true, of = "username")
 @EqualsAndHashCode(callSuper = true, of = { "enabled", "passwordHash",
         "username", "apiKey" })
-public class HAccount extends ModelEntityBase implements Serializable {
+public class HAccount extends ModelEntityBase implements Serializable,
+        HasUserFriendlyToString {
     private static final long serialVersionUID = 1L;
 
     private String username;
@@ -168,5 +169,10 @@ public class HAccount extends ModelEntityBase implements Serializable {
     @MapKey(name = "name")
     public Map<String, HAccountOption> getEditorOptions() {
         return editorOptions;
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return String.format("Account(username=%s, enabled=%s, roles=%s)", getUsername(), isEnabled(), getRoles());
     }
 }

--- a/zanata-model/src/main/java/org/zanata/model/HAccountRole.java
+++ b/zanata-model/src/main/java/org/zanata/model/HAccountRole.java
@@ -43,7 +43,7 @@ import org.zanata.model.type.RoleTypeType;
 @Entity
 @Setter
 @TypeDef(name = "roleType", typeClass = RoleTypeType.class)
-public class HAccountRole implements Serializable {
+public class HAccountRole implements Serializable, HasUserFriendlyToString {
     private static final long serialVersionUID = 9177366120789064801L;
 
     private Integer id;
@@ -83,6 +83,11 @@ public class HAccountRole implements Serializable {
     @NotNull
     public RoleType getRoleType() {
         return roleType;
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return getName();
     }
 
     public enum RoleType {

--- a/zanata-model/src/main/java/org/zanata/model/HIterationGroup.java
+++ b/zanata-model/src/main/java/org/zanata/model/HIterationGroup.java
@@ -48,7 +48,8 @@ import com.google.common.collect.Sets;
 @Setter
 @Getter
 @Access(AccessType.FIELD)
-public class HIterationGroup extends SlugEntityBase implements HasEntityStatus {
+public class HIterationGroup extends SlugEntityBase implements HasEntityStatus,
+        HasUserFriendlyToString {
     private static final long serialVersionUID = 5682522115222479842L;
 
     @Size(max = 80)
@@ -94,5 +95,11 @@ public class HIterationGroup extends SlugEntityBase implements HasEntityStatus {
 
     public void addProjectIteration(HProjectIteration iteration) {
         this.getProjectIterations().add(iteration);
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return String.format("Version group(slug=%s, name=%s, status=%s",
+                getSlug(), getName(), getStatus());
     }
 }

--- a/zanata-model/src/main/java/org/zanata/model/HLocale.java
+++ b/zanata-model/src/main/java/org/zanata/model/HLocale.java
@@ -58,7 +58,8 @@ import com.ibm.icu.util.ULocale;
 @ToString(of = { "localeId" }, doNotUseGetters = true)
 @EqualsAndHashCode(callSuper = false, of = { "localeId" },
         doNotUseGetters = true)
-public class HLocale extends ModelEntityBase implements Serializable {
+public class HLocale extends ModelEntityBase implements Serializable,
+        HasUserFriendlyToString {
     private static final long serialVersionUID = 1L;
     private @Nonnull
     LocaleId localeId;
@@ -157,4 +158,9 @@ public class HLocale extends ModelEntityBase implements Serializable {
         return new ULocale(this.localeId.getId());
     }
 
+    @Override
+    public String userFriendlyToString() {
+        return String.format("Locale(id=%s, name=%s)", getLocaleId(),
+                retrieveDisplayName());
+    }
 }

--- a/zanata-model/src/main/java/org/zanata/model/HLocaleMember.java
+++ b/zanata-model/src/main/java/org/zanata/model/HLocaleMember.java
@@ -47,7 +47,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 @Table(name = "HLocale_Member")
 @Setter
 @NoArgsConstructor
-public class HLocaleMember implements Serializable {
+public class HLocaleMember implements Serializable, HasUserFriendlyToString {
     private static final long serialVersionUID = 1L;
 
     private HLocaleMemberPk id = new HLocaleMemberPk();
@@ -56,6 +56,8 @@ public class HLocaleMember implements Serializable {
     private boolean isReviewer;
     private boolean isTranslator;
 
+    private transient String userFriendlyToString;
+
     public HLocaleMember(HPerson person, HLocale supportedLanguage,
             boolean isTranslator, boolean isReviewer, boolean isCoordinator) {
         id.setPerson(person);
@@ -63,6 +65,11 @@ public class HLocaleMember implements Serializable {
         setTranslator(isTranslator);
         setReviewer(isReviewer);
         setCoordinator(isCoordinator);
+        userFriendlyToString =
+                String.format(
+                        "Locale membership(person=%s, isTranslator=%s, isReviewer=%s, isCoordinator=%s)",
+                        person.getName(), isTranslator, isReviewer,
+                        isCoordinator);
     }
 
     @EmbeddedId
@@ -97,6 +104,11 @@ public class HLocaleMember implements Serializable {
     @Transient
     public HLocale getSupportedLanguage() {
         return id.getSupportedLanguage();
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return userFriendlyToString;
     }
 
     @Embeddable

--- a/zanata-model/src/main/java/org/zanata/model/HProject.java
+++ b/zanata-model/src/main/java/org/zanata/model/HProject.java
@@ -97,7 +97,7 @@ import com.google.common.collect.Sets;
 @Indexed
 @ToString(callSuper = true, of = "name")
 public class HProject extends SlugEntityBase implements Serializable,
-        HasEntityStatus {
+        HasEntityStatus, HasUserFriendlyToString {
     private static final long serialVersionUID = 1L;
 
     @Size(max = 80)
@@ -184,5 +184,11 @@ public class HProject extends SlugEntityBase implements Serializable,
     public void addMaintainer(HPerson maintainer) {
         this.getMaintainers().add(maintainer);
         maintainer.getMaintainerProjects().add(this);
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return String.format("Project(name=%s, slug=%s, status=%s)", getName(),
+                getSlug(), getStatus());
     }
 }

--- a/zanata-model/src/main/java/org/zanata/model/HProjectIteration.java
+++ b/zanata-model/src/main/java/org/zanata/model/HProjectIteration.java
@@ -87,7 +87,8 @@ import com.google.common.collect.Sets;
 @NoArgsConstructor
 @ToString(callSuper = true, of = { "project" })
 public class HProjectIteration extends SlugEntityBase implements
-        Iterable<DocumentWithId>, HasEntityStatus, IsEntityWithType {
+        Iterable<DocumentWithId>, HasEntityStatus, IsEntityWithType,
+        HasUserFriendlyToString {
     private static final long serialVersionUID = 182037127575991478L;
 
     @ManyToOne
@@ -172,5 +173,11 @@ public class HProjectIteration extends SlugEntityBase implements
             return Boolean.FALSE;
         }
         return requireTranslationReview;
+    }
+
+    @Override
+    public String userFriendlyToString() {
+        return String.format("Project version(slug=%s, status=%s)", getSlug(),
+                getStatus());
     }
 }

--- a/zanata-model/src/main/java/org/zanata/model/HasUserFriendlyToString.java
+++ b/zanata-model/src/main/java/org/zanata/model/HasUserFriendlyToString.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.model;
+
+/**
+ * Will give a user friendly string representation of the object. All targets in
+ * SecurityFunctions should implement this interface so that when the permission
+ * check fail and we throw an AuthorizationException, the message will be more
+ * meaningful.
+ *
+ * @see org.jboss.seam.security.SecurityFunctions
+ * @see org.zanata.security.ZanataIdentity#checkPermission(java.lang.String,
+ *      java.lang.Object...)
+ */
+public interface HasUserFriendlyToString {
+
+    String userFriendlyToString();
+}

--- a/zanata-war/src/main/java/org/zanata/rest/AuthorizationExceptionMapper.java
+++ b/zanata-war/src/main/java/org/zanata/rest/AuthorizationExceptionMapper.java
@@ -12,7 +12,8 @@ public class AuthorizationExceptionMapper implements ExceptionMapper<Authorizati
 
     @Override
     public Response toResponse(AuthorizationException exception) {
-        return Response.status(Status.UNAUTHORIZED).build();
+        return Response.status(Status.FORBIDDEN)
+                .entity(exception.getMessage()).build();
     }
 
 }

--- a/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.security;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -32,6 +33,7 @@ import org.jboss.seam.annotations.Startup;
 import org.jboss.seam.annotations.intercept.BypassInterceptors;
 import org.jboss.seam.contexts.Contexts;
 import org.jboss.seam.core.Events;
+import org.jboss.seam.security.AuthorizationException;
 import org.jboss.seam.security.Configuration;
 import org.jboss.seam.security.Identity;
 import org.jboss.seam.security.NotLoggedInException;
@@ -41,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import org.zanata.events.Logout;
 import org.zanata.model.HAccount;
+import org.zanata.model.HasUserFriendlyToString;
 import org.zanata.security.permission.MultiTargetList;
 import org.zanata.util.ServiceLocator;
 
@@ -141,12 +144,12 @@ public class ZanataIdentity extends Identity {
         if (result) {
             if (log.isDebugEnabled()) {
                 log.debug("ALLOWED hasPermission({}, {}, {}) for user {}",
-                        name, action, arg, getAccountUsername());
+                        name, action, Lists.newArrayList(arg), getAccountUsername());
             }
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("DENIED hasPermission({}, {}, {}) for user {}",
-                        name, action, arg, getAccountUsername());
+                        name, action, Lists.newArrayList(arg), getAccountUsername());
             }
         }
         log.trace("EXIT hasPermission(): {}", result);
@@ -182,7 +185,27 @@ public class ZanataIdentity extends Identity {
      *             if logged in but not authorised
      */
     public void checkPermission(String action, Object... targets) {
-        super.checkPermission(MultiTargetList.fromTargets(targets), action);
+        try {
+            super.checkPermission(MultiTargetList.fromTargets(targets), action);
+        } catch (AuthorizationException exception) {
+            // try to produce a better than default error message
+            List<String> meaningfulTargets = Lists.newArrayList();
+            for (Object target : targets) {
+                if (target instanceof HasUserFriendlyToString) {
+                    String targetString = ((HasUserFriendlyToString) target).userFriendlyToString();
+                    meaningfulTargets.add(targetString);
+                } else {
+                    log.warn(
+                            "target [{}] may not have user friendly string representation",
+                            target.getClass());
+                    meaningfulTargets.add(target.toString());
+                }
+            }
+            throw new AuthorizationException(
+                    String.format(
+                            "Failed to obtain permission('%s') with following facts(%s)",
+                            action, meaningfulTargets));
+        }
     }
 
     @Override

--- a/zanata-war/src/test/java/org/zanata/rest/compat/AccountRawCompatibilityITCase.java
+++ b/zanata-war/src/test/java/org/zanata/rest/compat/AccountRawCompatibilityITCase.java
@@ -235,7 +235,7 @@ public class AccountRawCompatibilityITCase extends CompatibilityBase {
         Response putResponse = accountClient.put(a);
 
         // Assert initial put
-        assertThat(putResponse.getStatus(), is(Status.UNAUTHORIZED.getStatusCode()));
+        assertThat(putResponse.getStatus(), is(Status.FORBIDDEN.getStatusCode()));
         releaseConnection(putResponse);
     }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=903964

For example, when invoke client with following command:
```z  -B push --push-type trans --merge-type import```

There are two(maybe more) possible permission failure:
* user is not part of the language team
* user don't have permission to do merge type import operation

In the past what we get back is just a 401 with no body in response. Now we can tell what exactly go wrong:
* when user is not a member for the locale
```
[ERROR] Execution failed: 
 * Error Message: PUT http://localhost:8080/zanata/rest/async/projects/p/jasper/iterations/i/1/r/MessageResources/translations/de?ext=comment&merge=import&assignCreditToUploader=false returned a response status of 401 Unauthorized;
 * Response From Server: Failed to obtain permission(modify-translation) with following facts([Locale(id=de, name=German), Project(name=jasper, slug=jasper, status=ACTIVE)])]
```

* when user is a translator but not project maintainer (no permission to do merge import)
```
[ERROR] Execution failed: Failed while pushing document translations: [Failed to obtain permission(import-translation) with following facts([Project version(slug=1, status=ACTIVE)])]
```