### PR TITLE
Remove change of 'Approved' to 'Translated' status

### DIFF
--- a/zanata-war/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
@@ -212,6 +212,6 @@ public class TranslationServiceImplTest extends ZanataDbunitJpaTest {
         assertThat(result.get(0).getTranslatedTextFlowTarget().getVersionNum(),
                 is(1)); // moved up only one version
         assertThat(result.get(0).getTranslatedTextFlowTarget().getState(),
-                is(ContentState.Translated));
+                is(ContentState.Approved));
     }
 }


### PR DESCRIPTION
Remove change of 'Approved' to 'Translated' status in a non require review project.