### PR TITLE
Add any missing foreign keys

### DIFF
--- a/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
+++ b/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
@@ -184,6 +184,11 @@
     </createIndex>
   </changeSet>
 
+  <changeSet author="sflaniga@redhat.com" id="2" dbms="mysql">
+    <comment>add foreign keys which may be missing due to MyISAM</comment>
+    <sqlFile path="db/mysql/add_missing_fks.sql" stripComments="true" />
+  </changeSet>
+
   <!-- TODO Ensure any new 3.7 tables are converted to InnoDB (on dev machines).
        See db.changelog-3.6.xml -->
 

--- a/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
+++ b/zanata-war/src/main/resources/db/changelogs/db.changelog-3.7.xml
@@ -186,7 +186,7 @@
 
   <changeSet author="sflaniga@redhat.com" id="2" dbms="mysql">
     <comment>add foreign keys which may be missing due to MyISAM</comment>
-    <sqlFile path="db/mysql/add_missing_fks.sql" stripComments="true" />
+    <sqlFile path="db/mysql/add_missing_fks.sql" stripComments="true" endDelimiter="\nGO" />
   </changeSet>
 
   <!-- TODO Ensure any new 3.7 tables are converted to InnoDB (on dev machines).

--- a/zanata-war/src/main/resources/db/mysql/add_missing_fks.sql
+++ b/zanata-war/src/main/resources/db/mysql/add_missing_fks.sql
@@ -1,0 +1,33 @@
+/*
+ * Warning: Please do not change this file!
+ * Any changes to the database schema should be added as
+ * Liquibase changeSets in db.changelog.xml
+ */
+
+ALTER TABLE Activity ADD CONSTRAINT FKActivity_person FOREIGN KEY IF NOT EXISTS (actor_id) REFERENCES HPerson(id);
+ALTER TABLE HAccountOption ADD CONSTRAINT FK_HAccountOption_HAccount FOREIGN KEY IF NOT EXISTS (account_id) REFERENCES HAccount(id);
+ALTER TABLE HCredentials ADD CONSTRAINT FK_credentials_account FOREIGN KEY IF NOT EXISTS (account_id) REFERENCES HAccount(id);
+ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_Locale FOREIGN KEY IF NOT EXISTS (localeId) REFERENCES HLocale(id);
+ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_ProjectIteration FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
+ALTER TABLE HDocumentUploadPart ADD CONSTRAINT FK_HDocumentUploadPart_DocumentUpload FOREIGN KEY IF NOT EXISTS (documentUploadId) REFERENCES HDocumentUpload(id);
+ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_Document FOREIGN KEY IF NOT EXISTS (documentId) REFERENCES HDocument(id);
+ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_RawDocument FOREIGN KEY IF NOT EXISTS (rawDocumentId) REFERENCES HRawDocument(id);
+ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_iterationGroupId FOREIGN KEY IF NOT EXISTS (iterationGroupId) REFERENCES HIterationGroup(id);
+ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_personId FOREIGN KEY IF NOT EXISTS (personId) REFERENCES HPerson(id);
+ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_iterationGroupId FOREIGN KEY IF NOT EXISTS (iterationGroupId) REFERENCES HIterationGroup(id);
+ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_projectIterationId FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
+ALTER TABLE HPersonEmailValidationKey ADD CONSTRAINT FK_HPersonEmailValidationKey_HPerson FOREIGN KEY IF NOT EXISTS (personId) REFERENCES HPerson(id);
+ALTER TABLE HProjectIteration_Validation ADD CONSTRAINT FK_HProjectIteration_Validation_HProjectIteration FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
+ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Project FOREIGN KEY IF NOT EXISTS (projectId) REFERENCES HProject(id);
+ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Role FOREIGN KEY IF NOT EXISTS (roleId) REFERENCES HAccountRole(id);
+ALTER TABLE HProject_Validation ADD CONSTRAINT FK_HProject_Validation_HProject FOREIGN KEY IF NOT EXISTS (projectId) REFERENCES HProject(id);
+ALTER TABLE HRoleAssignmentRule ADD CONSTRAINT FK_HRoleAssignmentRule_HAccountRole FOREIGN KEY IF NOT EXISTS (role_to_assign_id) REFERENCES HAccountRole(id);
+ALTER TABLE HTextFlowContentHistory ADD CONSTRAINT FKcontent_text_flow_history FOREIGN KEY IF NOT EXISTS (text_flow_history_id) REFERENCES HTextFlowHistory(id);
+ALTER TABLE HTextFlowTargetContentHistory ADD CONSTRAINT FKcontent_text_flow_target_history FOREIGN KEY IF NOT EXISTS (text_flow_target_history_id) REFERENCES HTextFlowTargetHistory(id);
+ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_comment FOREIGN KEY IF NOT EXISTS (target_id) REFERENCES HTextFlowTarget(id);
+ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_commenter FOREIGN KEY IF NOT EXISTS (commenter_id) REFERENCES HPerson(id);
+ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HIterationGroup FOREIGN KEY IF NOT EXISTS (iteration_group_id) REFERENCES HIterationGroup(id);
+ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HLocale FOREIGN KEY IF NOT EXISTS (locale_id) REFERENCES HLocale(id);
+ALTER TABLE TransMemoryUnit ADD CONSTRAINT FK_tmunit_trans_memory FOREIGN KEY IF NOT EXISTS (tm_id) REFERENCES TransMemory(id);
+ALTER TABLE TransMemoryUnitVariant ADD CONSTRAINT FK_TransUnitVariant_TransUnit FOREIGN KEY IF NOT EXISTS (trans_unit_id) REFERENCES TransMemoryUnit(id);
+ALTER TABLE TransMemory_Metadata ADD CONSTRAINT FK_Metadata_TransMemory FOREIGN KEY IF NOT EXISTS (trans_memory_id) REFERENCES TransMemory(id);

