### PR TITLE
rhbz1224594 Ensure UTF-8 when reading commonmark.min.js

### DIFF
--- a/zanata-war/src/main/java/org/zanata/util/CommonMarkRenderer.java
+++ b/zanata-war/src/main/java/org/zanata/util/CommonMarkRenderer.java
@@ -35,6 +35,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
@@ -90,7 +91,7 @@ public class CommonMarkRenderer {
 
     private Invocable getInvocable() {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                getScriptAsStream(getScriptName())))) {
+                getScriptAsStream(getScriptName()), StandardCharsets.UTF_8))) {
 
             ScriptEngine engine = newEngine();
             engine.eval("window = this;");


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1224594

This should prevent the error `org.mozilla.javascript.EvaluatorException: Property "├?" already defined in this object literal.` when loading `commonMarkRenderer` on the home page under Windows.