### PR TITLE
refactor: enable Java 1.8-style lambdas and streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -910,6 +910,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.sourceforge.streamsupport</groupId>
+        <artifactId>streamsupport</artifactId>
+        <version>1.3</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-orm</artifactId>
         <version>${hibernate.search.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <lombok.source.dir>${project.build.sourceDirectory}/org/zanata</lombok.source.dir>
     <lucene.version>3.6.2</lucene.version>
     <org.mock-server.version>3.9.17</org.mock-server.version>
+    <required.java>1.8</required.java>
 
     <!--
     Not used yet.
@@ -1451,6 +1452,28 @@
                   unless:set="cargo.installation" />
               </target>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <version>2.0.2</version>
+        <executions>
+          <execution>
+            <id>process-classes</id>
+            <phase>process-classes</phase>
+              <goals>
+              <goal>process-main</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>process-test-classes</id>
+            <phase>process-test-classes</phase>
+              <goals>
+              <goal>process-test</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/zanata-model/pom.xml
+++ b/zanata-model/pom.xml
@@ -183,6 +183,11 @@
     </dependency>
 
     <dependency>
+      <groupId>net.sourceforge.streamsupport</groupId>
+      <artifactId>streamsupport</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zanata-model/src/main/java/org/zanata/model/HTextFlow.java
+++ b/zanata-model/src/main/java/org/zanata/model/HTextFlow.java
@@ -50,6 +50,7 @@ import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import java8.util.stream.StreamSupport;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -393,12 +394,9 @@ public class HTextFlow extends HTextContainer implements Serializable,
     @Override
     public ITextFlowTarget getTargetContents(LocaleId localeId) {
         // TODO performance: need efficient way to look up a target by LocaleId
-        Collection<HTextFlowTarget> targets = getTargets().values();
-        for (HTextFlowTarget tft : targets) {
-            if (tft.getLocaleId().equals(localeId))
-                return tft;
-        }
-        return null;
+        return StreamSupport.stream(getTargets().values())
+                .filter(tft -> tft.getLocaleId().equals(localeId))
+                .findFirst().orElse(null);
     }
 
     @Transient
@@ -445,10 +443,10 @@ public class HTextFlow extends HTextContainer implements Serializable,
         String locale = toBCP47(document.getLocale());
         // TODO strip (eg) HTML tags before counting words. Needs more metadata
         // about the content type.
-        long count = 0;
-        for (String content : this.getContents()) {
-            count += OkapiUtil.countWords(content, locale);
-        }
+
+        long count = StreamSupport.stream(this.getContents())
+                .mapToLong(s -> OkapiUtil.countWords(s, locale))
+                .sum();
         setWordCount(count);
     }
 

--- a/zanata-model/src/main/java/org/zanata/model/tm/TransMemoryUnitVariant.java
+++ b/zanata-model/src/main/java/org/zanata/model/tm/TransMemoryUnitVariant.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.model.tm;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -32,6 +33,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 
+import java8.util.J8Arrays;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -46,8 +48,6 @@ import org.zanata.hibernate.search.TransUnitVariantClassBridge;
 import org.zanata.model.ModelEntityBase;
 import org.zanata.util.HashUtil;
 import org.zanata.util.OkapiUtil;
-
-import com.google.common.collect.Maps;
 
 /**
  * A translation unit variant. This is the equivalent of a translated string.
@@ -138,10 +138,9 @@ public class TransMemoryUnitVariant extends ModelEntityBase implements
 
     public static Map<String, TransMemoryUnitVariant> newMap(
             TransMemoryUnitVariant... tuvs) {
-        Map<String, TransMemoryUnitVariant> map = Maps.newHashMap();
-        for (TransMemoryUnitVariant target : tuvs) {
-            map.put(target.getLanguage(), target);
-        }
+        Map<String, TransMemoryUnitVariant> map = new HashMap<>();
+        J8Arrays.stream(tuvs)
+                .forEach(tuv -> map.put(tuv.getLanguage(), tuv));
         return map;
     }
 

--- a/zanata-model/src/test/java/org/zanata/model/HGlossaryEntryTest.java
+++ b/zanata-model/src/test/java/org/zanata/model/HGlossaryEntryTest.java
@@ -21,7 +21,9 @@
 package org.zanata.model;
 
 import java.util.Date;
+import java.util.Map;
 
+import java8.util.Maps;
 import org.junit.Before;
 import org.junit.Test;
 import org.zanata.common.LocaleId;
@@ -113,7 +115,8 @@ public class HGlossaryEntryTest {
 
     @Test
     public void hashMapDataTest() {
-        entry.getGlossaryTerms().clear();
+        Map<HLocale, HGlossaryTerm> glossaryTerms = entry.getGlossaryTerms();
+        glossaryTerms.clear();
 
         // Glossary Term 1 - EN_US
         setupTerm(1L, "TERM 1", LocaleId.EN_US, 1L);
@@ -124,11 +127,11 @@ public class HGlossaryEntryTest {
         // Glossary Term 3 - ES
         setupTerm(3L, "TERM 3", LocaleId.ES, 3L);
 
-        for (HLocale key : entry.getGlossaryTerms().keySet()) {
-            assertTrue(entry.getGlossaryTerms().containsKey(key));
-            assertNotNull(entry.getGlossaryTerms().get(key));
-        }
-
+        // TODO I'm not sure if this really tests anything:
+        Maps.forEach(glossaryTerms, (locale, term) -> {
+            assertTrue(glossaryTerms.containsKey(locale));
+            assertNotNull(glossaryTerms.get(locale));
+        });
     }
 
     private HLocale setupTerm(Long id, String content, LocaleId locale,


### PR DESCRIPTION
This will allow us to use Java 1.8-style lambdas and streams in server code, compiling under Java 1.8 but compatible with Java 1.7 runtimes.

 * https://github.com/orfjackal/retrolambda
 * https://sourceforge.net/projects/streamsupport/

See also https://github.com/zanata/zanata-parent/pull/40 (animal sniffer for java 1.7 compatibility)