### PR TITLE
fix: kerberos ticket-based authentication

### DIFF
--- a/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
+++ b/zanata-war/src/main/java/org/zanata/security/ZanataIdentity.java
@@ -185,6 +185,9 @@ public class ZanataIdentity implements Identity, Serializable {
 
     /**
      * Accepts an external subject and principal. (Use with caution)
+     * This method is used to propagate an authentication context. For
+     * example when spawing a new thread for an async task, or when
+     * authenticating externally through Kerberos.
      */
     public void acceptExternalSubjectAndPpal(Subject subject,
             Principal principal) {


### PR DESCRIPTION
With the move to CDI, using reflection to modify properties on CDI
proxied beans is not recommended. This change addresses said issue when
propagating the Kerberos authentication context onto the Zanata identity
bean.