### PR TITLE
Replace Cobertura with JaCoCo

### DIFF
--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -27,6 +27,8 @@
     <cargo.container.home>${project.build.directory}/jboss/container</cargo.container.home>
     <context.path>zanata</context.path>
 
+    <coverage.halt.failure>false</coverage.halt.failure>
+
     <!--mysql-maven-plugin will use these setup-->
     <ds.database>root</ds.database>
     <ds.username>root</ds.username>

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,7 @@
 
   <properties>
     <byteman.version>2.1.2</byteman.version>
-    <cobertura.total-line-rate>50</cobertura.total-line-rate>
-    <cobertura.total-branch-rate>30</cobertura.total-branch-rate>
-    <cobertura.halt.failure>false</cobertura.halt.failure>
+    <coverage.halt.failure>true</coverage.halt.failure>
     <delombok.dir>${project.build.directory}/delombok/org/zanata</delombok.dir>
     <!-- failsafe.version needs to be at least 2.19-20150503.223005-71: -->
     <failsafe.rerunFailingTestsCount>3</failsafe.rerunFailingTestsCount>
@@ -1165,17 +1163,6 @@
         <updatePolicy>never</updatePolicy>
       </snapshots>
     </pluginRepository>
-
-    <pluginRepository>
-      <id>cobertura-it-maven-plugin-maven2-release</id>
-      <url>http://cobertura-it-maven-plugin.googlecode.com/svn/maven2/releases</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </pluginRepository>
   </pluginRepositories>
 
 
@@ -1226,7 +1213,6 @@
               </allowedRepositories>
               <allowedPluginRepositories combine.children="append">
                 <allowedPluginRepository>apache.snapshots.https</allowedPluginRepository>
-                <allowedPluginRepository>cobertura-it-maven-plugin-maven2-release</allowedPluginRepository>
                 <allowedPluginRepository>jboss-public-repository-group</allowedPluginRepository>
               </allowedPluginRepositories>
             </requireNoRepositories>
@@ -1331,22 +1317,64 @@
           <!-- NB In some cases, we might not want to use gwt.version here -->
           <version>${gwt.version}</version>
         </plugin>
+
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.6</version>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.5.201505241946</version>
           <configuration>
-            <formats>
-              <format>xml</format>
-            </formats>
-            <instrumentation>
-              <ignoreMethodAnnotations>
-                <ignoreMethodAnnotation>org.zanata.util.CoverageIgnore</ignoreMethodAnnotation>
-              </ignoreMethodAnnotations>
-              <ignoreTrivial>true</ignoreTrivial>
-            </instrumentation>
+            <excludes>
+              <!--General exclusion-->
+              <exclude>**/test/**/*</exclude>
+              <exclude>**/*Exception*</exclude>
+              <exclude>**/*Test</exclude>
+              <exclude>**/*Tests</exclude>
+              <exclude>**/*ITCase</exclude>
+            </excludes>
+            <haltOnFailure>${coverage.halt.failure}</haltOnFailure>
+            <!-- Can't do these in jacoco (yet?)
+            See https://github.com/jacoco/jacoco/issues/15 -->
+            <!--<ignoreMethodAnnotation>org.zanata.util.CoverageIgnore</ignoreMethodAnnotation>-->
+            <!--<ignoreTrivial>true</ignoreTrivial>-->
+            <rules>
+              <rule>
+                <!-- overall... -->
+                <element>BUNDLE</element>
+                <limits>
+                  <limit>
+                    <!-- 55% of classes must be executed -->
+                    <!-- TODO Make this 100% -->
+                    <counter>CLASS</counter>
+                    <value>COVEREDRATIO</value>
+                    <minimum>0.55</minimum>
+                    <!--<minimum>0.50</minimum>-->
+                  </limit>
+                  <limit>
+                    <!-- 38% of instructions must be covered -->
+                    <!-- TODO Make this 80% -->
+                    <counter>INSTRUCTION</counter>
+                    <value>COVEREDRATIO</value>
+                    <minimum>0.38</minimum>
+                  </limit>
+                </limits>
+              </rule>
+              <!-- TODO enable this -->
+              <!--<rule>-->
+              <!--&lt;!&ndash; within each class... &ndash;&gt;-->
+              <!--<element>CLASS</element>-->
+              <!--<limits>-->
+              <!--<limit>-->
+              <!--&lt;!&ndash; 50% of instructions must be covered &ndash;&gt;-->
+              <!--<counter>INSTRUCTIONS</counter>-->
+              <!--<value>COVEREDRATIO</value>-->
+              <!--<minimum>0.50</minimum>-->
+              <!--</limit>-->
+              <!--</limits>-->
+              <!--</rule>-->
+            </rules>
           </configuration>
         </plugin>
