### PR TITLE
fix(gwt): avoid packaging .junit_symbolMaps/

### DIFF
--- a/zanata-war/src/main/java/org/zanata/webtrans/Application.gwt.xml
+++ b/zanata-war/src/main/java/org/zanata/webtrans/Application.gwt.xml
@@ -12,9 +12,6 @@
 
   <inherits name="com.google.gwt.inject.Inject" />
 
-  <!-- This makes the GWT Designer happy -->
-  <inherits name="com.google.gwt.junit.JUnit" />
-
   <!--google guava collection goodies-->
   <inherits name='com.google.common.collect.Collect' />
 


### PR DESCRIPTION
This should reduce the size of zanata.war, and probably speed up builds
a bit too.