### PR TITLE
fix(ZNTA-627): check whether project iteration is found

### DIFF
--- a/zanata-war/src/main/java/org/zanata/action/CopyTransAction.java
+++ b/zanata-war/src/main/java/org/zanata/action/CopyTransAction.java
@@ -21,6 +21,7 @@
 package org.zanata.action;
 
 import java.io.Serializable;
+import javax.annotation.Nonnull;
 import javax.faces.application.FacesMessage;
 
 import org.jboss.seam.ScopeType;
@@ -36,6 +37,7 @@ import org.zanata.dao.ProjectIterationDAO;
 import org.zanata.i18n.Messages;
 import org.zanata.model.HCopyTransOptions;
 import org.zanata.model.HProjectIteration;
+import org.zanata.rest.NoSuchEntityException;
 import org.zanata.seam.scope.ConversationScopeMessages;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.service.impl.CopyTransOptionFactory;
@@ -127,10 +129,16 @@ public class CopyTransAction extends CopyAction implements Serializable {
                 .getCopyTransProcessHandle(getProjectIteration());
     }
 
-    public HProjectIteration getProjectIteration() {
+    @Nonnull
+    private HProjectIteration getProjectIteration() {
+        // TODO share code with ProjectVersionService.retrieveAndCheckIteration?
         if (projectIteration == null) {
             projectIteration =
                     projectIterationDAO.getBySlug(projectSlug, iterationSlug);
+            if (projectIteration == null) {
+                throw new NoSuchEntityException("Project version '" + projectSlug
+                        + ":" + iterationSlug + "' not found.");
+            }
         }
         return projectIteration;
     }

--- a/zanata-war/src/main/java/org/zanata/action/CopyTransManager.java
+++ b/zanata-war/src/main/java/org/zanata/action/CopyTransManager.java
@@ -148,7 +148,7 @@ public class CopyTransManager implements Serializable {
                 .getHandleByKey(key);
     }
 
-    public void cancelCopyTrans(HProjectIteration iteration) {
+    public void cancelCopyTrans(@Nonnull HProjectIteration iteration) {
         if (isCopyTransRunning(iteration)) {
             CopyTransProcessKey key = CopyTransProcessKey.getKey(iteration);
             CopyTransTaskHandle handle =


### PR DESCRIPTION
https://zanata.atlassian.net/browse/ZNTA-627

This should prevent server log messages like this one:

    java.lang.IllegalArgumentException: Copy Trans can only run for HProjectIteration and HDocument
    	at org.zanata.action.CopyTransManager.isCopyTransRunning(CopyTransManager.java:80)
    	at sun.reflect.GeneratedMethodAccessor687.invoke(Unknown Source)
    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.lang.reflect.Method.invoke(Method.java:606)
    	at org.jboss.seam.util.Reflections.invoke(Reflections.java:22)
    	at org.jboss.seam.intercept.RootInvocationContext.proceed(RootInvocationContext.java:32)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:56)
    	at org.jboss.seam.transaction.RollbackInterceptor.aroundInvoke(RollbackInterceptor.java:28)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.core.BijectionInterceptor.aroundInvoke(BijectionInterceptor.java:79)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.core.MethodContextInterceptor.aroundInvoke(MethodContextInterceptor.java:44)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.intercept.RootInterceptor.invoke(RootInterceptor.java:107)
    	at org.jboss.seam.intercept.JavaBeanInterceptor.interceptInvocation(JavaBeanInterceptor.java:196)
    	at org.jboss.seam.intercept.JavaBeanInterceptor.invoke(JavaBeanInterceptor.java:114)
    	at org.zanata.action.CopyTransManager_$$_javassist_seam_47.isCopyTransRunning(CopyTransManager_$$_javassist_seam_47.java)
    	at org.zanata.action.CopyTransAction.isInProgress(CopyTransAction.java:92)
    	at sun.reflect.GeneratedMethodAccessor686.invoke(Unknown Source)
    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.lang.reflect.Method.invoke(Method.java:606)
    	at org.jboss.seam.util.Reflections.invoke(Reflections.java:22)
    	at org.jboss.seam.intercept.RootInvocationContext.proceed(RootInvocationContext.java:32)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:56)
    	at org.jboss.seam.transaction.RollbackInterceptor.aroundInvoke(RollbackInterceptor.java:28)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.core.BijectionInterceptor.aroundInvoke(BijectionInterceptor.java:79)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.core.ConversationInterceptor.aroundInvoke(ConversationInterceptor.java:65)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.core.MethodContextInterceptor.aroundInvoke(MethodContextInterceptor.java:44)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.security.SecurityInterceptor.aroundInvoke(SecurityInterceptor.java:163)
    	at org.jboss.seam.intercept.SeamInvocationContext.proceed(SeamInvocationContext.java:68)
    	at org.jboss.seam.intercept.RootInterceptor.invoke(RootInterceptor.java:107)
    	at org.jboss.seam.intercept.JavaBeanInterceptor.interceptInvocation(JavaBeanInterceptor.java:196)
    	at org.jboss.seam.intercept.JavaBeanInterceptor.invoke(JavaBeanInterceptor.java:114)
    	at org.zanata.action.CopyTransAction_$$_javassist_seam_46.isInProgress(CopyTransAction_$$_javassist_seam_46.java)
    	at sun.reflect.GeneratedMethodAccessor685.invoke(Unknown Source)
    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.lang.reflect.Method.invoke(Method.java:606)
    	at javax.el.BeanELResolver.getValue(BeanELResolver.java:304)
    	at com.sun.faces.el.DemuxCompositeELResolver._getValue(DemuxCompositeELResolver.java:176)
    	at com.sun.faces.el.DemuxCompositeELResolver.getValue(DemuxCompositeELResolver.java:203)
    	at org.jboss.el.parser.AstPropertySuffix.getValue(AstPropertySuffix.java:53)
    	at org.jboss.el.parser.AstValue.getValue(AstValue.java:67)
    	at org.jboss.el.parser.AstChoice.getValue(AstChoice.java:27)
    	at org.jboss.el.parser.AstDeferredExpression.getValue(AstDeferredExpression.java:26)
    	at org.jboss.el.parser.AstCompositeExpression.getValue(AstCompositeExpression.java:31)
    	at org.jboss.el.ValueExpressionImpl.getValue(ValueExpressionImpl.java:186)
    	at com.sun.faces.facelets.el.ContextualCompositeValueExpression.getValue(ContextualCompositeValueExpression.java:156)
    	at com.sun.faces.facelets.el.TagValueExpression.getValue(TagValueExpression.java:109)
    	at javax.faces.component.ComponentStateHelper.eval(ComponentStateHelper.java:194)
    	at javax.faces.component.ComponentStateHelper.eval(ComponentStateHelper.java:182)
    	at org.jboss.seam.ui.component.html.HtmlDiv.getStyleClass(HtmlDiv.java:82)
    	at org.jboss.seam.ui.renderkit.StyleRendererBase.doEncodeBegin(StyleRendererBase.java:24)
    	at org.jboss.seam.ui.util.cdk.RendererBase.encodeBegin(RendererBase.java:79)
    	at javax.faces.component.UIComponentBase.encodeBegin(UIComponentBase.java:822)
    	at com.sun.faces.renderkit.html_basic.HtmlBasicRenderer.encodeRecursive(HtmlBasicRenderer.java:302)
    	at com.sun.faces.renderkit.html_basic.GroupRenderer.encodeChildren(GroupRenderer.java:105)
    	at javax.faces.component.UIComponentBase.encodeChildren(UIComponentBase.java:847)
    	at javax.faces.component.UIComponent.encodeAll(UIComponent.java:1819)
    	at com.sun.faces.renderkit.html_basic.CompositeRenderer.encodeChildren(CompositeRenderer.java:78)
    	at javax.faces.component.UIComponentBase.encodeChildren(UIComponentBase.java:847)
    	at javax.faces.component.UIComponent.encodeAll(UIComponent.java:1819)
    	at javax.faces.component.UIComponent.encodeAll(UIComponent.java:1822)
    	at javax.faces.component.UIComponent.encodeAll(UIComponent.java:1822)
    	at com.sun.faces.application.view.FaceletViewHandlingStrategy.renderView(FaceletViewHandlingStrategy.java:447)
    	at com.sun.faces.application.view.MultiViewHandler.renderView(MultiViewHandler.java:125)
    	at org.jboss.seam.jsf.SeamViewHandler.renderView(SeamViewHandler.java:188)
    	at javax.faces.application.ViewHandlerWrapper.renderView(ViewHandlerWrapper.java:286)
    	at com.sun.faces.lifecycle.RenderResponsePhase.execute(RenderResponsePhase.java:120)
    	at com.sun.faces.lifecycle.Phase.doPhase(Phase.java:101)
    	at com.sun.faces.lifecycle.LifecycleImpl.render(LifecycleImpl.java:139)
    	at javax.faces.webapp.FacesServlet.service(FacesServlet.java:594)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:295)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:832)
    	at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:620)
    	at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:553)
    	at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:482)
    	at org.tuckey.web.filters.urlrewrite.NormalRewrittenUrl.doRewrite(NormalRewrittenUrl.java:213)
    	at org.tuckey.web.filters.urlrewrite.RuleChain.handleRewrite(RuleChain.java:171)
    	at org.tuckey.web.filters.urlrewrite.RuleChain.doRules(RuleChain.java:145)
    	at org.tuckey.web.filters.urlrewrite.UrlRewriter.processRequest(UrlRewriter.java:92)
    	at org.tuckey.web.filters.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:389)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:246)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.jboss.seam.servlet.SeamFilter$FilterChainImpl.doFilter(SeamFilter.java:83)
    	at org.jboss.seam.web.LoggingFilter.doFilter(LoggingFilter.java:60)
    	at org.jboss.seam.servlet.SeamFilter$FilterChainImpl.doFilter(SeamFilter.java:69)
    	at org.jboss.seam.servlet.SeamFilter$FilterChainImpl.doFilter(SeamFilter.java:73)
    	at org.jboss.seam.web.ExceptionFilter.doFilter(ExceptionFilter.java:64)
    	at org.jboss.seam.servlet.SeamFilter$FilterChainImpl.doFilter(SeamFilter.java:69)
    	at org.jboss.seam.servlet.SeamFilter.doFilter(SeamFilter.java:158)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:246)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.zanata.seam.interceptor.MonitoringWrapper.doFilter(MonitoringWrapper.java:67)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:246)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.zanata.servlet.GWTCacheControlFilter.doFilter(GWTCacheControlFilter.java:61)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:246)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.zanata.servlet.MDCInsertingServletFilter.doFilter(MDCInsertingServletFilter.java:70)
    	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:246)
    	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:214)
    	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:231)
    	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:149)
    	at org.jboss.as.jpa.interceptor.WebNonTxEmCloserValve.invoke(WebNonTxEmCloserValve.java:50)
    	at org.jboss.as.jpa.interceptor.WebNonTxEmCloserValve.invoke(WebNonTxEmCloserValve.java:50)
    	at org.jboss.security.negotiation.NegotiationAuthenticator$WrapperValve.invoke(NegotiationAuthenticator.java:490)
    	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:420)
    	at org.jboss.as.web.security.SecurityContextAssociationValve.invoke(SecurityContextAssociationValve.java:169)
    	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:150)
    	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:97)
    	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:102)
    	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
    	at org.apache.coyote.ajp.AjpProcessor.process(AjpProcessor.java:490)
    	at org.apache.coyote.ajp.AjpProtocol$AjpConnectionHandler.process(AjpProtocol.java:420)
    	at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:926)
    	at java.lang.Thread.run(Thread.java:745)
