### PR TITLE
ZNTA-758 Glossary Usability

### DIFF
--- a/frontend/src/main/web/index.css
+++ b/frontend/src/main/web/index.css
@@ -1,1 +1,0 @@
-@import 'zanata-ui/lib/styles/index.css';

--- a/frontend/src/main/web/index.html
+++ b/frontend/src/main/web/index.html
@@ -2,7 +2,7 @@
 <head lang="en">
   <meta charset="UTF-8">
   <meta name='viewport' content='width=device-width,initial-scale=1'>
-  <!--<link type="text/css" rel="stylesheet" href="http://localhost:5000/assets/css/style.css">-->
+  <link type="text/css" rel="stylesheet" href="bundle.css">
   <title>Zanata</title>
   <script type="text/javascript">
     WebFontConfig = {

--- a/frontend/src/main/web/index.js
+++ b/frontend/src/main/web/index.js
@@ -5,7 +5,7 @@ import Views from './lib/constants/Views.js';
 import Configs from './lib/constants/Configs';
 import StringUtils from './lib/utils/StringUtils';
 import _ from 'lodash';
-import css from './index.css'
+import 'zanata-ui/lib/styles/index.css'
 
 /**
  * Process attributes in dom element:id='main-content'

--- a/frontend/src/main/web/lib/components/SystemGlossary.jsx
+++ b/frontend/src/main/web/lib/components/SystemGlossary.jsx
@@ -68,13 +68,33 @@ var SystemGlossary = React.createClass({
     }, 500);
   },
 
+  _currentLocaleCount: function () {
+    const locales = this.state.localeOptions
+    const selectedTransLocale = this.state.selectedTransLocale
+    return _.result(_.find(locales, function(locale) {
+      return locale.value === selectedTransLocale
+    }), 'count')
+  },
+
   render: function() {
     const srcLocale = this.state.srcLocale;
-    var count = 0,
-      selectedTransLocale = this.state.selectedTransLocale,
-      uploadSection,
-      newEntrySection,
-      messageModal;
+    let count = 0
+    let selectedTransLocale = this.state.selectedTransLocale
+    let uploadSection
+    let newEntrySection
+    let messageModal
+    const currentLocaleCount = this._currentLocaleCount()
+
+    let optionOutput = (op) => {
+      let count = op.count || 0
+      return (
+        <span className='dfx aic jcsb'>
+          <span className='fxauto tove ovh whsnw' title={op.label}>{op.label}</span>
+          <span className='fxnone csec pl1/8 tove ovh whsnw tar maw4'>{op.value}</span>
+          <span className='fxnone csec50 pl1/8 tove ovh whsnw tar w2'>{count}</span>
+        </span>
+      )
+    }
 
     if(this.state.notification) {
       messageModal = <MessageModal value={this.state.notification}/>;
@@ -96,6 +116,13 @@ var SystemGlossary = React.createClass({
       loader = (<Loader className='csec ml1/2' size={3}/>);
     }
 
+    const currentLocaleCountComponent = (currentLocaleCount >= 0) ? (
+      <span className='df aic'>
+        <Icon name='translate' className='csec50 mr1/8' />
+        <span className='csec'>{currentLocaleCount}</span>
+      </span>
+    ) : null
+
     return (
       <div>
         <Icons />
@@ -109,6 +136,7 @@ var SystemGlossary = React.createClass({
               className='wmi8'
               value={this.state.selectedTransLocale}
               options={this.state.localeOptions}
+              optionRenderer={optionOutput}
               onChange={this._onTranslationLocaleChange}/>
             {loader}
           </div>
@@ -127,7 +155,7 @@ var SystemGlossary = React.createClass({
                 icon='search'
                 border='outline'
                 resetButton
-                loading={this.state.loadingEntries && this.state.filter}
+                loading={!!this.state.loadingEntries && !!this.state.filter}
                 onReset={this._handleFilterReset}
                 placeholder='Search Glossary'
                 id="search"
@@ -136,7 +164,8 @@ var SystemGlossary = React.createClass({
             </div>
           </div>
           <div className='dfx aic'>
-            <Icon name='glossary' className='csec50 mr1/4' />
+            {currentLocaleCountComponent}
+            <Icon name='glossary' className='csec50 ml1/4 mr1/8' />
             <span className='csec'>{count}</span>
           </div>
         </div>

--- a/frontend/src/main/web/lib/components/SystemGlossary.jsx
+++ b/frontend/src/main/web/lib/components/SystemGlossary.jsx
@@ -75,18 +75,6 @@ var SystemGlossary = React.createClass({
       messageModal = <MessageModal value={this.state.notification}/>;
     }
 
-    var contents = (<DataTable
-      glossaryData={this.state.glossary}
-      glossaryIds={this.state.glossaryIds}
-      focusedRow={this.state.focusedRow}
-      hoveredRow={this.state.hoveredRow}
-      totalCount={this.state.totalCount}
-      canAddNewEntry={this.state.canAddNewEntry}
-      canUpdateEntry={this.state.canUpdateEntry}
-      user={Configs.user}
-      srcLocale={srcLocale}
-      selectedTransLocale={selectedTransLocale}/>);
-
     if(!_.isUndefined(srcLocale) && !_.isNull(srcLocale)) {
       count = this.state.srcLocale.numberOfTerms;
     }
@@ -100,7 +88,7 @@ var SystemGlossary = React.createClass({
     var loader;
 
     if(this.state.loadingEntries) {
-      loader = (<Loader size={3}/>);
+      loader = (<Loader className='csec' size={3}/>);
     }
 
     return (
@@ -108,12 +96,12 @@ var SystemGlossary = React.createClass({
         <Icons />
         <div className='dfx aic mb1'>
           <div className='fxauto dfx aic'>
-            <h1 className='fz2 dib csec'>System Glossary</h1>
+            <h1 className='fz2 dib csec whsnw tove ovh'>System Glossary</h1>
             <Icon name='chevron-right' className='mh1/2 csec50' size='s1'/>
             <Select
               name='language-selection'
               placeholder='Select a language…'
-              className='w16'
+              className='wmi8'
               value={this.state.selectedTransLocale}
               options={this.state.localeOptions}
               onChange={this._onTranslationLocaleChange}/>
@@ -146,7 +134,20 @@ var SystemGlossary = React.createClass({
           </div>
         </div>
         <div>
-          {contents}
+          <DataTable
+            glossaryData={this.state.glossary}
+            glossaryIds={this.state.glossaryIds}
+            focusedRow={this.state.focusedRow}
+            hoveredRow={this.state.hoveredRow}
+            totalCount={this.state.totalCount}
+            canAddNewEntry={this.state.canAddNewEntry}
+            canUpdateEntry={this.state.canUpdateEntry}
+            user={Configs.user}
+            srcLocale={srcLocale}
+            locales={this.state.locales}
+            allowNewEntry={allowNewEntry}
+            loading={this.state.loadingEntries}
+            selectedTransLocale={selectedTransLocale}/>
         </div>
       </div>
     );

--- a/frontend/src/main/web/lib/components/SystemGlossary.jsx
+++ b/frontend/src/main/web/lib/components/SystemGlossary.jsx
@@ -52,14 +52,19 @@ var SystemGlossary = React.createClass({
     }
   },
 
+  _handleFilterReset: function (event) {
+    this.setState({filter: ''})
+    Actions.updateFilter('')
+  },
+
   _handleFilterChange: function(event) {
     this.setState({filter: event.target.value});
 
-    if(this.filterTimeout !== null) {
+    if(this.filterTimeout) {
       clearTimeout(this.filterTimeout);
     }
     this.filterTimeout = setTimeout(() => {
-      Actions.updateFilter(this.state.filter);
+      Actions.updateFilter(this.state.filter)
     }, 500);
   },
 
@@ -88,13 +93,13 @@ var SystemGlossary = React.createClass({
     var loader;
 
     if(this.state.loadingEntries) {
-      loader = (<Loader className='csec' size={3}/>);
+      loader = (<Loader className='csec ml1/2' size={3}/>);
     }
 
     return (
       <div>
         <Icons />
-        <div className='dfx aic mb1'>
+        <div className='dfx aic mb2'>
           <div className='fxauto dfx aic'>
             <h1 className='fz2 dib csec whsnw tove ovh'>System Glossary</h1>
             <Icon name='chevron-right' className='mh1/2 csec50' size='s1'/>
@@ -113,15 +118,17 @@ var SystemGlossary = React.createClass({
             {newEntrySection}
           </div>
         </div>
-        <div className='dfx aic mb1'>
+        <div className='dfx aic mb1/2'>
           <div className='fxauto'>
-            <div className='w8'>
+            <div className='maw16'>
               <Input value={this.state.filter}
                 label='Search Glossary'
                 hideLabel
-                className="w100p pr1&1/2"
+                icon='search'
                 border='outline'
-                reset
+                resetButton
+                loading={this.state.loadingEntries && this.state.filter}
+                onReset={this._handleFilterReset}
                 placeholder='Search Glossary'
                 id="search"
                 onKeyDown={this._handleFilterKeyDown}
@@ -145,6 +152,7 @@ var SystemGlossary = React.createClass({
             user={Configs.user}
             srcLocale={srcLocale}
             locales={this.state.locales}
+            filter={this.state.filter}
             allowNewEntry={allowNewEntry}
             loading={this.state.loadingEntries}
             selectedTransLocale={selectedTransLocale}/>

--- a/frontend/src/main/web/lib/components/glossary/DataTable.jsx
+++ b/frontend/src/main/web/lib/components/glossary/DataTable.jsx
@@ -99,7 +99,7 @@ var DataTable = React.createClass({
    * @param  top : number - the position of the top of the DataTable. If not supplied, the top position will be calculated based on DOM height.
    */
   _getHeight: function(top) {
-    var footer = window.document.getElementById("footer");
+    var footer = window.document.querySelector('.js-footer');
     var footerHeight = footer ? footer.clientHeight : 91;
 
     top = _.isUndefined(top) ? React.findDOMNode(this).offsetTop: top;
@@ -259,7 +259,7 @@ var DataTable = React.createClass({
   _renderPosCell: function (id, cellDataKey, rowData, rowIndex,
                             columnData, width) {
     var readOnly = !this.props.canUpdateEntry || this._isTranslationSelected(),
-      placeholder = 'enter part of speech';
+      placeholder = 'Noun, Verb, etc';
     return this._renderCell({
       id: id,
       rowIndex: rowIndex,

--- a/frontend/src/main/web/lib/components/glossary/DataTable.jsx
+++ b/frontend/src/main/web/lib/components/glossary/DataTable.jsx
@@ -1,12 +1,15 @@
 import React, {PureRenderMixin} from 'react/addons';
 import Actions from '../../actions/GlossaryActions';
 import {Table, Column} from 'fixed-data-table';
+import { Button, Icon } from 'zanata-ui';
 import StringUtils from '../../utils/StringUtils'
 import InputCell from './InputCell';
 import LoadingCell from './LoadingCell'
 import ActionCell from './ActionCell'
 import SourceActionCell from './SourceActionCell'
 import ColumnHeader from './ColumnHeader'
+import NewEntryModal from './NewEntryModal'
+import ImportModal from './ImportModal'
 import _ from 'lodash';
 
 var DataTable = React.createClass({
@@ -74,7 +77,10 @@ var DataTable = React.createClass({
     focusedRow: React.PropTypes.shape({
       id: React.PropTypes.number,
       rowIndex: React.PropTypes.number
-    })
+    }),
+    locales: React.PropTypes.object,
+    allowNewEntry: React.PropTypes.bool,
+    loading: React.PropTypes.bool
   },
 
   getInitialState: function () {
@@ -446,19 +452,14 @@ var DataTable = React.createClass({
   },
 
   render: function() {
-    var columns = [];
-
-    columns.push(this._getSourceColumn());
-    if(this._isTranslationSelected()) {
-      columns.push(this._getTransColumn());
-    } else {
-      columns.push(this._getTransCountColumn());
-    }
-    columns.push(this._getPosColumn());
-    columns.push(this._getDescColumn());
-    columns.push(this._getActionColumn());
-
-    return (
+    const columns = [
+      this._getSourceColumn(),
+      this._isTranslationSelected() ? this._getTransColumn() : this._getTransCountColumn(),
+      this._getPosColumn(),
+      this._getDescColumn(),
+      this._getActionColumn()
+    ]
+    const termTable = (
       <Table
         onRowClick={this._onRowClick}
         onRowMouseEnter={this._onRowMouseEnter}
@@ -472,7 +473,24 @@ var DataTable = React.createClass({
         headerHeight={this.CELL_HEIGHT}>
         {columns}
       </Table>
-    );
+    )
+    const addTerms = this.props.allowNewEntry ? (
+      <span className='ml1/4 difx aic'> Add a <NewEntryModal className='mh1/4' srcLocale={this.props.srcLocale}/> or <ImportModal className='ml1/4' srcLocale={this.props.srcLocale} transLocales={this.props.locales}/>.</span>
+    ) : null
+    const emptyState = !this.props.totalCount && !this.props.loading ? (
+      <div className='posa a0 mt2 df aic jcc'>
+        <p className='csec50 df aic'>
+          <Icon name='info' size='1' className='mr1/4'/>
+          No terms have been entered. {addTerms}
+        </p>
+      </div>
+    ) : null
+    return (
+      <div className='posr'>
+        {termTable}
+        {emptyState}
+      </div>
+    )
   }
 });
 

--- a/frontend/src/main/web/lib/components/glossary/DataTable.jsx
+++ b/frontend/src/main/web/lib/components/glossary/DataTable.jsx
@@ -1,7 +1,7 @@
 import React, {PureRenderMixin} from 'react/addons';
 import Actions from '../../actions/GlossaryActions';
 import {Table, Column} from 'fixed-data-table';
-import { Button, Icon } from 'zanata-ui';
+import { Button, Icon, Tooltip, OverlayTrigger } from 'zanata-ui';
 import StringUtils from '../../utils/StringUtils'
 import InputCell from './InputCell';
 import LoadingCell from './LoadingCell'
@@ -198,15 +198,23 @@ var DataTable = React.createClass({
     Actions.updateSortOrder(field, ascending);
   },
 
-  _renderCell: function ({ id, rowIndex, field, readOnly, placeholder, maxLength }) {
-    var key = this._generateKey(field.col, rowIndex, id);
+  _renderCell: function ({ id, rowIndex, field, readOnly, placeholder, maxLength, tooltip }) {
+    var key = this._generateKey(field.col, rowIndex, id)
     if (id === null) {
       return <LoadingCell key={key}/>;
     } else {
-      var entry = this._getGlossaryEntry(id);
-      var value = _.get(entry, field.field);
-      if (readOnly) {
-        return <span className="mh1/2" key={key}>{value}</span>;
+      const entry = this._getGlossaryEntry(id)
+      const value = _.get(entry, field.field)
+      const tooltipContent = tooltip ? (<Tooltip id={key}>{value}</Tooltip>) : null
+      const readonlyValue = <span className="mh1/2 db ovh tove" key={key}>{value}</span>
+      if (readOnly && tooltip) {
+        return (
+          <OverlayTrigger placement='top' rootClose overlay={tooltipContent}>
+            {readonlyValue}
+          </OverlayTrigger>
+        )
+      } else if (readOnly) {
+        return readonlyValue
       } else {
         return (
           <InputCell
@@ -271,7 +279,8 @@ var DataTable = React.createClass({
       field: this.ENTRY.DESC,
       readOnly: readOnly,
       placeholder: placeholder,
-      maxLength: 255
+      maxLength: 255,
+      tooltip: true
     });
   },
 

--- a/frontend/src/main/web/lib/components/glossary/DataTable.jsx
+++ b/frontend/src/main/web/lib/components/glossary/DataTable.jsx
@@ -80,7 +80,8 @@ var DataTable = React.createClass({
     }),
     locales: React.PropTypes.object,
     allowNewEntry: React.PropTypes.bool,
-    loading: React.PropTypes.bool
+    loading: React.PropTypes.bool,
+    filter: React.PropTypes.string
   },
 
   getInitialState: function () {
@@ -486,7 +487,15 @@ var DataTable = React.createClass({
     const addTerms = this.props.allowNewEntry ? (
       <span className='ml1/4 difx aic'> Add a <NewEntryModal className='mh1/4' srcLocale={this.props.srcLocale}/> or <ImportModal className='ml1/4' srcLocale={this.props.srcLocale} transLocales={this.props.locales}/>.</span>
     ) : null
-    const emptyState = !this.props.totalCount && !this.props.loading ? (
+    const noResultsState = this.props.filter && !this.props.totalCount && !this.props.loading ? (
+      <div className='posa a0 mt2 df aic jcc'>
+        <p className='csec50 df aic'>
+          <Icon name='info' size='1' className='mr1/4'/>
+          No results for "{this.props.filter}". Maybe try another search.
+        </p>
+      </div>
+    ) : null
+    const emptyState = !this.props.filter && !this.props.totalCount && !this.props.loading ? (
       <div className='posa a0 mt2 df aic jcc'>
         <p className='csec50 df aic'>
           <Icon name='info' size='1' className='mr1/4'/>
@@ -497,6 +506,7 @@ var DataTable = React.createClass({
     return (
       <div className='posr'>
         {termTable}
+        {noResultsState}
         {emptyState}
       </div>
     )

--- a/frontend/src/main/web/lib/components/glossary/ImportModal.jsx
+++ b/frontend/src/main/web/lib/components/glossary/ImportModal.jsx
@@ -123,7 +123,7 @@ var ImportModal = React.createClass({
 
     return (
       <div className={this.props.className}>
-        <Button onClick={this._showModal} link>
+        <Button className='whsnw tove ovh' onClick={this._showModal} link>
           <Icon name='import' className='mr1/4' /><span>Import Glossary</span>
         </Button>
         <Modal show={this.state.show} onHide={this._closeModal}>

--- a/frontend/src/main/web/lib/components/glossary/NewEntryModal.jsx
+++ b/frontend/src/main/web/lib/components/glossary/NewEntryModal.jsx
@@ -85,7 +85,7 @@ var NewEntryModal = React.createClass({
   render: function () {
     return (
       <div className={this.props.className}>
-        <Button onClick={this._showModal} link>
+        <Button className='whsnw tove ovh' onClick={this._showModal} link>
           <Icon name='plus' className='mr1/8'/><span>New Term</span>
         </Button>
         <Modal show={this.state.show} onHide={this._closeModal}>

--- a/frontend/src/main/web/lib/components/glossary/NewEntryModal.jsx
+++ b/frontend/src/main/web/lib/components/glossary/NewEntryModal.jsx
@@ -101,6 +101,7 @@ var NewEntryModal = React.createClass({
               placeholder='The new term'
               onChange={this._onTermChange}
               onReset={this._onTermReset}
+              autoFocus
               />
 
             <Input

--- a/frontend/src/main/web/lib/stores/GlossaryStore.js
+++ b/frontend/src/main/web/lib/stores/GlossaryStore.js
@@ -78,7 +78,8 @@ function processLocalesStatistic(res) {
       _state.locales[transLocale.locale.localeId] = transLocale;
       _state.localeOptions.push({
         value: transLocale.locale.localeId,
-        label: `${transLocale.locale.displayName} - (${transLocale.numberOfTerms})`
+        label: transLocale.locale.displayName,
+        count: transLocale.numberOfTerms
       });
     });
   }

--- a/frontend/src/main/web/package.json
+++ b/frontend/src/main/web/package.json
@@ -15,6 +15,7 @@
     "babel-loader": "^4.0.0",
     "css-loader": "^0.16.0",
     "cssnext-loader": "^1.0.1",
+    "extract-text-webpack-plugin": "^0.9.1",
     "jest-cli": "^0.4.18",
     "jsx-loader": "^0.12.2",
     "react-hot-loader": "^1.1.1",
@@ -39,7 +40,7 @@
     "react-chartjs": "^0.4.0",
     "react-router": "^0.13.3",
     "superagent": "^0.21.0",
-    "zanata-ui": "^1.0.9"
+    "zanata-ui": "^1.0.11"
   },
   "jest": {
     "unmockedModulePathPatterns": [

--- a/frontend/src/main/web/package.json
+++ b/frontend/src/main/web/package.json
@@ -39,7 +39,7 @@
     "react-chartjs": "^0.4.0",
     "react-router": "^0.13.3",
     "superagent": "^0.21.0",
-    "zanata-ui": "^1.0.7"
+    "zanata-ui": "^1.0.8"
   },
   "jest": {
     "unmockedModulePathPatterns": [

--- a/frontend/src/main/web/package.json
+++ b/frontend/src/main/web/package.json
@@ -39,7 +39,7 @@
     "react-chartjs": "^0.4.0",
     "react-router": "^0.13.3",
     "superagent": "^0.21.0",
-    "zanata-ui": "^1.0.8"
+    "zanata-ui": "^1.0.9"
   },
   "jest": {
     "unmockedModulePathPatterns": [

--- a/frontend/src/main/web/webpack.config.js
+++ b/frontend/src/main/web/webpack.config.js
@@ -1,4 +1,5 @@
-var webpack = require('webpack');
+var webpack = require('webpack')
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 module.exports = {
   context: __dirname,
@@ -6,7 +7,7 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',
-    './index',
+    './index'
   ],
   output: {
     path: __dirname,
@@ -22,7 +23,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loaders: ['style', 'css', 'cssnext']
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader?safe')
       }
     ]
   },
@@ -36,7 +37,8 @@ module.exports = {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.DefinePlugin({ "global.GENTLY": false }),
+    new ExtractTextPlugin('bundle.css'),
+    new webpack.DefinePlugin({ 'global.GENTLY': false }),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new webpack.NoErrorsPlugin()
   ],
@@ -46,4 +48,4 @@ module.exports = {
   node: {
     __dirname: true
   }
-};
+}

--- a/frontend/src/main/web/webpack.prod.config.js
+++ b/frontend/src/main/web/webpack.prod.config.js
@@ -1,5 +1,6 @@
-var webpack = require('webpack');
-var path = require('path');
+var webpack = require('webpack')
+var path = require('path')
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 // bundle destination (default is current directory)
 var bundleDest = process.env.npm_config_env_bundleDest || __dirname;
@@ -23,7 +24,7 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loaders: ['style', 'css', 'cssnext']
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader?safe')
       }
     ]
   },
@@ -38,6 +39,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({ "global.GENTLY": false }),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new ExtractTextPlugin('bundle.css'),
     new webpack.optimize.UglifyJsPlugin({
         compress: {
             warnings: false

--- a/zanata-war/src/main/webapp/WEB-INF/template/template_ui.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/template/template_ui.xhtml
@@ -32,6 +32,8 @@
     <link type="text/css" rel="stylesheet" href="#{assets['css/style.min.css']}"/>
     <!--<![endif]-->
 
+    <link type="text/css" rel="stylesheet" href="#{request.contextPath}/bundle.css"/>
+
     <!--[if (lt IE 9) & (!IEMobile)]>
     <script src="js/vendor/selectivizr-min.js"></script>
     <![endif]-->


### PR DESCRIPTION
Should fix these problems:

- Add search, loading and reset icons to filter input
- Make it more obvious to select a language
- Grey out info icons if they have no information
- Add empty state if there are no terms available
- Add tooltip to show entire term descriptions
- Column heading for "translations" should be the name of the language being translated
- Make modal cover entire screen (including header)

From https://zanata.atlassian.net/browse/ZNTA-758