### PR TITLE
Downgrade Surefire for release

### DIFF
--- a/functional-test/src/test/java/org/zanata/feature/misc/FlakyTest.java
+++ b/functional-test/src/test/java/org/zanata/feature/misc/FlakyTest.java
@@ -21,6 +21,7 @@
 
 package org.zanata.feature.misc;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.zanata.feature.testharness.TestPlan;
@@ -37,6 +38,7 @@ public class FlakyTest {
     static int n = 0;
 
     @Category(TestPlan.BasicAcceptanceTest.class)
+    @Ignore("waiting for SUREFIRE-1152 in surefire 2.19")
     @Test
     public void testFlaky() {
         if (n++ == 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <failsafe.rerunFailingTestsCount>3</failsafe.rerunFailingTestsCount>
     <failsafe.useFile>false</failsafe.useFile>
     <surefire.useFile>false</surefire.useFile>
-    <surefire.version>2.19-SNAPSHOT</surefire.version>
+    <surefire.version>2.18.1</surefire.version>
     <!-- Applies to surefire and failsafe (if enabled) -->
     <failIfNoTests>true</failIfNoTests>
 


### PR DESCRIPTION
We can't release Zanata with a SNAPSHOT dependency, so we will have to downgrade for the moment.