### PR TITLE
Update to WildFly 9.0.0.CR1 again

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -27,8 +27,6 @@
     <cargo.container.home>${project.build.directory}/jboss/container</cargo.container.home>
     <context.path>zanata</context.path>
 
-    <!--data source-->
-    <ds.jndi.name>zanataDatasource</ds.jndi.name>
     <!--mysql-maven-plugin will use these setup-->
     <ds.database>root</ds.database>
     <ds.username>root</ds.username>

--- a/functional-test/src/test/resources/conf/standalone_wildfly.xml
+++ b/functional-test/src/test/resources/conf/standalone_wildfly.xml
@@ -268,7 +268,6 @@
       -->
       <cache-container name="zanata" default-cache="default"
         jndi-name="java:jboss/infinispan/container/zanata"
-        start="EAGER"
         module="org.jboss.as.clustering.web.infinispan">
         <local-cache name="default">
           <transaction mode="NON_XA" />

--- a/pom.xml
+++ b/pom.xml
@@ -1480,7 +1480,7 @@
         <wildfly.client.version>8.1.0.Final</wildfly.client.version>
         <!-- used in the wildfly8 profile in zanata-war -->
         <!-- This is the server version -->
-        <wildfly.version>9.0.0.Beta2</wildfly.version>
+        <wildfly.version>9.0.0.CR1</wildfly.version>
         <!-- In case this profile was activated by default: -->
         <appserver>wildfly8</appserver>
         <cargo.installation>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</cargo.installation>

--- a/zanata-war/src/etc/h2.properties
+++ b/zanata-war/src/etc/h2.properties
@@ -1,4 +1,3 @@
-ds.jndi.name=zanataTestDatasource
 ds.hibernate.dialect=org.hibernate.dialect.H2Dialect
 ds.driver.class=org.h2.Driver
 ds.connection.url=jdbc:h2:mem:zanata;DB_CLOSE_DELAY=-1

--- a/zanata-war/src/etc/mysql.properties
+++ b/zanata-war/src/etc/mysql.properties
@@ -1,4 +1,3 @@
-ds.jndi.name=zanataDatasource
 ds.driver.class=com.mysql.jdbc.Driver
 ds.connection.url=jdbc:mysql://localhost:3306/zanata?characterEncoding=UTF-8
 ds.user.name=sa

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/components.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/components.xml
@@ -71,10 +71,9 @@
 
       entity-manager-factory name is also referenced in in persistence.xml
   -->
-  <!-- FIXME zanataDatabase vs testDatabase -->
   <persistence:entity-manager-factory
     name="entityManagerFactory"
-    persistence-unit-name="@persistence-unit-name@"
+    persistence-unit-name="zanataDatasourcePU"
     installed="true"
     startup="true" />
 

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/persistence.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/persistence.xml
@@ -4,9 +4,9 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
   version="2.0">
 
-  <persistence-unit name="${ds.jndi.name}PU" transaction-type="JTA">
+  <persistence-unit name="zanataDatasourcePU" transaction-type="JTA">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
-    <jta-data-source>java:jboss/datasources/${ds.jndi.name}</jta-data-source>
+    <jta-data-source>java:jboss/datasources/zanataDatasource</jta-data-source>
     <mapping-file>META-INF/orm.xml</mapping-file>
 
     <class>org.zanata.model.Activity</class>

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/components.properties
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/components.properties
@@ -3,5 +3,5 @@
 
 env.debug=${env.debug}
 env.dbunit.type=${env.dbunit.type}
-persistence-unit-name=${ds.jndi.name}PU
+persistence-unit-name=zanataDatasourcePU
 web.assets.version=${zanata.web.assets.version}

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/components.properties
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/components.properties
@@ -3,5 +3,4 @@
 
 env.debug=${env.debug}
 env.dbunit.type=${env.dbunit.type}
-persistence-unit-name=zanataDatasourcePU
 web.assets.version=${zanata.web.assets.version}

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
@@ -92,7 +92,7 @@
 
   <context-param>
     <param-name>liquibase.datasource</param-name>
