### PR TITLE
fix(ZNTA-640): prevent NullPointerException and provide more contextual information

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
@@ -1002,13 +1002,27 @@ public class TranslationServiceImpl implements TranslationService {
                         // generate request
                         List<String> oldContents = oldTarget.getContents();
                         ContentState oldState = oldTarget.getState();
+
+                        final EntityType copiedEntityType = oldTarget.getCopiedEntityType();
+                        if (copiedEntityType == null) {
+                            log.error(
+                                    "Attempting to create a TransUnitUpdateRequest but copiedEntityType is null");
+                        }
+                        final String copiedEntityTypeAbbr = copiedEntityType == null ? "" :copiedEntityType.getAbbr();
+
+                        final TranslationSourceType sourceType = oldTarget.getSourceType();
+                        if (sourceType == null) {
+                            log.error("Attempting to create a TransUnitUpdateRequest but sourceType is null");
+                        }
+                        final String sourceTypeAbbr = sourceType == null ? "" : sourceType.getAbbr();
+
                         TransUnitUpdateRequest request =
                                 new TransUnitUpdateRequest(tuId, oldContents,
                                         oldState, versionNum,
                                         oldTarget.getRevisionComment(),
-                                        oldTarget.getCopiedEntityId(), oldTarget
-                                                .getCopiedEntityType().getAbbr(),
-                                        oldTarget.getSourceType().getAbbr());
+                                        oldTarget.getCopiedEntityId(),
+                                        copiedEntityTypeAbbr,
+                                        sourceTypeAbbr);
                         // add to list
                         updateRequests.add(request);
                     } else {


### PR DESCRIPTION
https://zanata.atlassian.net/browse/ZNTA-640

There are two possible things that can be `null`, probably the latter since it has not been around as long. I'm logging both just in case.

I am not sure if it is appropriate to use an empty string instead of a valid abbreviation to prevent the exception. @aeng you wrote `TranslationSourceType` which is probably `null` here, what do you think?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/940)

<!-- Reviewable:end -->