+
         <!-- change maven-release-plugin back to defaults (instead of oss-parent's settings)  -->
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
@@ -1394,6 +1422,48 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <!-- use with jacoco-maven-plugin -->
+      <!-- Warning: always execute tests again *without instrumentation*
+       (ie without -Dcoverage) before a release.  See
+       http://stackoverflow.com/a/15799871/14379 -->
+      <id>coverage</id>
+      <activation>
+        <property>
+          <name>coverage</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
     <profile>
       <!-- This profile runs a single integration test with

--- a/zanata-liquibase/pom.xml
+++ b/zanata-liquibase/pom.xml
@@ -9,6 +9,10 @@
 
   <artifactId>zanata-liquibase</artifactId>
 
+  <properties>
+    <coverage.halt.failure>false</coverage.halt.failure>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/zanata-model/pom.xml
+++ b/zanata-model/pom.xml
@@ -19,6 +19,8 @@
   </scm>
 
   <properties>
+    <!-- Improve coverage to match the thresholds in server/pom.xml -->
+    <coverage.halt.failure>false</coverage.halt.failure>
   </properties>
 
   <build>

--- a/zanata-test-war/pom.xml
+++ b/zanata-test-war/pom.xml
@@ -11,6 +11,7 @@
   <description>This module will use war overlay to add some extra REST api to zanata-war, which enables test data generation and a few extra functionalities</description>
 
   <properties>
+    <coverage.halt.failure>false</coverage.halt.failure>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- target zanata instance will be built by war overlay -->
     <zanata.test.war.name>zanata-test-${project.version}</zanata.test.war.name>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -22,6 +22,9 @@
     <war.config.dir>${basedir}/src/etc</war.config.dir>
     <allow.deploy.skip>true</allow.deploy.skip>
 
+    <!-- for surefire (and failsafe) -->
+    <argLine>-Dconcordion.output.dir=${concordion.output.dir} -XX:MaxPermSize=256m</argLine>
+
     <!-- application properties -->
     <env.debug>false</env.debug>
     <war.name>zanata</war.name>
@@ -405,7 +408,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Dconcordion.output.dir=${concordion.output.dir} -XX:MaxPermSize=256m</argLine>
+          <!-- Do not define argLine here (conflicts with jacoco:prepare-agent) -->
           <testNGArtifactName>none:none</testNGArtifactName>
           <!-- TODO ensure that stateful tests (eg using Hibernate Search)
                are isolated, or rename them to ITCase (Arquillian), and
@@ -423,58 +426,46 @@
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
+
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
-          <instrumentation>
-            <excludes>
-              <!--WebTran exclusion-->
-              <!--TODO move all gwt wrapper class under specific package. i.e boundary-->
-              <!--<exclude>**/boundary/**/*</exclude>-->
-              <exclude>**/test/**/*</exclude>
-              <exclude>**/Sample*</exclude>
-              <exclude>**/dto/**</exclude>
-              <!--<exclude>**/supersource/**/*</exclude>-->
-              <exclude>**/client/**/*View</exclude>
-              <exclude>**/client/Application*</exclude>
-              <exclude>**/client/auth/**</exclude>
-              <exclude>**/client/events/**</exclude>
-              <exclude>**/client/gin/**</exclude>
-              <exclude>**/client/rpc/**</exclude>
-              <exclude>**/client/ui/**</exclude>
-              <exclude>**/client/view/**</exclude>
-              <exclude>**/client/util/**</exclude>
-              <exclude>**/EventWrapperImpl*</exclude>
-              <exclude>**/*DataProvider*</exclude>
-              <exclude>**/*SelectionModel*</exclude>
-              <!--below are some trivial classes(java bean) at the moment-->
-              <exclude>**/shared/auth/**</exclude>
-              <exclude>**/shared/model/**</exclude>
-              <exclude>**/shared/rpc/**</exclude>
-              <exclude>**/shared/util/**</exclude>
-              <!--hard to test due to environment dependent-->
-              <exclude>org/zanata/security/**</exclude>
-
-              <!--Server exclusion-->
-              <exclude>**/job/**</exclude>
-              <exclude>**/liquibase/**</exclude>
-              <exclude>**/log4j/**</exclude>
-              <exclude>**/seam/**</exclude>
-              <exclude>**/rest/files/*</exclude>
-              <exclude>**/rest/*Mapper</exclude>
-              <exclude>**/openid/*</exclude>
-              <exclude>**/servlet/*</exclude>
-
-              <!--General exclusion-->
-              <exclude>**/*Exception*</exclude>
-            </excludes>
-          </instrumentation>
-          <check>
-            <totalBranchRate>${cobertura.total-branch-rate}</totalBranchRate>
-            <totalLineRate>${cobertura.total-line-rate}</totalLineRate>
-            <haltOnFailure>${cobertura.halt.failure}</haltOnFailure>
-          </check>
+          <excludes>
+            <!--WebTran exclusion-->
+            <!--TODO move all gwt wrapper class under specific package. i.e   &lt;!&ndash;<exclude>**/boundary/**/*</exclude>-->
+            <exclude>**/Sample*</exclude>
+            <exclude>**/dto/**</exclude>
+            <!--<exclude>**/supersource/**/*</exclude>-->
+            <exclude>**/client/**/*View</exclude>
+            <exclude>**/client/Application*</exclude>
+            <exclude>**/client/auth/**</exclude>
+            <exclude>**/client/events/**</exclude>
+            <exclude>**/client/gin/**</exclude>
+            <exclude>**/client/rpc/**</exclude>
+            <exclude>**/client/ui/**</exclude>
+            <exclude>**/client/view/**</exclude>
+            <exclude>**/client/util/**</exclude>
+            <exclude>**/EventWrapperImpl*</exclude>
+            <exclude>**/*DataProvider*</exclude>
+            <exclude>**/*SelectionModel*</exclude>
+            <!--below are some trivial classes(java bean) at the moment-->
+            <exclude>**/shared/auth/**</exclude>
+            <exclude>**/shared/model/**</exclude>
+            <exclude>**/shared/rpc/**</exclude>
+            <exclude>**/shared/util/**</exclude>
+            <!--hard to test due to environment dependent-->
+            <exclude>org/zanata/security/**</exclude>
+            <!--Server exclusion-->
+            <exclude>**/job/**</exclude>
+            <exclude>**/liquibase/**</exclude>
+            <exclude>**/log4j/**</exclude>
+            <exclude>**/seam/**</exclude>
+            <exclude>**/rest/files/*</exclude>
+            <exclude>**/rest/*Mapper</exclude>
+            <exclude>**/openid/*</exclude>
+            <exclude>**/servlet/*</exclude>
+          </excludes>
         </configuration>
       </plugin>
 
@@ -837,115 +828,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>it-coverage</id>
-      <!-- In order to combine unit test and integration test coverage together, it requires below two commands:
-      mvn clean verify -Pit-coverage,nogwt
-      mvn cobertura:cobertura
-      Adding -Dcobertura.report.format=html to the second command will output report as html.
-      Jenkins requires xml format.
-      -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-it-maven-plugin</artifactId>
-            <version>2.5</version>
-            <configuration>
-              <instrumentation>
-                <excludes>
-                  <!--WebTran exclusion-->
-                  <!--TODO move all gwt wrapper class under specific package. i.e boundary-->
-                  <!--<exclude>**/boundary/**/*</exclude>-->
-                  <exclude>**/test/**/*</exclude>
-                  <!--<exclude>**/supersource/**/*</exclude>-->
-                  <exclude>**/client/**/*View</exclude>
-                  <exclude>**/client/Application*</exclude>
-                  <exclude>**/client/auth/**</exclude>
-                  <exclude>**/client/events/**</exclude>
-                  <exclude>**/client/gin/**</exclude>
-                  <exclude>**/client/rpc/**</exclude>
-                  <exclude>**/client/ui/**</exclude>
-                  <exclude>**/client/view/**</exclude>
-                  <exclude>**/EventWrapperImpl*</exclude>
-                  <exclude>**/*DataProvider*</exclude>
-                  <exclude>**/*SelectionModel*</exclude>
-                  <!--below are some trivial classes(java bean) at the moment-->
-                  <exclude>**/shared/auth/**</exclude>
-                  <exclude>**/shared/model/**</exclude>
-                  <exclude>**/shared/rpc/**</exclude>
-
-                  <!--Server exclusion-->
-                  <exclude>**/job/**</exclude>
-                  <exclude>**/liquibase/**</exclude>
-                  <exclude>**/log4j/**</exclude>
-                  <exclude>**/seam/**</exclude>
-                  <exclude>**/rest/files/*</exclude>
-                  <exclude>**/rest/*Mapper</exclude>
-                  <exclude>**/openid/*</exclude>
-                  <exclude>**/servlet/*</exclude>
-
-                  <!--General exclusion-->
-                  <exclude>**/*Exception*</exclude>
-                </excludes>
-              </instrumentation>
-              <formats>
-                <format>xml</format>
-              </formats>
-              <check>
-                <haltOnFailure>false</haltOnFailure>
-              </check>
-            </configuration>
-            <executions>
-              <execution>
-                <id>cobertura-clean</id>
-                <phase>clean</phase>
-                <goals>
-                  <goal>clean</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>cobertura-instrument</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>instrument</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>cobertura-check-only</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>check-only</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-
-      <reporting>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-it-maven-plugin</artifactId>
-            <configuration>
-              <formats>
-                <format>html</format>
-                <!--<format>xml</format>-->
-              </formats>
-            </configuration>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>report-only</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-        </plugins>
-      </reporting>
     </profile>
 
     <profile>

--- a/zanata-war/src/main/java/org/zanata/util/CoverageIgnore.java
+++ b/zanata-war/src/main/java/org/zanata/util/CoverageIgnore.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Cobertura 2.0+ will ignore any method with this annotation.
+ * TODO: not currently understood by jacoco filtering
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This allows us to run unit tests once only, either with coverage
(`-Dcoverage`) or without.  I can't find a way to run tests exactly once
with Cobertura.  If surefire is configured to skip tests, Cobertura
won't run them either, and I can't find a way to generate a Cobertura
report on its own.

JaCoCo is configured to enforce coverage ratios, initially just for
zanata-war.