### PR TITLE
Work around path problem for JavaMelody

### DIFF
--- a/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
+++ b/zanata-war/src/main/webapp-jboss/WEB-INF/web.xml
@@ -118,6 +118,11 @@
     <param-value>java:jboss/datasources/zanataDatasource</param-value>
   </context-param>
 
+  <context-param>
+    <param-name>javamelody.monitoring-path</param-name>
+    <param-value>/admin/monitoring</param-value>
+  </context-param>
+
   <!-- Zanata custom taglib -->
   <context-param>
     <param-name>javax.faces.FACELETS_LIBRARIES</param-name>
@@ -163,10 +168,6 @@
   <filter>
     <filter-name>monitoring</filter-name>
     <filter-class>org.zanata.seam.interceptor.MonitoringWrapper</filter-class>
-    <init-param>
-      <param-name>monitoring-path</param-name>
-      <param-value>/admin/monitoring</param-value>
-    </init-param>
   </filter>
   <filter-mapping>
     <filter-name>monitoring</filter-name>


### PR DESCRIPTION
On some platforms, the MonitoringFilter has no init parameters
by the time requests come in, which causes JavaMelody to appear
under /monitoring instead of /admin/monitoring. This change uses
a servlet context parameter instead of a filter parameter.