### PR TITLE
feat: add InternalLoginModule alias

### DIFF
--- a/zanata-war/src/main/java/org/zanata/security/jaas/InternalLoginModule.java
+++ b/zanata-war/src/main/java/org/zanata/security/jaas/InternalLoginModule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.security.jaas;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+public class InternalLoginModule extends org.jboss.seam.security.jaas.SeamLoginModule {
+}


### PR DESCRIPTION
This should make it easier for QA to switch between testing release and master, and also help anyone who follows the latest installation guide when deploying Zanata 3.7.