### PR TITLE
Remove ignore dup for schema/xml.xsd

### DIFF
--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -199,8 +199,6 @@
             <ignoredResourcePattern>build.properties</ignoredResourcePattern>
             <!-- Seam -->
             <ignoredResourcePattern>seam.properties</ignoredResourcePattern>
-            <!-- jboss-metadata-common and zanata-adapter-xliff -->
-            <ignoredResourcePattern>schema/xml.xsd</ignoredResourcePattern>
           </ignoredResourcePatterns>
         </configuration>
       </plugin>


### PR DESCRIPTION
There are some differences between the copy of `schema/xml.xsd` in jboss-metadata-common and zanata-adapter-xliff, but I'm not sure jboss-metadata-common is still on the test classpath, so I'm hoping we might not need the exemption after all. 