### PR TITLE
fix(change email): redirection to home page after email change

### DIFF
--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
@@ -42,8 +42,10 @@ public class DashboardAccountTab extends DashboardBasePage {
     public static final String EMAIL_TAKEN_ERROR =
             "This email address is already taken";
 
+    private By emailForm = By.id("email-update-form");
     private By emailField = By.id("email-update-form:emailField:input:email");
-    private By updateEmailButton = By.linkText("Update email");
+    // Use form and button tag to find the item, as its id is altered by jsf
+    private By updateEmailButton = By.tagName("button");
     private By oldPasswordField = By.id("passwordChangeForm:oldPasswordField:input:oldPassword");
     private By newPasswordField = By.id("passwordChangeForm:newPasswordField:input:newPassword");
     private By changePasswordButton = By.cssSelector("button[id^='passwordChangeForm:changePasswordButton']");
@@ -61,7 +63,7 @@ public class DashboardAccountTab extends DashboardBasePage {
 
     public DashboardAccountTab clickUpdateEmailButton() {
         log.info("Click Update Email");
-        clickElement(updateEmailButton);
+        clickElement(readyElement(emailForm).findElement(updateEmailButton));
         return new DashboardAccountTab(getDriver());
     }
 

--- a/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
+++ b/functional-test/src/main/java/org/zanata/page/dashboard/dashboardsettings/DashboardAccountTab.java
@@ -43,7 +43,7 @@ public class DashboardAccountTab extends DashboardBasePage {
             "This email address is already taken";
 
     private By emailField = By.id("email-update-form:emailField:input:email");
-    private By updateEmailButton = By.id("email-update-form:updateEmailButton");
+    private By updateEmailButton = By.linkText("Update email");
     private By oldPasswordField = By.id("passwordChangeForm:oldPasswordField:input:oldPassword");
     private By newPasswordField = By.id("passwordChangeForm:newPasswordField:input:newPassword");
     private By changePasswordButton = By.cssSelector("button[id^='passwordChangeForm:changePasswordButton']");

--- a/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/settings.xhtml
+++ b/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/settings.xhtml
@@ -64,15 +64,10 @@
                 </h:inputText>
               </zanata:decorate>
           </div>
-          <input id="updateEmailButton" type="submit"
-            value="Update email"
-            action="#{userSettingsAction.updateEmail}"
-            render="email-update-form"
-            status="update-email-loader"
-            styleClass="button" jsfc="a4j:commandButton"/>
-          <a4j:status name="update-email-loader">
-            <f:facet name="start"><zanata:loader layout="inline" type="loader--small"/></f:facet>
-          </a4j:status>
+          <zanata:ajax-command-button action="#{userSettingsAction.updateEmail()}" styleClass="button"
+            render="email-update-form" id="updateEmailButton">
+            #{msgs['jsf.UpdateEmail']}
+          </zanata:ajax-command-button>
         </h:form>
         <hr/>
         <ui:fragment rendered="#{applicationConfiguration.internalAuth}">


### PR DESCRIPTION
https://zanata.atlassian.net/browse/ZNTA-871

This will have the same issue as account activation where the message won't display but redirection works.
One of the solution I can think of is instead of using /account/validate_email/
{key} and /account/activate/{key}
to validate, use
http://localhost/zanata?validateEmail= {key}
* http://localhost/zanata?activateAccount={key}
With that, we can ensure message gets displayed properly.