-    <param-value>java:jboss/datasources/${ds.jndi.name}</param-value>
+    <param-value>java:jboss/datasources/zanataDatasource</param-value>
   </context-param>
   <!--
   <context-param>
@@ -115,7 +115,7 @@
 
   <context-param>
     <param-name>javamelody.datasources</param-name>
-    <param-value>java:jboss/datasources/${ds.jndi.name}</param-value>
+    <param-value>java:jboss/datasources/zanataDatasource</param-value>
   </context-param>
 
   <!-- Zanata custom taglib -->

--- a/zanata-war/src/test/groovy/org/zanata/ZanataGroovyJpaTest.groovy
+++ b/zanata-war/src/test/groovy/org/zanata/ZanataGroovyJpaTest.groovy
@@ -28,7 +28,7 @@ import javax.persistence.Persistence
 @Listeners(TestMethodListener.class)
 abstract class ZanataGroovyJpaTest {
     private static final Logger log = LoggerFactory.getLogger(ZanataJpaTest.class);
-    private static final String PERSIST_NAME = "zanataTestDatasourcePU";
+    private static final String PERSIST_NAME = "zanataDatasourcePU";
 
     private static EntityManagerFactory emf;
 

--- a/zanata-war/src/test/java/org/zanata/ArquillianTest.java
+++ b/zanata-war/src/test/java/org/zanata/ArquillianTest.java
@@ -96,7 +96,7 @@ public abstract class ArquillianTest {
         try {
             DataSource dataSource =
                     (DataSource) Naming.getInitialContext().lookup(
-                            "java:jboss/datasources/zanataTestDatasource");
+                            "java:jboss/datasources/zanataDatasource");
             DatabaseConnection dbConn =
                     new DatabaseConnection(dataSource.getConnection());
             // NB: Specific to H2

--- a/zanata-war/src/test/java/org/zanata/RestTest.java
+++ b/zanata-war/src/test/java/org/zanata/RestTest.java
@@ -160,7 +160,7 @@ public abstract class RestTest {
         try {
             DataSource dataSource =
                     (DataSource) Naming.getInitialContext().lookup(
-                            "java:jboss/datasources/zanataTestDatasource");
+                            "java:jboss/datasources/zanataDatasource");
             DatabaseConnection dbConn =
                     new DatabaseConnection(dataSource.getConnection());
             // NB: Specific to H2

--- a/zanata-war/src/test/java/org/zanata/ZanataJpaTest.java
+++ b/zanata-war/src/test/java/org/zanata/ZanataJpaTest.java
@@ -31,7 +31,7 @@ import org.zanata.util.ZanataEntities;
 @Test(singleThreaded = true)
 public abstract class ZanataJpaTest {
     private static final Logger log = LoggerFactory.getLogger(ZanataJpaTest.class);
-    private static final String PERSIST_NAME = "zanataTestDatasourcePU";
+    private static final String PERSIST_NAME = "zanataDatasourcePU";
 
     private static EntityManagerFactory emf;
 

--- a/zanata-war/src/test/java/org/zanata/arquillian/Deployments.java
+++ b/zanata-war/src/test/java/org/zanata/arquillian/Deployments.java
@@ -101,6 +101,7 @@ public class Deployments {
                 "arquillian/components.properties"), "components.properties");
         archive.addAsResource("import.sql");
         archive.addAsResource("messages.properties");
+        archive.addAsWebInfResource(new File("src/main/webapp-jboss/WEB-INF/jboss-web.xml"));
         archive.addAsWebInfResource(new File(
                 "src/main/webapp-jboss/WEB-INF/jboss-deployment-structure.xml"));
         archive.setWebXML("arquillian/test-web.xml");

--- a/zanata-war/src/test/java/org/zanata/provider/JPAProvider.java
+++ b/zanata-war/src/test/java/org/zanata/provider/JPAProvider.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JPAProvider {
     private static final Logger log = LoggerFactory.getLogger(JPAProvider.class);
-    private static final String PERSIST_NAME = "zanataTestDatasourcePU";
+    private static final String PERSIST_NAME = "zanataDatasourcePU";
 
     private static EntityManagerFactory emf;
 

--- a/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplPerformanceTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplPerformanceTest.java
@@ -72,7 +72,7 @@ import com.google.common.collect.ImmutableMap;
  */
 @Slf4j
 public class CopyTransServiceImplPerformanceTest {
-    private static final String PERSIST_NAME = "zanataTestDatasourcePU";
+    private static final String PERSIST_NAME = "zanataDatasourcePU";
     private static final String MYSQL_TEST_DB_URL =
             "jdbc:log4jdbc:mysql://localhost:3306/zanata_unit_test?characterEncoding=UTF-8";
     private static final String MYSQL_DIALECT =

--- a/zanata-war/src/test/resources/META-INF/persistence.xml
+++ b/zanata-war/src/test/resources/META-INF/persistence.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
   version="2.0">
 
-  <persistence-unit name="zanataTestDatasourcePU"
+  <persistence-unit name="zanataDatasourcePU"
     transaction-type="RESOURCE_LOCAL">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
 

--- a/zanata-war/src/test/resources/arquillian/components.properties
+++ b/zanata-war/src/test/resources/arquillian/components.properties
@@ -3,5 +3,4 @@
 
 env.debug=true
 env.dbunit.type=HSQL
-persistence-unit-name=zanataDatasourcePU
 web.assets.version=1

--- a/zanata-war/src/test/resources/arquillian/components.properties
+++ b/zanata-war/src/test/resources/arquillian/components.properties
@@ -3,5 +3,5 @@
 
 env.debug=true
 env.dbunit.type=HSQL
-persistence-unit-name=zanataTestDatasourcePU
+persistence-unit-name=zanataDatasourcePU
 web.assets.version=1

--- a/zanata-war/src/test/resources/arquillian/persistence.xml
+++ b/zanata-war/src/test/resources/arquillian/persistence.xml
@@ -4,11 +4,11 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
   version="2.0">
 
-  <persistence-unit name="zanataTestDatasourcePU"
+  <persistence-unit name="zanataDatasourcePU"
     transaction-type="JTA">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
 
-    <jta-data-source>java:jboss/datasources/zanataTestDatasource</jta-data-source>
+    <jta-data-source>java:jboss/datasources/zanataDatasource</jta-data-source>
 
     <!--
       NB non-jta-data-source is not compatible with JPA tests, but is

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian-wildfly.xml
@@ -153,8 +153,8 @@
     </subsystem>
     <subsystem xmlns="urn:jboss:domain:datasources:2.0">
       <datasources>
-        <datasource jndi-name="java:jboss/datasources/zanataTestDatasource"
-          pool-name="zanataTestDatasourcePool" enabled="true"
+        <datasource jndi-name="java:jboss/datasources/zanataDatasource"
+          pool-name="zanataDatasource" enabled="true"
           use-ccm="true"
           use-java-context="true">
           <connection-url>jdbc:h2:mem:zanata;DB_CLOSE_DELAY=-1</connection-url>
@@ -280,7 +280,6 @@
       Zanata multi-purpose caches.
       -->
       <cache-container name="zanata" default-cache="default" jndi-name="java:jboss/infinispan/container/zanata"
-        start="EAGER"
         module="org.jboss.as.clustering.web.infinispan">
         <local-cache name="default">
           <transaction mode="NON_XA"/>

--- a/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian/standalone-arquillian.xml
@@ -116,8 +116,8 @@
     <subsystem xmlns="urn:jboss:domain:configadmin:1.0" />
     <subsystem xmlns="urn:jboss:domain:datasources:1.1">
       <datasources>
-        <datasource jndi-name="java:jboss/datasources/zanataTestDatasource"
-          pool-name="zanataTestDatasourcePool" enabled="true"
+        <datasource jndi-name="java:jboss/datasources/zanataDatasource"
+          pool-name="zanataDatasource" enabled="true"
           use-ccm="true"
           use-java-context="true">
           <connection-url>jdbc:h2:mem:zanata;DB_CLOSE_DELAY=-1</connection-url>


### PR DESCRIPTION
- Add jboss-web.xml to Arquillian deployments to ensure JNDI resources
  are initialised.
- Rename zanataTestDatasource to zanataDatasource to match jboss-web.xml.
- Remove ds.jndi.name property.