### PR TITLE
test: back-port document.storage.directory change

### DIFF
--- a/functional-test/src/test/resources/conf/standalone.xml
+++ b/functional-test/src/test/resources/conf/standalone.xml
@@ -28,6 +28,8 @@
   </extensions>
   <system-properties>
     <property name="zanata.countAjax" value="true" />
+    <property name="document.storage.directory"
+      value="./target/documents" />
     <property name="jboss.as.management.blocking.timeout" value="1000"/>
   </system-properties>
   <management>

--- a/functional-test/src/test/resources/conf/standalone_wildfly.xml
+++ b/functional-test/src/test/resources/conf/standalone_wildfly.xml
@@ -28,6 +28,8 @@
   </extensions>
   <system-properties>
     <property name="zanata.countAjax" value="true" />
+    <property name="document.storage.directory"
+      value="./target/documents" />
     <property name="jboss.as.management.blocking.timeout" value="1000"/>
   </system-properties>
   <management>


### PR DESCRIPTION
This should help with liquibase checksum errors for changeset db.changelog-3.1.xml/damason@redhat.com/6 when running functional tests after switching between `release` and `master` branches.