### PR TITLE
Fix email message generated when user joining team

### DIFF
--- a/zanata-war/src/main/resources/org/zanata/email/templates/email_request_to_join_language.vm
+++ b/zanata-war/src/main/resources/org/zanata/email/templates/email_request_to_join_language.vm
@@ -30,7 +30,7 @@
 </p>
 
 #if ($htmlMessage)
-  <p>$msgs.format("jsf.email.UserMessageIntro", $fromName)</p>
+  <p>$msgs.format("jsf.email.UserMessageIntro", $fromLoginName)</p>
   <hr/>
   $htmlMessage
   <hr/>


### PR DESCRIPTION
It was:
> You can add user with username "Some User" to the "xx" team as translator using the "Add Team Member" action on the language team page.

whereas it should have been:

> You can add user with username "some_username" to the "xx" team as translator using the "Add Team Member" action on the language team page.