--- a/zanata-war/src/main/resources/db/mysql/add_missing_fks.sql
+++ b/zanata-war/src/main/resources/db/mysql/add_missing_fks.sql
@@ -4,30 +4,178 @@
  * Liquibase changeSets in db.changelog.xml
  */
 
-ALTER TABLE Activity ADD CONSTRAINT FKActivity_person FOREIGN KEY IF NOT EXISTS (actor_id) REFERENCES HPerson(id);
-ALTER TABLE HAccountOption ADD CONSTRAINT FK_HAccountOption_HAccount FOREIGN KEY IF NOT EXISTS (account_id) REFERENCES HAccount(id);
-ALTER TABLE HCredentials ADD CONSTRAINT FK_credentials_account FOREIGN KEY IF NOT EXISTS (account_id) REFERENCES HAccount(id);
-ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_Locale FOREIGN KEY IF NOT EXISTS (localeId) REFERENCES HLocale(id);
-ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_ProjectIteration FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
-ALTER TABLE HDocumentUploadPart ADD CONSTRAINT FK_HDocumentUploadPart_DocumentUpload FOREIGN KEY IF NOT EXISTS (documentUploadId) REFERENCES HDocumentUpload(id);
-ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_Document FOREIGN KEY IF NOT EXISTS (documentId) REFERENCES HDocument(id);
-ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_RawDocument FOREIGN KEY IF NOT EXISTS (rawDocumentId) REFERENCES HRawDocument(id);
-ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_iterationGroupId FOREIGN KEY IF NOT EXISTS (iterationGroupId) REFERENCES HIterationGroup(id);
-ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_personId FOREIGN KEY IF NOT EXISTS (personId) REFERENCES HPerson(id);
-ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_iterationGroupId FOREIGN KEY IF NOT EXISTS (iterationGroupId) REFERENCES HIterationGroup(id);
-ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_projectIterationId FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
-ALTER TABLE HPersonEmailValidationKey ADD CONSTRAINT FK_HPersonEmailValidationKey_HPerson FOREIGN KEY IF NOT EXISTS (personId) REFERENCES HPerson(id);
-ALTER TABLE HProjectIteration_Validation ADD CONSTRAINT FK_HProjectIteration_Validation_HProjectIteration FOREIGN KEY IF NOT EXISTS (projectIterationId) REFERENCES HProjectIteration(id);
-ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Project FOREIGN KEY IF NOT EXISTS (projectId) REFERENCES HProject(id);
-ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Role FOREIGN KEY IF NOT EXISTS (roleId) REFERENCES HAccountRole(id);
-ALTER TABLE HProject_Validation ADD CONSTRAINT FK_HProject_Validation_HProject FOREIGN KEY IF NOT EXISTS (projectId) REFERENCES HProject(id);
-ALTER TABLE HRoleAssignmentRule ADD CONSTRAINT FK_HRoleAssignmentRule_HAccountRole FOREIGN KEY IF NOT EXISTS (role_to_assign_id) REFERENCES HAccountRole(id);
-ALTER TABLE HTextFlowContentHistory ADD CONSTRAINT FKcontent_text_flow_history FOREIGN KEY IF NOT EXISTS (text_flow_history_id) REFERENCES HTextFlowHistory(id);
-ALTER TABLE HTextFlowTargetContentHistory ADD CONSTRAINT FKcontent_text_flow_target_history FOREIGN KEY IF NOT EXISTS (text_flow_target_history_id) REFERENCES HTextFlowTargetHistory(id);
-ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_comment FOREIGN KEY IF NOT EXISTS (target_id) REFERENCES HTextFlowTarget(id);
-ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_commenter FOREIGN KEY IF NOT EXISTS (commenter_id) REFERENCES HPerson(id);
-ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HIterationGroup FOREIGN KEY IF NOT EXISTS (iteration_group_id) REFERENCES HIterationGroup(id);
-ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HLocale FOREIGN KEY IF NOT EXISTS (locale_id) REFERENCES HLocale(id);
-ALTER TABLE TransMemoryUnit ADD CONSTRAINT FK_tmunit_trans_memory FOREIGN KEY IF NOT EXISTS (tm_id) REFERENCES TransMemory(id);
-ALTER TABLE TransMemoryUnitVariant ADD CONSTRAINT FK_TransUnitVariant_TransUnit FOREIGN KEY IF NOT EXISTS (trans_unit_id) REFERENCES TransMemoryUnit(id);
-ALTER TABLE TransMemory_Metadata ADD CONSTRAINT FK_Metadata_TransMemory FOREIGN KEY IF NOT EXISTS (trans_memory_id) REFERENCES TransMemory(id);
+/* DELIMITER GO */
+
+DROP PROCEDURE IF EXISTS zanataAddMissingFKs
+GO
+
+CREATE PROCEDURE zanataAddMissingFKs()
+BEGIN
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+           CONSTRAINT_SCHEMA = SCHEMA() AND
+           CONSTRAINT_NAME   = 'FKActivity_person' AND
+           CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE Activity ADD CONSTRAINT FKActivity_person FOREIGN KEY (actor_id) REFERENCES HPerson(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HAccountOption_HAccount' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HAccountOption ADD CONSTRAINT FK_HAccountOption_HAccount FOREIGN KEY (account_id) REFERENCES HAccount(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_credentials_account' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HCredentials ADD CONSTRAINT FK_credentials_account FOREIGN KEY (account_id) REFERENCES HAccount(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HDocumentUpload_Locale' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_Locale FOREIGN KEY (localeId) REFERENCES HLocale(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HDocumentUpload_ProjectIteration' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HDocumentUpload ADD CONSTRAINT FK_HDocumentUpload_ProjectIteration FOREIGN KEY (projectIterationId) REFERENCES HProjectIteration(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HDocumentUploadPart_DocumentUpload' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HDocumentUploadPart ADD CONSTRAINT FK_HDocumentUploadPart_DocumentUpload FOREIGN KEY (documentUploadId) REFERENCES HDocumentUpload(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HDocumentRawDocument_Document' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_Document FOREIGN KEY (documentId) REFERENCES HDocument(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HDocumentRawDocument_RawDocument' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HDocument_RawDocument ADD CONSTRAINT FK_HDocumentRawDocument_RawDocument FOREIGN KEY (rawDocumentId) REFERENCES HRawDocument(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKiterationGroupMaintainer_iterationGroupId' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_iterationGroupId FOREIGN KEY (iterationGroupId) REFERENCES HIterationGroup(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKiterationGroupMaintainer_personId' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HIterationGroup_Maintainer ADD CONSTRAINT FKiterationGroupMaintainer_personId FOREIGN KEY (personId) REFERENCES HPerson(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKiterationGroup_ProjectIteration_iterationGroupId' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_iterationGroupId FOREIGN KEY (iterationGroupId) REFERENCES HIterationGroup(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKiterationGroup_ProjectIteration_projectIterationId' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HIterationGroup_ProjectIteration ADD CONSTRAINT FKiterationGroup_ProjectIteration_projectIterationId FOREIGN KEY (projectIterationId) REFERENCES HProjectIteration(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HPersonEmailValidationKey_HPerson' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HPersonEmailValidationKey ADD CONSTRAINT FK_HPersonEmailValidationKey_HPerson FOREIGN KEY (personId) REFERENCES HPerson(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HProjectIteration_Validation_HProjectIteration' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HProjectIteration_Validation ADD CONSTRAINT FK_HProjectIteration_Validation_HProjectIteration FOREIGN KEY (projectIterationId) REFERENCES HProjectIteration(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HProjectAllowedRole_Project' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Project FOREIGN KEY (projectId) REFERENCES HProject(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HProjectAllowedRole_Role' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HProject_AllowedRole ADD CONSTRAINT FK_HProjectAllowedRole_Role FOREIGN KEY (roleId) REFERENCES HAccountRole(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HProject_Validation_HProject' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HProject_Validation ADD CONSTRAINT FK_HProject_Validation_HProject FOREIGN KEY (projectId) REFERENCES HProject(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_HRoleAssignmentRule_HAccountRole' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HRoleAssignmentRule ADD CONSTRAINT FK_HRoleAssignmentRule_HAccountRole FOREIGN KEY (role_to_assign_id) REFERENCES HAccountRole(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKcontent_text_flow_history' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HTextFlowContentHistory ADD CONSTRAINT FKcontent_text_flow_history FOREIGN KEY (text_flow_history_id) REFERENCES HTextFlowHistory(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKcontent_text_flow_target_history' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HTextFlowTargetContentHistory ADD CONSTRAINT FKcontent_text_flow_target_history FOREIGN KEY (text_flow_target_history_id) REFERENCES HTextFlowTargetHistory(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKtarget_review_comment' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_comment FOREIGN KEY (target_id) REFERENCES HTextFlowTarget(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FKtarget_review_commenter' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE HTextFlowTargetReviewComment ADD CONSTRAINT FKtarget_review_commenter FOREIGN KEY (commenter_id) REFERENCES HPerson(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_IterationGroup_Locale_HIterationGroup' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HIterationGroup FOREIGN KEY (iteration_group_id) REFERENCES HIterationGroup(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_IterationGroup_Locale_HLocale' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE IterationGroup_Locale ADD CONSTRAINT FK_IterationGroup_Locale_HLocale FOREIGN KEY (locale_id) REFERENCES HLocale(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_tmunit_trans_memory' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE TransMemoryUnit ADD CONSTRAINT FK_tmunit_trans_memory FOREIGN KEY (tm_id) REFERENCES TransMemory(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_TransUnitVariant_TransUnit' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE TransMemoryUnitVariant ADD CONSTRAINT FK_TransUnitVariant_TransUnit FOREIGN KEY (trans_unit_id) REFERENCES TransMemoryUnit(id);
+    END IF;
+    IF 0 = (SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS WHERE
+        CONSTRAINT_SCHEMA = SCHEMA() AND
+        CONSTRAINT_NAME   = 'FK_Metadata_TransMemory' AND
+        CONSTRAINT_TYPE   = 'FOREIGN KEY') THEN
+        ALTER TABLE TransMemory_Metadata ADD CONSTRAINT FK_Metadata_TransMemory FOREIGN KEY (trans_memory_id) REFERENCES TransMemory(id);
+    END IF;
+END
+GO
+CALL zanataAddMissingFKs()
+GO
+DROP PROCEDURE zanataAddMissingFKs
+GO


### PR DESCRIPTION
In the past, some Zanata environments defaulted to MyISAM for new
tables, and so some tables were MyISAM when we tried to create various
foreign keys. (MySQL silently ignores ADD FOREIGN KEY for MyISAM
tables.) This commit ensures that the affected foreign keys are
created if they don't exist.