### PR TITLE
chore: add scripts and docs for common dev tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Zanata is Free software, licensed under the [LGPL][].
 Developers
 ----------
 
-*Prerequisites*
+### Prerequisites
 
 You will need:
 - Java SDK 8 (OpenJDK recommended)
@@ -36,9 +36,9 @@ You will need:
 - Mysql or MariaDB
 - JBoss EAP 6 or Wildfly
 
-*Scripts*
+### Building
 
-You can use one of the scripts to build the project using maven:
+#### Quickly build a .war file
 
 [`etc/scripts/quickbuild.sh`](etc/scripts/quickbuild.sh) - Builds the project
 as quickly as possible, targeting both Firefox and Chrome when building GWT
@@ -48,6 +48,8 @@ If you wish to build GWT components for chrome or firefox only, you can specify 
 `-c` and `-f` arguments respectively.
 
 The `-h` argument prints the script's help.
+
+#### Build and run a server for testing
 
 [`etc/scripts/cargowait.sh`](etc/scripts/cargowait.sh) - Builds the Zanata artifact
 and starts a JBoss server using the cargo plugin. This script is particularly

--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ translators in seconds.
 Zanata is Free software, licensed under the [LGPL][].
 
 [LGPL]: http://www.gnu.org/licenses/lgpl-2.1.html
+
+Developers
+----------
+
+You can use one of the scripts to build the project using maven:
+
+[`etc/scripts/quickbuild.sh`](etc/scripts/quickbuild.sh) - Builds the project as quickly as possible, targeting all
+browsers in the GWT components, and skipping all checks and verifications (i.e.
+tests, checkstyle, etc)
+
+If you wish to build GWT componets for chrome or firefox, you can specify the
+`-c` and `-f` arguments respectively.
+
+The `-f` argument prints the script's help.
+
+[`etc/scripts/cargowait.sh`](etc/scripts/cargowait.sh) - Builds the Zanata artifact and starts a JBoss server using the
+cargo plugin. This script is particularly useful for quickly starting a Zanata
+instance, and for running functional tests from an IDE.

--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ Developers
 
 You can use one of the scripts to build the project using maven:
 
-[`etc/scripts/quickbuild.sh`](etc/scripts/quickbuild.sh) - Builds the project as quickly as possible, targeting all
-browsers in the GWT components, and skipping all checks and verifications (i.e.
-tests, checkstyle, etc)
+[`etc/scripts/quickbuild.sh`](etc/scripts/quickbuild.sh) - Builds the project
+as quickly as possible, targeting both Firefox and Chrome when building GWT
+components, and skipping all checks and verifications (i.e. tests, checkstyle, etc)
 
-If you wish to build GWT componets for chrome or firefox, you can specify the
+If you wish to build GWT components for chrome or firefox only, you can specify the
 `-c` and `-f` arguments respectively.
 
-The `-f` argument prints the script's help.
+The `-h` argument prints the script's help.
 
-[`etc/scripts/cargowait.sh`](etc/scripts/cargowait.sh) - Builds the Zanata artifact and starts a JBoss server using the
-cargo plugin. This script is particularly useful for quickly starting a Zanata
-instance, and for running functional tests from an IDE.
+[`etc/scripts/cargowait.sh`](etc/scripts/cargowait.sh) - Builds the Zanata artifact
+and starts a JBoss server using the cargo plugin. This script is particularly
+useful for starting a Zanata instance with the aim of running functional tests
+from an IDE.
+
+The `-h` argument prints the script's help.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Zanata is Free software, licensed under the [LGPL][].
 Developers
 ----------
 
+*Prerequisites*
+
+You will need:
+- Java SDK 8 (OpenJDK recommended)
+- npm
+- Mysql or MariaDB
+- JBoss EAP 6 or Wildfly
+
+*Scripts*
+
 You can use one of the scripts to build the project using maven:
 
 [`etc/scripts/quickbuild.sh`](etc/scripts/quickbuild.sh) - Builds the project

--- a/etc/scripts/quickbuild.sh
+++ b/etc/scripts/quickbuild.sh
@@ -2,7 +2,7 @@
 #set -x
 
 gwtMode="-Dchromefirefox"
-while getopts "cfh:" opt; do
+while getopts "cfh" opt; do
   case ${opt} in
     c)
       gwtMode="-Dchrome"

--- a/etc/scripts/quickbuild.sh
+++ b/etc/scripts/quickbuild.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#set -x
+
+while getopts "cfh:" opt; do
+  case ${opt} in
+    c)
+      gwtMode="-Dchrome"
+      echo ">> Building GWT for Google Chrome"
+      ;;
+    f)
+      gwtMode="-Dfirefox"
+      echo ">> Building GWT for Mozilla Firefox"
+      ;;
+    h)
+      echo ">> Run this script to quickly build the Zanata web archive" >&2
+      echo ">>>> -c Only build GWT components for Chrome" >&2
+      echo ">>>> -f Only build GWT components for Firefox" >&2
+      exit 0;
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1;
+      ;;
+  esac
+done
+
+DIR="$( cd -P "$( dirname "$0" )" && pwd )"
+cd $DIR/../..
+mvn -DskipArqTests -DskipUnitTests -Danimal.sniffer.skip $gwtMode -am -pl zanata-war package

--- a/etc/scripts/quickbuild.sh
+++ b/etc/scripts/quickbuild.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #set -x
 
+gwtMode="-Dchromefirefox"
 while getopts "cfh:" opt; do
   case ${opt} in
     c)

--- a/etc/scripts/quickbuild.sh
+++ b/etc/scripts/quickbuild.sh
@@ -1,22 +1,33 @@
 #!/bin/bash
 #set -x
 
+function usage {
+  echo ">> Run this script to quickly build the Zanata web archive" >&2
+  echo ">>>> -c Only build GWT components for Chrome (incompatible with -f)" >&2
+  echo ">>>> -f Only build GWT components for Firefox (incompatible with -c)" >&2
+  echo ">>>> Default GWT build is both Chrome and Firefox" >&2
+  exit 0;
+}
+
 gwtMode="-Dchromefirefox"
 while getopts "cfh" opt; do
   case ${opt} in
     c)
+      if [ $gwtMode == "-Dfirefox" ]
+        then usage
+      fi
       gwtMode="-Dchrome"
       echo ">> Building GWT for Google Chrome"
       ;;
     f)
+      if [ $gwtMode == "-Dchrome" ]
+        then usage
+      fi
       gwtMode="-Dfirefox"
       echo ">> Building GWT for Mozilla Firefox"
       ;;
     h)
-      echo ">> Run this script to quickly build the Zanata web archive" >&2
-      echo ">>>> -c Only build GWT components for Chrome" >&2
-      echo ">>>> -f Only build GWT components for Firefox" >&2
-      exit 0;
+      usage
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2


### PR DESCRIPTION
Add another script to build zanata.war and document any useful scripts which developers might use to get started or do development with Zanata.