### PR TITLE
test: exclude unit test inner classes from Arquillian

### DIFF
--- a/zanata-war/src/test/java/org/zanata/arquillian/Deployments.java
+++ b/zanata-war/src/test/java/org/zanata/arquillian/Deployments.java
@@ -28,12 +28,14 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.google.common.base.Joiner;
 import org.apache.deltaspike.core.api.projectstage.ProjectStage;
 import org.apache.deltaspike.core.util.ProjectStageProducer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -105,13 +107,6 @@ public class Deployments {
             // as a class file)
             return !object.get().startsWith("/org/zanata/model/") &&
                     !object.get().startsWith("/org/zanata/util/RequestContextValueStore") &&
-                    !object.get().startsWith("/org/zanata/seam/AutowireContexts") &&
-                    !object.get().startsWith("/org/zanata/seam/AutowireInstance") &&
-                    !object.get().startsWith("/org/zanata/seam/AutowireTransaction") &&
-                    !object.get().startsWith("/org/zanata/seam/FieldComponentAccessor") &&
-                    !object.get().startsWith("/org/zanata/seam/MethodComponentAccessor") &&
-                    !object.get().startsWith("/org/zanata/seam/SeamAutowire") &&
-                    !object.get().startsWith("/org/zanata/seam/test") &&
                     notUnusedGwtClientCode(object) &&
                     notUnitTest(object);
         };
@@ -143,10 +138,16 @@ public class Deployments {
 
         addRemoteHelpers(archive);
 
-        // Export (to actually see what is being deployed)
-//         archive.as(ZipExporter.class).exportTo(new
-//         File("/home/pahuang/temp/archive.war"), true);
+        // uncomment to see what will be in the war
+//        ArrayList<ArchivePath> paths =
+//                new ArrayList<>(archive.getContent().keySet());
+//        Collections.sort(paths);
+//        String contents = "  " + Joiner.on("\n  ").join(paths);
+//        System.out.println(contents);
 
+        // Export (to actually see what is being deployed)
+//        archive.as(ZipExporter.class).exportTo(
+//                 new File("/tmp/zanata-arquillian.war"), true);
         return archive;
     }
 
@@ -200,7 +201,10 @@ public class Deployments {
                 || context.contains("RestTest")
                 || context.contains("TestAsyncBean")
                 || context.contains("ResourceTestObjectFactory")
-                || !context.matches(".+Test(s)?\\.class$");
+                // unit test classes
+                || !(context.matches(".+Test(s)?\\.class$") ||
+                // inner classes of unit test classes
+                context.matches(".+Test(s)?\\$.*\\.class$"));
     }
 
     private static boolean notUnusedGwtClientCode(ArchivePath object) {


### PR DESCRIPTION
This was breaking Arquillian test deployments on WildFly, apparently triggered by commit 98016cd142303592a16348007ceee2bd8aced817 (SeamAutowire -> CDI-Unit).