### PR TITLE
chore: move zanatasearchindex under target dir in tests

### DIFF
--- a/zanata-war/src/test/resources/META-INF/persistence.xml
+++ b/zanata-war/src/test/resources/META-INF/persistence.xml
@@ -106,7 +106,7 @@
       <property name="hibernate.search.default.directory_provider"
         value="org.hibernate.search.store.impl.FSDirectoryProvider" />
       <property name="hibernate.search.default.indexBase"
-        value="zanatasearchindex" />
+        value="./target/zanatasearchindex" />
       <property name="hibernate.search.lucene_version" value="LUCENE_36" />
       <property name="hibernate.search.worker.batch_size" value="50" />
 

--- a/zanata-war/src/test/resources/arquillian/persistence.xml
+++ b/zanata-war/src/test/resources/arquillian/persistence.xml
@@ -99,7 +99,7 @@
       <property name="hibernate.search.default.directory_provider"
         value="org.hibernate.search.store.impl.FSDirectoryProvider" />
       <property name="hibernate.search.default.indexBase"
-        value="zanatasearchindex" />
+        value="./target/zanatasearchindex" />
       <property name="hibernate.search.lucene_version" value="LUCENE_36" />
       <property name="hibernate.search.worker.batch_size" value="50" />
 


### PR DESCRIPTION
... instead of creating `zanatasearchindex` in current directory, which prevents `mvn clean` from doing its job (eg when Lucene lock files are lying around)