### PR TITLE
fix(ZNTA-628): fall back on locale's plural forms

### DIFF
--- a/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
+++ b/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
@@ -773,7 +773,7 @@ public class ResourceUtils {
         }
 
         headerEntry = containedHeaders.get(PLURAL_FORMS_HDR);
-        if (headerEntry == null) {
+        if (headerEntry == null || headerEntry.getValue().isEmpty()) {
             headerEntry =
                     new HeaderEntry(PLURAL_FORMS_HDR,
                             this.getPluralForms(locale));

--- a/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
+++ b/zanata-war/src/main/java/org/zanata/rest/service/ResourceUtils.java
@@ -78,6 +78,7 @@ import org.zanata.util.StringUtil;
 
 import com.google.common.base.Optional;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
 @Name("resourceUtils")
@@ -773,7 +774,7 @@ public class ResourceUtils {
         }
 
         headerEntry = containedHeaders.get(PLURAL_FORMS_HDR);
-        if (headerEntry == null || headerEntry.getValue().isEmpty()) {
+        if (headerEntry == null || isBlank(headerEntry.getValue())) {
             headerEntry =
                     new HeaderEntry(PLURAL_FORMS_HDR,
                             this.getPluralForms(locale));
@@ -1040,7 +1041,7 @@ public class ResourceUtils {
     int getNumPlurals(@Nullable String poHeaders, LocaleId localeId) {
         String pluralForms = null;
         try {
-            if (poHeaders != null && !poHeaders.isEmpty()) {
+            if (!isEmpty(poHeaders)) {
                 Properties headerList = new Properties();
                 headerList.load(new StringReader(poHeaders));
 

--- a/zanata-war/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
+++ b/zanata-war/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
@@ -352,7 +352,7 @@ public class ResourceUtilsTest extends ZanataTest {
             LocaleId localeId = LocaleId.fromJavaName(propKey);
             resourceUtils.getPluralForms(localeId, true, false);
             verify(mockLocaleDAO).findByLocaleId(localeId);
-            resourceUtils.getNPluralForms(null, localeId);
+            resourceUtils.getNumPlurals(null, localeId);
         }
     }
 


### PR DESCRIPTION
Fall back on locale's plural forms when plurals header is empty.
Also simplify the code and improve log messages.