### PR TITLE
Eliminate JS errors from functional tests

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -186,29 +186,12 @@ public class AbstractPage {
     }
 
     /**
-     * Wait for any AJAX and timeout requests to return.
-     */
-    public void waitForAbsolutePageSilence() {
-        waitForPageSilence(true);
-    }
-
-    /**
-     * Wait for any AJAX (but not timeout) requests to return.
-     */
-    public void waitForPageSilence() {
-        waitForPageSilence(false);
-    }
-
-    /**
      * Wait for any AJAX/timeout requests to return.
      */
-    private void waitForPageSilence(boolean includingTimeouts) {
-        final String script;
-        if (includingTimeouts) {
-            script = "return XMLHttpRequest.active + window.timeoutCounter";
-        } else {
-            script = "return XMLHttpRequest.active";
-        }
+    public void waitForPageSilence() {
+        // TODO wait for any short-lived timeouts to expire (eg less than 1000 ms)
+        // but not multi-second timeouts (eg global faces messages)
+        final String script = "return XMLHttpRequest.active";
         // Wait for AJAX/timeout requests to be 0
         waitForAMoment().withMessage("page silence").until(new Predicate<WebDriver>() {
             @Override

--- a/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
@@ -157,15 +157,8 @@ public enum WebDriverFactory {
      * @throws WebDriverLogException exception containing the first warning/error message, if any
      */
     public void logLogs() {
-        // TODO always throw, once we fix our tests
-        logLogs(false);
-//        logLogs(true);
-    }
-
-    @Deprecated
-    public void logLogs(boolean throwIfWarn) {
         for (String type : getLogTypes()) {
-            logLogs(type, throwIfWarn);
+            logLogs(type, true);
         }
     }
 

--- a/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
@@ -127,7 +127,7 @@ public enum WebDriverFactory {
             ++logCount;
             if (logEntry.getLevel().intValue() >= Level.SEVERE.intValue()) {
                 log.error(logEntry.toString());
-                if (throwIfWarn && firstException == null) {
+                if (firstException == null || !firstException.isErrorLog()) {
                     firstException = new WebDriverLogException(logEntry.getLevel(),
                             logEntry.toString());
                 }
@@ -154,11 +154,20 @@ public enum WebDriverFactory {
     /**
      * Dump any outstanding browser logs to the main log.
      *
-     * @throws WebDriverLogException exception containing the first warning/error message, if any
+     * @throws WebDriverLogException exception containing the first error message, if any
      */
     public void logLogs() {
+        logLogs(false);
+    }
+
+    /**
+     * Dump any outstanding browser logs to the main log.
+     *
+     * @throws WebDriverLogException exception containing the first warning/error message, if any
+     */
+    public void logLogs(boolean throwIfWarn) {
         for (String type : getLogTypes()) {
-            logLogs(type, true);
+            logLogs(type, throwIfWarn);
         }
     }
 

--- a/functional-test/src/main/java/org/zanata/page/WebDriverLogException.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverLogException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.page;
+
+import java.util.logging.Level;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+public class WebDriverLogException extends RuntimeException {
+    public WebDriverLogException(Level logLevel, String logMessage) {
+        super(logLevel + ": " + logMessage);
+    }
+}

--- a/functional-test/src/main/java/org/zanata/page/WebDriverLogException.java
+++ b/functional-test/src/main/java/org/zanata/page/WebDriverLogException.java
@@ -26,7 +26,14 @@ import java.util.logging.Level;
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
 public class WebDriverLogException extends RuntimeException {
+    private final boolean errorLog;
+
     public WebDriverLogException(Level logLevel, String logMessage) {
         super(logLevel + ": " + logMessage);
+        this.errorLog = (logLevel.intValue() >= Level.SEVERE.intValue());
+    }
+
+    public boolean isErrorLog() {
+        return errorLog;
     }
 }

--- a/functional-test/src/test/java/org/zanata/feature/testharness/ZanataTestCase.java
+++ b/functional-test/src/test/java/org/zanata/feature/testharness/ZanataTestCase.java
@@ -78,6 +78,7 @@ public class ZanataTestCase {
 
     @After
     public void testExit() {
+        WebDriverFactory.INSTANCE.logLogs();
         Duration duration = new Duration(testFunctionStart, new DateTime());
         PeriodFormatter periodFormatter = new PeriodFormatterBuilder()
                 .appendLiteral("Finished "
@@ -91,7 +92,6 @@ public class ZanataTestCase {
                 .appendSuffix("ms")
                 .toFormatter();
         log.info(periodFormatter.print(duration.toPeriod()));
-        WebDriverFactory.INSTANCE.logLogs();
     }
 
 }

--- a/zanata-war/src/main/webapp/WEB-INF/layout/project/languages-list.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/project/languages-list.xhtml
@@ -69,12 +69,14 @@
        content from ajax is present in the DOM -->
   <script type="text/javascript">
   //<![CDATA[
+  jQuery(document).ready(function () {
     // refresh checkbox facades on language lists
     zanata.form.appendCheckboxes(jQuery('##{id}').element);
     // ensure active locales filter is applied correctly after items are refreshed
     filterLocalesFromTextBox("[id='#{component.namingContainer.clientId}:#{id}-filter-input']", '##{id}-list');
     // Triggers appropriate button visibility.
     jQuery('##{id}-list').change();
+  });
   //]]>
   </script>
 

--- a/zanata-war/src/main/webapp/WEB-INF/layout/project/person-permissions-modal.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/project/person-permissions-modal.xhtml
@@ -248,15 +248,20 @@
       </div>
       <script type="text/javascript">
         //<![CDATA[
-        zanata.form.appendCheckboxes(jQuery('##{id}-content').element);
+        // zanata is undefined during doc load (but we can skip)
+        if (typeof zanata !== 'undefined') {
+          zanata.form.appendCheckboxes(jQuery('##{id}-content').element);
+        }
         //]]>
       </script>
       <ui:fragment rendered="#{projectPermissionDialog.lastMaintainerSelected() or not identity.hasPermission(projectPermissionDialog.project, 'manage-members')}">
         <script type="text/javascript">
           //<![CDATA[
-          jQuery('##{id}-project-permissions')
-                  .find(' input')
-                  .trigger('disable');
+          jQuery(document).ready(function () {
+            jQuery('##{id}-project-permissions')
+              .find(' input')
+              .trigger('disable');
+          });
           //]]>
         </script>
       </ui:fragment>
@@ -265,7 +270,7 @@
              (not needed if the user has no permission, since both are permanently disabled )-->
         <script type="text/javascript">
           //<![CDATA[
-          (function () {
+          jQuery(document).ready(function () {
             var checkboxes = jQuery('##{id}-project-permissions').find('input');
             var translationMaintainerCheckbox = checkboxes.first();
             var maintainerCheckbox = checkboxes.eq(1);
@@ -290,13 +295,13 @@
 
             // make sure the initial state is right
             refreshCheckboxDisplay();
-            })();
+          });
           //]]>
         </script>
       </ui:fragment>
       <script type="text/javascript">
         //<![CDATA[
-        (function () {
+        jQuery(document).ready(function () {
           var checkboxes = jQuery('##{id}-project-permissions').find('input');
           var translationMaintainerCheckbox = checkboxes.first();
           var maintainerCheckbox = checkboxes.eq(1);
@@ -315,7 +320,7 @@
             maintainerInfo.toggleClass('is-hidden', !isMaintainer);
             translationMaintainerInfo.toggleClass('is-hidden', isMaintainer || !isTransMaintainer);
           }
-        })();
+        });
         //]]>
       </script>
     </h:panelGroup>


### PR DESCRIPTION
Based on revised code from http://stackoverflow.com/a/4411986/14379

Also removing `setTimeout()` support: the `timeoutCounter` is not used, and
  the wrapper code is causing problems.

This should eliminate the server error during `EditHomePageTest.editPageCode` and `EditProjectAboutTest.addAboutPageDetails`: `Uncaught TypeError: func is not a function`