### PR TITLE
chore: use JVM version for tools jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1648,7 +1648,7 @@
               <dependency>
                 <groupId>sun.jdk</groupId>
                 <artifactId>tools</artifactId>
-                <version>1.6</version>
+                <version>${required.jvm}</version>
                 <scope>system</scope>
                 <systemPath>${java.home}/../lib/tools.jar</systemPath>
               </dependency>


### PR DESCRIPTION
We don't use Java 1.6 any more.