### PR TITLE
Move constructor logic to @Create methods

### DIFF
--- a/zanata-war/src/main/java/org/zanata/WebAssetsConfiguration.java
+++ b/zanata-war/src/main/java/org/zanata/WebAssetsConfiguration.java
@@ -62,7 +62,8 @@ public class WebAssetsConfiguration extends AbstractMap<String, String> {
 
     private String webAssetsUrlBase;
 
-    public WebAssetsConfiguration() {
+    @PostConstruct
+    public void postConstruct() {
         String assetsProperty = System.getProperty(ASSETS_PROPERTY_KEY);
 
         /**

--- a/zanata-war/src/main/java/org/zanata/rest/service/VersionService.java
+++ b/zanata-war/src/main/java/org/zanata/rest/service/VersionService.java
@@ -1,5 +1,6 @@
 package org.zanata.rest.service;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -13,14 +14,11 @@ import org.zanata.util.VersionUtility;
 @Path(VersionResource.SERVICE_PATH)
 public class VersionService implements VersionResource {
 
-    private final VersionInfo version;
+    private VersionInfo version;
 
-    public VersionService() {
-        this(VersionUtility.getAPIVersionInfo());
-    }
-
-    VersionService(VersionInfo ver) {
-        this.version = ver;
+    @PostConstruct
+    public void postConstruct() {
+        this.version = VersionUtility.getAPIVersionInfo();
     }
 
     @Override

--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationStateCacheImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationStateCacheImpl.java
@@ -106,10 +106,8 @@ public class TranslationStateCacheImpl implements TranslationStateCache {
     @Inject
     private LocaleDAO localeDAO;
 
-    // constructor for Seam
+    // constructor for CDI
     public TranslationStateCacheImpl() {
-        this(new DocumentStatisticLoader(), new HTextFlowTargetIdLoader(),
-                new HTextFlowTargetValidationLoader());
     }
 
     // Constructor for testing
@@ -125,6 +123,15 @@ public class TranslationStateCacheImpl implements TranslationStateCache {
 
     @PostConstruct
     public void create() {
+        if (documentStatisticLoader == null) {
+            documentStatisticLoader = new DocumentStatisticLoader();
+        }
+        if (docStatusLoader == null) {
+            docStatusLoader = new HTextFlowTargetIdLoader();
+        }
+        if (targetValidationLoader == null) {
+            targetValidationLoader = new HTextFlowTargetValidationLoader();
+        }
         documentStatisticCache =
                 InfinispanCacheWrapper.create(DOC_STATISTIC_CACHE_NAME,
                         cacheContainer, documentStatisticLoader);

--- a/zanata-war/src/main/java/org/zanata/service/impl/VersionStateCacheImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/VersionStateCacheImpl.java
@@ -68,12 +68,12 @@ public class VersionStateCacheImpl implements VersionStateCache {
     @Inject
     private IServiceLocator serviceLocator;
 
-    // constructor for Seam
+    // constructor for CDI
     public VersionStateCacheImpl() {
-        this(new VersionStatisticLoader());
     }
 
     // Constructor for testing
+    @VisibleForTesting
     public VersionStateCacheImpl(
             CacheLoader<VersionLocaleKey, WordStatistic> versionStatisticLoader) {
         this.versionStatisticLoader = versionStatisticLoader;
@@ -81,6 +81,9 @@ public class VersionStateCacheImpl implements VersionStateCache {
 
     @PostConstruct
     public void create() {
+        if (versionStatisticLoader == null) {
+            versionStatisticLoader = new VersionStatisticLoader();
+        }
         versionStatisticCache =
                 InfinispanCacheWrapper.create(VERSION_STATISTIC_CACHE_NAME,
                         cacheContainer, versionStatisticLoader);

--- a/zanata-war/src/main/java/org/zanata/webtrans/server/TranslationWorkspaceManagerImpl.java
+++ b/zanata-war/src/main/java/org/zanata/webtrans/server/TranslationWorkspaceManagerImpl.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -81,13 +82,13 @@ public class TranslationWorkspaceManagerImpl implements
     @Inject
     private ValidationService validationServiceImpl;
 
-    private final ConcurrentHashMap<WorkspaceId, TranslationWorkspace> workspaceMap;
-    private final Multimap<ProjectIterationId, TranslationWorkspace> projIterWorkspaceMap;
-    private final EventRegistry eventRegistry;
+    private ConcurrentHashMap<WorkspaceId, TranslationWorkspace> workspaceMap;
+    private Multimap<ProjectIterationId, TranslationWorkspace> projIterWorkspaceMap;
+    private EventRegistry eventRegistry;
 
-    public TranslationWorkspaceManagerImpl() {
-        this.workspaceMap =
-                new ConcurrentHashMap<WorkspaceId, TranslationWorkspace>();
+    @PostConstruct
+    public void postConstruct() {
+        this.workspaceMap = new ConcurrentHashMap<>();
         Multimap<ProjectIterationId, TranslationWorkspace> piwm =
                 HashMultimap.create();
         this.projIterWorkspaceMap = Multimaps.synchronizedMultimap(piwm);


### PR DESCRIPTION
In both Seam and CDI, the bean's constructor will be invoked twice:
once for the proxy object, and once for the actual instance, so any
logic should be in @Create/@PostConstruct methods, not the constructor.

In Seam, @javax.annotation.PostConstruct methods appear to cause Seam to
treat the bean as an EJB, which means some injections don't happen before
the @PostConstruct method (or at all, possibly).  (These methods will be
migrated to @PostConstruct for CDI.)