### PR TITLE
Add explicit dependency on jms.

### DIFF
--- a/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-deployment-structure.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/jboss-deployment-structure.xml
@@ -25,6 +25,7 @@
       <module name="javax.faces.api" />
       <!-- not needed for wildfly: -->
       <module name="javax.interceptor.api" />
+      <module name="javax.jms.api" />
       <module name="javax.mail.api" />
       <module name="javax.servlet.api" />
       <module name="javax.transaction.api"/>


### PR DESCRIPTION
This was causing a deployment failure on JBoss EAP 6.3.3 with a root cause of

  java.lang.ClassNotFoundException: javax.jms.MessageListener
    from [Module "deployment.zanata.war:main" from Service Module Loader]

Related: https://issues.jboss.org/browse/WFLY-4642