### PR TITLE
Boost Lucene query using TFT metadata

### DIFF
--- a/zanata-war/src/main/java/org/zanata/rest/editor/service/SuggestionsService.java
+++ b/zanata-war/src/main/java/org/zanata/rest/editor/service/SuggestionsService.java
@@ -21,7 +21,7 @@
 package org.zanata.rest.editor.service;
 
 import com.google.common.base.Joiner;
-import com.googlecode.totallylazy.Either;
+import com.google.common.base.Optional;
 import com.googlecode.totallylazy.Option;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Name;
@@ -33,7 +33,6 @@ import org.zanata.rest.editor.service.resource.SuggestionsResource;
 import org.zanata.service.LocaleService;
 import org.zanata.service.TranslationMemoryService;
 import org.zanata.webtrans.shared.model.TransMemoryQuery;
-import org.zanata.webtrans.shared.rpc.HasSearchType;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.Path;
@@ -61,7 +60,8 @@ public class SuggestionsService implements SuggestionsResource {
     private LocaleService localeService;
 
     @Override
-    public Response query(List<String> query, String sourceLocaleString, String transLocaleString, String searchTypeString) {
+    public Response query(List<String> query, String sourceLocaleString,
+            String transLocaleString, String searchTypeString, long textFlowTargetId) {
 
         Option<SearchType> searchType = getSearchType(searchTypeString);
         if (searchType.isEmpty()) {
@@ -82,8 +82,14 @@ public class SuggestionsService implements SuggestionsResource {
                     .build();
         }
 
+        Optional<Long> tft;
+        if (textFlowTargetId < 0) {
+            tft = Optional.absent();
+        } else {
+            tft = Optional.of(textFlowTargetId);
+        }
         List<Suggestion> suggestions = transMemoryService.searchTransMemoryWithDetails(transLocale.get(),
-                sourceLocale.get(), new TransMemoryQuery(query, searchType.get()));
+                sourceLocale.get(), new TransMemoryQuery(query, searchType.get()), tft);
 
         // Wrap in generic entity to prevent type erasure, so that an
         // appropriate MessageBodyReader can be used.

--- a/zanata-war/src/main/java/org/zanata/rest/editor/service/resource/SuggestionsResource.java
+++ b/zanata-war/src/main/java/org/zanata/rest/editor/service/resource/SuggestionsResource.java
@@ -63,8 +63,9 @@ public interface SuggestionsResource {
      */
     @POST
     @Produces({ MediaTypes.APPLICATION_ZANATA_SUGGESTIONS_JSON, MediaType.APPLICATION_JSON })
-    public Response query(List<String> query,
-                          @QueryParam("from") String sourceLocale,
-                          @QueryParam("to") String transLocale,
-                          @QueryParam("searchType") @DefaultValue("FUZZY_PLURAL") String searchType);
+    Response query(List<String> query,
+            @QueryParam("from") String sourceLocale,
+            @QueryParam("to") String transLocale,
+            @QueryParam("searchType") @DefaultValue("FUZZY_PLURAL") String searchType,
+            @QueryParam("textFlowTargetId") @DefaultValue("-1") long textFlowTargetId);
 }

--- a/zanata-war/src/main/java/org/zanata/service/TranslationMemoryService.java
+++ b/zanata-war/src/main/java/org/zanata/service/TranslationMemoryService.java
@@ -27,6 +27,7 @@ import org.zanata.model.HLocale;
 import org.zanata.model.HTextFlow;
 import org.zanata.model.HTextFlowTarget;
 import org.zanata.rest.editor.dto.suggestion.Suggestion;
+import org.zanata.util.SysProperties;
 import org.zanata.webtrans.shared.model.TransMemoryDetails;
 import org.zanata.webtrans.shared.model.TransMemoryQuery;
 import org.zanata.webtrans.shared.model.TransMemoryResultItem;
@@ -60,5 +61,5 @@ public interface TranslationMemoryService extends TranslationFinder {
      */
     List<Suggestion> searchTransMemoryWithDetails(
             LocaleId targetLocaleId, LocaleId sourceLocaleId,
-            TransMemoryQuery transMemoryQuery);
+            TransMemoryQuery transMemoryQuery, Optional<Long> textFlowTargetId);
 }

--- a/zanata-war/src/main/java/org/zanata/util/SysProperties.java
+++ b/zanata-war/src/main/java/org/zanata/util/SysProperties.java
@@ -31,14 +31,30 @@ public class SysProperties {
      * Maximum number of Lucene results to be considered in TM searches.
      */
     public static final String TM_MAX_RESULTS = "zanata.tm.max.results";
-/*
+    /**
+     * Override Lucene boost value for text contents
+     */
     public static final String TM_BOOST_CONTENT = "zanata.tm.boost.content";
+    /**
+     * Override Lucene value for textflowtarget (id)
+     */
     public static final String TM_BOOST_TFTID = "zanata.tm.boost.tftid";
+    /**
+     * Override Lucene value for project (slug)
+     */
     public static final String TM_BOOST_PROJECT = "zanata.tm.boost.project";
+    /**
+     * Override Lucene value for document name (docId)
+     */
     public static final String TM_BOOST_DOCID = "zanata.tm.boost.docid";
+    /**
+     * Override Lucene value for textflow (resId)
+     */
     public static final String TM_BOOST_RESID = "zanata.tm.boost.resid";
+    /**
+     * Override Lucene value for project iteration (slug)
+     */
     public static final String TM_BOOST_ITERATION = "zanata.tm.boost.iteration";
-*/
 
     /**
      * Gets the value of a system property as a float if available,


### PR DESCRIPTION
This PR builds on top of #923, by changing Lucene's scoring algorithm to favour results which share some or all of the same:

* TextFlowTarget (id)
* Project (slug)
* Iteration (slug)
* Document (docId)
* TextFlow (resId)
