### PR TITLE
Get wildfly zip from JBoss Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1543,7 +1543,7 @@
         <wildfly.version>9.0.0.CR2</wildfly.version>
         <!-- In case this profile was activated by default: -->
         <appserver>wildfly8</appserver>
-        <cargo.installation>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</cargo.installation>
+        <cargo.installation>https://repository.jboss.org/nexus/content/groups/developer/org/wildfly/wildfly-dist/${wildfly.version}/wildfly-dist-${wildfly.version}.zip</cargo.installation>
 
         <!-- Versions of our compatibility modules for wildfly -->
         <module.wildfly.version>8.1.0.Final</module.wildfly.version>


### PR DESCRIPTION
Wildfly 10 alphas are in Maven, but currently not
    http://wildfly.org/downloads/

This commit makes it easy to test against a WildFly alpha, just by setting the Maven property `wildfly.version`.

http://wildfly-development.1055759.n5.nabble.com/First-Alphas-of-WildFly-10-and-WildFly-Core-2-have-been-released-td5715883.html
http://wildfly-development.1055759.n5.nabble.com/10-0-0-Alpha2-released-amp-9-status-update-td5715967.html