### PR TITLE
Fix ClassNotFoundException on EAP rpm: rhbz1228086

### DIFF
--- a/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-deployment-structure.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-deployment-structure.xml
@@ -38,6 +38,13 @@
       <module name="org.jboss.security.negotiation" />
       <module name="org.picketbox" />
       <module name="org.slf4j" />
+      <system>
+        <paths>
+          <!-- Needed by de.christophkraemer.rhino.javascript.RhinoScriptEngine -->
+          <path name="sun/security/action"/>
+          <path name="sun/security/util" />
+        </paths>
+      </system>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1228086

This fixes java.lang.ClassNotFoundException: 
sun.security.action.GetPropertyAction when loading the projects page,
on JBoss EAP 6.4.0 installed via rpm.