### PR TITLE
fix(ZNTA-639): handle ViewExpiredException

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,7 @@
 * [ZNTA-634](https://zanata.atlassian.net/browse/ZNTA-634) - Users being logged out after a short period of inactivity
 * [ZNTA-719](https://zanata.atlassian.net/browse/ZNTA-719) - Translation merge targets the wrong source version
 * [ZNTA-718](https://zanata.atlassian.net/browse/ZNTA-718) - Allow admin and project maintainer to merge translation from all active projects.
+* [ZNTA-639](https://zanata.atlassian.net/browse/ZNTA-639) - Expired sessions causing ViewExpiredExceptions
 
 
 -----------------------

--- a/zanata-war/src/main/java/org/zanata/ZanataInit.java
+++ b/zanata-war/src/main/java/org/zanata/ZanataInit.java
@@ -66,7 +66,6 @@ import org.jboss.seam.annotations.Observer;
 import org.jboss.seam.annotations.Scope;
 import org.jboss.seam.contexts.ServletLifecycle;
 import org.jboss.seam.mail.MailSession;
-import org.jboss.seam.transaction.FacesTransactionEvents;
 import org.zanata.events.ServerStarted;
 import org.zanata.exception.ZanataInitializationException;
 import org.zanata.rest.dto.VersionInfo;
@@ -113,14 +112,8 @@ public class ZanataInit {
     @In
     private EntityManagerFactory entityManagerFactory;
 
-    @In
-    private FacesTransactionEvents facesTransactionEvents;
-
     @Observer("org.jboss.seam.postInitialization")
     public void initZanata() throws Exception {
-        // disable the automatic JSF message when a transaction fails
-        // TODO [CDI] Will not be needed after CDI migration
-        facesTransactionEvents.setTransactionFailedMessageEnabled(false);
         checkAppServerVersion();
         ServletContext servletContext =
                 ServletLifecycle.getCurrentServletContext();

--- a/zanata-war/src/main/java/org/zanata/ZanataInit.java
+++ b/zanata-war/src/main/java/org/zanata/ZanataInit.java
@@ -66,6 +66,7 @@ import org.jboss.seam.annotations.Observer;
 import org.jboss.seam.annotations.Scope;
 import org.jboss.seam.contexts.ServletLifecycle;
 import org.jboss.seam.mail.MailSession;
+import org.jboss.seam.transaction.FacesTransactionEvents;
 import org.zanata.events.ServerStarted;
 import org.zanata.exception.ZanataInitializationException;
 import org.zanata.rest.dto.VersionInfo;
@@ -112,8 +113,13 @@ public class ZanataInit {
     @In
     private EntityManagerFactory entityManagerFactory;
 
+    @In
+    private FacesTransactionEvents facesTransactionEvents;
+
     @Observer("org.jboss.seam.postInitialization")
     public void initZanata() throws Exception {
+        // disable the automatic JSF message when a transaction fails
+        facesTransactionEvents.setTransactionFailedMessageEnabled(false);
         checkAppServerVersion();
         ServletContext servletContext =
                 ServletLifecycle.getCurrentServletContext();

--- a/zanata-war/src/main/java/org/zanata/ZanataInit.java
+++ b/zanata-war/src/main/java/org/zanata/ZanataInit.java
@@ -119,6 +119,7 @@ public class ZanataInit {
     @Observer("org.jboss.seam.postInitialization")
     public void initZanata() throws Exception {
         // disable the automatic JSF message when a transaction fails
+        // TODO [CDI] Will not be needed after CDI migration
         facesTransactionEvents.setTransactionFailedMessageEnabled(false);
         checkAppServerVersion();
         ServletContext servletContext =

--- a/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandler.java
+++ b/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandler.java
@@ -87,7 +87,7 @@ public class AjaxViewExpiredExceptionHandler extends ExceptionHandlerWrapper {
         exception = unwrap(exception);
 
         if (exception instanceof ViewExpiredException) {
-            Messages msg =
+            Messages msgs =
                     ServiceLocator.instance().getInstance(Messages.class);
             FacesMessages jsfMessages =
                     ServiceLocator.instance().getInstance(
@@ -95,7 +95,7 @@ public class AjaxViewExpiredExceptionHandler extends ExceptionHandlerWrapper {
             HttpServletRequest request =
                     (HttpServletRequest) facesContext.getExternalContext()
                             .getRequest();
-            jsfMessages.addGlobal("Your session has expired. Please reload the page.");
+            jsfMessages.addGlobal(msgs.get("jsf.ViewExpiredException.AjaxError"));
 
             // Set the necessary servlet request attributes which a bit
             // decent error page may expect.

--- a/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandler.java
+++ b/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandler.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.exception;
+
+import static javax.servlet.RequestDispatcher.ERROR_EXCEPTION;
+import static javax.servlet.RequestDispatcher.ERROR_EXCEPTION_TYPE;
+import static javax.servlet.RequestDispatcher.ERROR_MESSAGE;
+import static javax.servlet.RequestDispatcher.ERROR_REQUEST_URI;
+import static javax.servlet.RequestDispatcher.ERROR_STATUS_CODE;
+
+import java.util.Iterator;
+
+import javax.el.ELException;
+import javax.faces.FacesException;
+import javax.faces.application.ViewExpiredException;
+import javax.faces.context.ExceptionHandler;
+import javax.faces.context.ExceptionHandlerWrapper;
+import javax.faces.context.FacesContext;
+import javax.faces.event.ExceptionQueuedEvent;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.zanata.i18n.Messages;
+import org.zanata.ui.faces.FacesMessages;
+import org.zanata.util.ServiceLocator;
+
+/**
+ * Exception handler for JSF's ViewExpiredException. This only comes into action
+ * for AJAX requets. For non-ajax handling see pages.xml
+ *
+ * This class is partially based on ideas from OmniFaces' Ajax exception handler.
+ * (https://github.com/omnifaces/omnifaces/blob/master/src/main/java/org/omnifaces/exceptionhandler/FullAjaxExceptionHandler.java)
+ *
+ * @author Carlos Munoz <a
+ *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
+ */
+public class AjaxViewExpiredExceptionHandler extends ExceptionHandlerWrapper {
+    private ExceptionHandler wrapped;
+
+    public AjaxViewExpiredExceptionHandler(ExceptionHandler wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public void handle() throws FacesException {
+        handleAjaxException();
+        wrapped.handle();
+    }
+
+    private void handleAjaxException() {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+
+        if (facesContext == null
+                || !facesContext.getPartialViewContext().isAjaxRequest()) {
+            return; // Not an ajax request.
+        }
+
+        Iterator<ExceptionQueuedEvent> unhandledExceptionQueuedEvents =
+                getUnhandledExceptionQueuedEvents().iterator();
+
+        if (!unhandledExceptionQueuedEvents.hasNext()) {
+            return; // There's no unhandled exception.
+        }
+
+        Throwable exception =
+                unhandledExceptionQueuedEvents.next().getContext()
+                        .getException();
+
+        exception = unwrap(exception);
+
+        if (exception instanceof ViewExpiredException) {
+            Messages msg =
+                    ServiceLocator.instance().getInstance(Messages.class);
+            FacesMessages jsfMessages =
+                    ServiceLocator.instance().getInstance(
+                            FacesMessages.class);
+            HttpServletRequest request =
+                    (HttpServletRequest) facesContext.getExternalContext()
+                            .getRequest();
+            jsfMessages.addGlobal("Your session has expired. Please reload the page.");
+
+            // Set the necessary servlet request attributes which a bit
+            // decent error page may expect.
+            request.setAttribute(ERROR_EXCEPTION, exception);
+            request.setAttribute(ERROR_EXCEPTION_TYPE, exception.getClass());
+            request.setAttribute(ERROR_MESSAGE, exception.getMessage());
+            request.setAttribute(ERROR_REQUEST_URI, request.getRequestURI());
+            request.setAttribute(ERROR_STATUS_CODE,
+                    HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+            unhandledExceptionQueuedEvents.remove();
+        }
+    }
+
+    @Override
+    public ExceptionHandler getWrapped() {
+        return wrapped;
+    }
+
+    private static <T extends Throwable> Throwable unwrap(Throwable exception,
+            Class<T> type) {
+        Throwable unwrappedException = exception;
+        while (type.isInstance(unwrappedException)
+                && unwrappedException.getCause() != null) {
+            unwrappedException = unwrappedException.getCause();
+        }
+        return unwrappedException;
+    }
+
+    /**
+     * Unwraps exceptions fired as ELException or FacesException only.
+     *
+     * @param exception
+     * @return
+     */
+    private static Throwable unwrap(Throwable exception) {
+        return unwrap(unwrap(exception, FacesException.class),
+                ELException.class);
+    }
+}

--- a/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandlerFactory.java
+++ b/zanata-war/src/main/java/org/zanata/exception/AjaxViewExpiredExceptionHandlerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.exception;
+
+import javax.faces.context.ExceptionHandler;
+import javax.faces.context.ExceptionHandlerFactory;
+
+/**
+ * Exception Handler factory for ViewExpiredException handlers.
+ * This class should be configured in faces-config.xml for use.
+ * @author Carlos Munoz <a
+ *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
+ */
+public class AjaxViewExpiredExceptionHandlerFactory extends
+        ExceptionHandlerFactory {
+
+    private ExceptionHandlerFactory parent;
+
+    public AjaxViewExpiredExceptionHandlerFactory(
+            ExceptionHandlerFactory parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public ExceptionHandler getExceptionHandler() {
+        return new AjaxViewExpiredExceptionHandler(parent.getExceptionHandler());
+    }
+}

--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -935,8 +935,10 @@ jsf.ErrorTitle=We're sorry
 jsf.NoErrors=No errors
 jsf.YouCanHelpUs=But you can help us fix it!
 jsf.ReportThisProblem=Report this problem
-
-
+jsf.ViewExpiredException.Error.PageTitle=Session expired
+jsf.ViewExpiredException.ErrorTitle=You have been away for too long...
+jsf.ViewExpiredException.Error=... and your session has expired. Please click the button below to go back to the original page or hit back on your browser.
+jsf.ViewExpiredException.GoBack=Go Back
 
 #------ [home] > My Profile ------
 jsf.EditProfile=Edit Profile

--- a/zanata-war/src/main/resources/messages.properties
+++ b/zanata-war/src/main/resources/messages.properties
@@ -938,6 +938,7 @@ jsf.ReportThisProblem=Report this problem
 jsf.ViewExpiredException.Error.PageTitle=Session expired
 jsf.ViewExpiredException.ErrorTitle=You have been away for too long...
 jsf.ViewExpiredException.Error=... and your session has expired. Please click the button below to go back to the original page or hit back on your browser.
+jsf.ViewExpiredException.AjaxError=Your session has expired. Please reload the page.
 jsf.ViewExpiredException.GoBack=Go Back
 
 #------ [home] > My Profile ------

--- a/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/components.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/classes/META-INF/components.xml
@@ -45,6 +45,10 @@
   <!--   <component name="org.jboss.seam.async.dispatcher" class="org.jboss.seam.async.QuartzDispatcher"/> -->
   <component class="org.jboss.seam.async.QuartzDispatcher" />
 
+  <!-- Disable the automatic transaction JSF messages -->
+  <component class="org.jboss.seam.transaction.FacesTransactionEvents"
+    installed="false"/>
+
   <resteasy:application resource-path-prefix="/restv1" />
 
   <web:multipart-filter create-temp-files="false"

--- a/zanata-war/src/main/webapp/WEB-INF/faces-config.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/faces-config.xml
@@ -57,6 +57,10 @@
     <phase-listener>org.zanata.ui.faces.FacesMessagesPhaseListener</phase-listener>
   </lifecycle>
 
+  <factory>
+    <exception-handler-factory>org.zanata.exception.AjaxViewExpiredExceptionHandlerFactory</exception-handler-factory>
+  </factory>
+
   <render-kit>
     <renderer>
       <component-family>javax.faces.Input</component-family>

--- a/zanata-war/src/main/webapp/WEB-INF/pages.xml
+++ b/zanata-war/src/main/webapp/WEB-INF/pages.xml
@@ -419,7 +419,7 @@
 
   <exception class="javax.faces.application.ViewExpiredException"
     log-level="debug">
-    <redirect view-id="/error.xhtml">
+    <redirect view-id="/error/viewexpiredexception.xhtml">
       <message
         severity="warn">#{msgs['jsf.YourSessionHasTimedOutPleaseTryAgain']}
       </message>

--- a/zanata-war/src/main/webapp/error/viewexpiredexception.xhtml
+++ b/zanata-war/src/main/webapp/error/viewexpiredexception.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:ui="http://java.sun.com/jsf/facelets"
+  xmlns:h="http://java.sun.com/jsf/html"
+  template="../WEB-INF/template/template.xhtml">
+
+  <ui:define name="page_title">#{msgs['jsf.ViewExpiredException.Error.PageTitle']}</ui:define>
+  <ui:param name="showGlobalMessages" value="false"/>
+  <ui:define name="center_content">
+    <ui:fragment>
+      <ul class="list--no-bullets">
+        <li>
+          <div class="alert">
+            <h2 class="alert__heading">#{msgs['jsf.ViewExpiredException.ErrorTitle']}</h2>
+
+            <div class="alert__content">
+              <ul class="list--no-bullets">
+                <li><h:outputText escape="false" value="#{msgs['jsf.ViewExpiredException.Error']}"/></li>
+              </ul>
+
+              <p>
+                <button
+                  onclick="window.history.back();">
+                  #{msgs['jsf.ViewExpiredException.GoBack']}
+                </button>
+              </p>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </ui:fragment>
+  </ui:define>
+</ui:composition>


### PR DESCRIPTION
Handle these type of exceptions both in ajax and non-ajax requests.
For ajax requests, inform the user and ask them to reload.
For non-ajax requests, inform the user and offer to head back to the
original page.

https://zanata.atlassian.net/browse/ZNTA-639