### PR TITLE
Ignore slow tests

### DIFF
--- a/zanata-war/src/test/java/org/zanata/SlowTest.java
+++ b/zanata-war/src/test/java/org/zanata/SlowTest.java
@@ -26,6 +26,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * (Currently not handled by test framework: please use
+ * <code>@Ignore("slow test")</code> as well.)
  * Marker annotation to identify tests that might be potentially slow to run.
  *
  * @author Carlos Munoz <a

--- a/zanata-war/src/test/java/org/zanata/rest/service/ResourceUtilsJpaTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/ResourceUtilsJpaTest.java
@@ -69,7 +69,7 @@ public class ResourceUtilsJpaTest extends ZanataJpaTest {
         // TODO check the results in 'to'
     }
 
-    @Ignore
+    @Ignore("slow test")
     // This should be executed manually in IDE
     @Test
     @SlowTest

--- a/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplPerformanceTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplPerformanceTest.java
@@ -42,7 +42,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
-import org.junit.runner.RunWith;
 import org.zanata.PerformanceProfiling;
 import org.zanata.SlowTest;
 import org.zanata.common.ContentState;
@@ -311,8 +310,8 @@ public class CopyTransServiceImplPerformanceTest extends ZanataTest {
                         FixedValueMaker.EMPTY_STRING_MAKER);
     }
 
+    @Ignore("slow test")
     @Test
-    @Ignore
     @SlowTest
     @PerformanceProfiling
     public void testCopyTransForDocument() throws Exception {

--- a/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
@@ -144,9 +144,9 @@ public class CopyTransServiceImplTest extends ZanataDbunitJpaTest {
         return val;
     }
 
-    @Ignore("slow test")
     @Test
     @UseDataProvider("copyTransParams")
+    // (about 2 seconds)
     @SlowTest
     public void testCopyTrans(CopyTransExecution execution) {
         // Prepare Execution

--- a/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
@@ -144,6 +144,7 @@ public class CopyTransServiceImplTest extends ZanataDbunitJpaTest {
         return val;
     }
 
+    @Ignore("slow test")
     @Test
     @UseDataProvider("copyTransParams")
     @SlowTest

--- a/zanata-war/src/test/java/org/zanata/service/impl/DocumentServiceImplTest.java
+++ b/zanata-war/src/test/java/org/zanata/service/impl/DocumentServiceImplTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -83,6 +84,7 @@ public class DocumentServiceImplTest {
     private ApplicationConfiguration applicationConfiguration;
 
     private DocumentServiceImpl documentService;
+    private DocumentServiceImpl spyService;
 
     private Long docId = 1L, versionId = 1L, tfId = 1L;
     private LocaleId localeId = LocaleId.DE;
@@ -104,6 +106,11 @@ public class DocumentServiceImplTest {
         documentService = new DocumentServiceImpl();
         documentService.init(projectIterationDAO, documentDAO,
             translationStateCacheImpl, urlUtil, applicationConfiguration, msgs);
+        // TODO spy should only be needed for legacy code
+        spyService = Mockito.spy(documentService);
+        // avoid triggering HTTP requests in a unit test:
+        doNothing().when(spyService).publishDocumentMilestoneEvent(
+                any(WebHook.class), any(DocumentMilestoneEvent.class));
 
         HProjectIteration version = Mockito.mock(HProjectIteration.class);
         HProject project = Mockito.mock(HProject.class);
@@ -128,10 +135,8 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventTranslatedTest() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
         doNothing().when(spyService).publishDocumentMilestoneEvent(
                 any(WebHook.class), any(DocumentMilestoneEvent.class));
-
         WordStatistic stats = new WordStatistic(0, 0, 0, 10, 0);
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))
             .thenReturn(stats);
@@ -152,8 +157,6 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventTranslatedNot100Test() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
-
         WordStatistic stats = new WordStatistic(0, 1, 0, 9, 0);
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))
             .thenReturn(stats);
@@ -174,10 +177,8 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventApprovedTest() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
         doNothing().when(spyService).publishDocumentMilestoneEvent(
             any(WebHook.class), any(DocumentMilestoneEvent.class));
-
         WordStatistic stats = new WordStatistic(10, 0, 0, 0, 0);
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))
             .thenReturn(stats);
@@ -197,8 +198,6 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventApprovedNot100Test() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
-
         WordStatistic stats = new WordStatistic(9, 0, 0, 1, 0);
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))
             .thenReturn(stats);
@@ -219,7 +218,6 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventSameStateTest1() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
         WordStatistic stats = new WordStatistic(10, 0, 0, 0, 0);
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))
             .thenReturn(stats);
@@ -240,7 +238,6 @@ public class DocumentServiceImplTest {
 
     @Test
     public void documentMilestoneEventSameStateTest2() {
-        DocumentServiceImpl spyService = Mockito.spy(documentService);
         WordStatistic stats = new WordStatistic(0, 0, 0, 10, 0);
 
         when(translationStateCacheImpl.getDocumentStatistics(docId, localeId))


### PR DESCRIPTION
`@SlowTest` is currently not handled by our JUnit setup, so we have to `@Ignore` such tests, at least for now.