### PR TITLE
Simplify appserver properties

### DIFF
--- a/etc/scripts/extractAppserver.groovy
+++ b/etc/scripts/extractAppserver.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+
+import groovy.util.AntBuilder
+
+// NB: project is a MavenProject
+// http://maven.apache.org/ref/3-LATEST/maven-core/apidocs/org/apache/maven/project/MavenProject.html
+
+String downloadDir = project.properties.get('download.dir') // ~/Downloads
+String cargoExtractDir = project.properties.get('cargo.extract.dir') // target/cargo/installs
+String url = project.properties.get('cargo.installation') // http://example.com/jbosseap6.zip
+
+String filename = url.substring(url.lastIndexOf('/')+1)
+String filePath = "${downloadDir}/${filename}"
+String basename = filename.substring(0, filename.lastIndexOf('.'))
+String extractDir = "${cargoExtractDir}/${basename}"
+
+def ant = new AntBuilder()
+ant.mkdir(dir: downloadDir)
+ant.get(src: url, dest: filePath, skipexisting: "true")
+ant.unzip(src: filePath, dest:"${extractDir}")
+
+def files = new File(extractDir).listFiles()
+if (files.length != 1) {
+    throw new Exception('zip should contain exactly one top-level dir; see ' + extractDir)
+}
+def topLevelDir = files[0].path
+
+project.properties.put('appserver.home', topLevelDir)

--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -477,6 +477,16 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>extract-appserver</id>
+                <phase>prepare-package</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>
               <execution>
@@ -585,10 +595,6 @@
               </deployables>
             </configuration>
             <executions>
-              <execution>
-                <id>cargo-install</id>
-                <phase>prepare-package</phase>
-              </execution>
               <execution>
                 <id>cargo-start</id>
                 <phase>pre-integration-test</phase>
@@ -819,11 +825,8 @@
                 <echo>-DskipArqTests : to skip Arquillian integration tests (if building zanata-war)</echo>
                 <echo />
                 <echo>Unless skipping tests, you must choose an appserver:</echo>
-                <echo>-Dappserver=jbosseap6 -Dcargo.installation=http://example.com/jbosseap640.zip -Dcargo.basename=jbosseap640</echo>
-                <echo>or -Dappserver=wildfly8</echo>
-                <echo>NB: cargo.basename needs to match the basename of the file given in cargo.installation.</echo>
-                <echo>For example, if cargo.installation is http://example.com/download/jboss-6.4.0.zip, cargo.basename should be jboss-6.4.0.</echo>
-                <echo>appserver.dir.name is top-level dir inside zip.  For jbosseap6, default is jboss-eap-6.3.  Override for later versions.</echo>
+                <echo>-Dappserver=jbosseap6 or -Dappserver=wildfly8</echo>
+                <echo>For jbosseap6, env var EAP6_URL should point to an EAP zip file.</echo>
                 <echo />
                 <echo>-DallFuncTests to enable all functional tests (defaults to smoke tests)</echo>
                 <echo />
@@ -854,7 +857,7 @@
             <configuration>
               <target unless="skipFuncTests">
                 <fail message="'appserver' property must be set to run integration tests (or else use -DskipFuncTests)" unless="appserver" />
-                <fail message="'cargo.installation' property must be set to run integration tests (or else use -DskipFuncTests)" unless="cargo.installation" />
+                <fail message="'cargo.installation' property is null (set env var EAP6_URL or else use -DskipFuncTests)" unless="cargo.installation" />
               </target>
             </configuration>
           </execution>
@@ -903,6 +906,7 @@
         <configuration>
           <container>
             <type>installed</type>
+            <home>${appserver.home}</home>
 
             <systemProperties>
               <ehcache.disk.store.dir>${project.build.directory}/ehcache</ehcache.disk.store.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -1182,6 +1182,34 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <!-- NB: This execution needs to be before antrun, because it
