### PR TITLE
Update DeltaSpike to 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <!-- Applies to surefire and failsafe (if enabled) -->
     <failIfNoTests>true</failIfNoTests>
 
-    <deltaspike.version>1.5.2</deltaspike.version>
+    <deltaspike.version>1.5.4</deltaspike.version>
     <cdi.runtime>runtime</cdi.runtime>
     <cdi.compile>compile</cdi.compile>
     <picketlink.version>2.5.4.SP4</picketlink.version>


### PR DESCRIPTION
This version of DeltaSpike includes an improved windowhandler.js which
preserves #fragments in URLs when a client-side dswid redirect is
triggered. Ref: https://issues.apache.org/jira/browse/DELTASPIKE-1074