+               creates the wildfly directory for the unzip tasks. -->
+          <execution>
+            <id>extract-appserver</id>
+            <!-- submodules should use 'prepare-package' to activate this -->
+            <phase>none</phase>
+            <goals><goal>execute</goal></goals>
+            <configuration>
+              <scripts>
+                <!-- Extracts app server and sets the Maven property
+                appserver.home (where the appserver is installed) -->
+                <script>file:///${project.basedir}/../etc/scripts/extractAppserver.groovy</script>
+              </scripts>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant-nodeps</artifactId>
+            <version>1.8.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.zanata</groupId>
         <artifactId>zanata-maven-plugin</artifactId>
         <version>3.6.0</version>
@@ -1249,8 +1277,10 @@
                 <echo message="cargo.installation=${cargo.installation}" />
                 <echo message="appserver.home=${appserver.home}" />
                 <echo message="DISPLAY=${env.DISPLAY}" />
-                <echo message="WARNING: 'appserver' property must be set unless skippping integration tests" unless:set="appserver" />
-                <echo message="WARNING: 'cargo.installation' property (and possibly cargo.basename) must be set unless skipping integration tests" unless:set="cargo.installation" />
+                <echo message="WARNING: 'appserver' property must be set unless skipping integration tests"
+                  unless:set="appserver" />
+                <echo message="WARNING: 'cargo.installation' property is null.  You might need to set the env var EAP6_URL"
+                  unless:set="cargo.installation" />
               </target>
             </configuration>
           </execution>
@@ -1275,32 +1305,12 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.5</version>
+          <version>1.4.14</version>
           <configuration combine.self="append">
             <container>
               <containerId>${cargo.container}</containerId>
-              <!--if install from url-->
-              <zipUrlInstaller>
-                <url>${cargo.installation}</url>
-                <downloadDir>${download.dir}</downloadDir>
-                <extractDir>${cargo.extract.dir}</extractDir>
-              </zipUrlInstaller>
             </container>
           </configuration>
-          <executions>
-            <!-- Download and extract app server under target/ -->
-            <!-- NB: This execution needs to be before antrun, because it
-                 creates the wildfly directory for the unzip tasks. -->
-            <!-- TODO use antrun to download and extract appserver? -->
-            <execution>
-              <id>cargo-install</id>
-              <!-- submodules should use 'prepare-package' to activate this -->
-              <phase>none</phase>
-              <goals>
-                <goal>install</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
@@ -1388,6 +1398,11 @@
           <configuration>
             <providerSelection>2.0</providerSelection>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1485,10 +1500,7 @@
       </activation>
       <properties>
         <cargo.container>jboss72x</cargo.container>
-        <!-- name of the top-level dir within the appserver zip -->
-        <appserver.dir.name>jboss-eap-6.4</appserver.dir.name>
-        <!-- where the appserver will be installed -->
-        <appserver.home>${cargo.extract.dir}/${cargo.basename}/${appserver.dir.name}</appserver.home>
+        <cargo.installation>${env.EAP6_URL}</cargo.installation>
       </properties>
     </profile>
 
@@ -1503,6 +1515,7 @@
       </activation>
       <properties>
         <cargo.container>wildfly8x</cargo.container>
+        <!-- Version of the management api used by Arquillian and Cargo -->
         <wildfly.client.version>8.1.0.Final</wildfly.client.version>
         <!-- used in the wildfly8 profile in zanata-war -->
         <!-- This is the server version -->
@@ -1510,11 +1523,8 @@
         <!-- In case this profile was activated by default: -->
         <appserver>wildfly8</appserver>
         <cargo.installation>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</cargo.installation>
-        <!-- name of the top-level dir within the appserver zip -->
-        <appserver.dir.name>wildfly-${wildfly.version}</appserver.dir.name>
-        <!-- where the appserver will be installed -->
-        <appserver.home>${cargo.extract.dir}/${appserver.dir.name}/${appserver.dir.name}</appserver.home>
 
+        <!-- Versions of our compatibility modules for wildfly -->
         <module.wildfly.version>8.1.0.Final</module.wildfly.version>
         <mojarra.module.version>2.1.29-01</mojarra.module.version>
         <mojarra.module.name>wildfly-${module.wildfly.version}-module-mojarra-${mojarra.module.version}.zip</mojarra.module.name>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -63,7 +63,6 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.1</version>
         <executions>
           <execution>
             <id>default</id>
@@ -1022,18 +1021,18 @@
                 <configuration>
                   <target unless="skipArqTests">
                     <fail message="'appserver' property must be set to run integration tests (or else use -DskipArqTests)" unless="appserver" />
-                    <fail message="'cargo.installation' property must be set to run integration tests (or else use -DskipArqTests)" unless="cargo.installation" />
+                    <fail message="'cargo.installation' property is null (set env var EAP6_URL or else use -DskipArqTests)" unless="cargo.installation" />
                   </target>
                 </configuration>
               </execution>
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven2-plugin</artifactId>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
             <executions>
               <execution>
-                <id>cargo-install</id>
+                <id>extract-appserver</id>
                 <phase>prepare-package</phase>
               </execution>
             </executions>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -86,27 +86,8 @@
             </goals>
             <configuration>
               <scripts>
-                <script>
-                  def props = new Properties()
-                  project.artifacts.each { a -&gt;
-                    def coord = a.groupId + ":" + a.artifactId + ":" + a.type + (a.classifier ? ":" + a.classifier : "")
-                    // Make version available to the build:
-                    project.properties.put "version." + coord, a.version
-                    // This can be expanded to ether deps if required:
-                    if (a.groupId.startsWith('org.webjars')) {
-                      // Make webjar version available at runtime:
-                      props.put coord, a.version
-                    }
-                  }
-                  // NB: this has a corresponding resource directory
-                  // declaration above.
-                  def genDir = new File(project.build.directory,
-                    'generated-resources/deps')
-                  genDir.mkdirs()
-                  new File(genDir, 'dependencies.properties').withWriter { out -&gt;
-                    props.store out, 'Zanata dependency versions'
-                  }
-                </script>
+                <script>file:///${project.basedir}/src/etc/dependencyVersions.groovy</script>
+
               </scripts>
             </configuration>
           </execution>

--- a/zanata-war/src/etc/dependencyVersions.groovy
+++ b/zanata-war/src/etc/dependencyVersions.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+def props = new Properties()
+// NB: project is a MavenProject
+// http://maven.apache.org/ref/3-LATEST/maven-core/apidocs/org/apache/maven/project/MavenProject.html
+project.artifacts.each { a ->
+    def coord = a.groupId + ":" + a.artifactId + ":" + a.type + (a.classifier ? ":" + a.classifier : "")
+    // Make version available to the build:
+    project.properties.put "version." + coord, a.version
+    // This can be expanded to other deps if required:
+    if (a.groupId.startsWith('org.webjars')) {
+        // Make webjar version available at runtime:
+        props.put coord, a.version
+    }
+}
+
+// NB: this has a corresponding resource directory
+// declaration above.
+def genDir = new File(project.build.directory,
+    'generated-resources/deps')
+genDir.mkdirs()
+new File(genDir, 'dependencies.properties').withWriter { out ->
+    props.store out, 'Zanata dependency versions'
+}


### PR DESCRIPTION
This should make it easier to switch between EAP and WildFly for testing.  Assuming you have set `EAP6_URL`, and you're happy to use the version of WildFly specified in the pom, you just switch between `-Dappserver=jbosseap6` and `-Dappserver=wildfly8`.  

No need to specify any of these (and it's easier to switch if you don't):
- cargo.installation
- cargo.basename
- appserver.dir.name

You can still specify these if you want to change the version of WildFly itself or the version of the management api:
- wildfly.version
- wildfly.client.version
