### PR TITLE
fix(ZNTA-906): try catch for NullPointerException

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/LocaleServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/LocaleServiceImpl.java
@@ -22,6 +22,7 @@ package org.zanata.service.impl;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,17 +90,18 @@ public class LocaleServiceImpl implements LocaleService {
     }
 
     public static Map<LocaleId, String> getLocaleAliasesByIteration(HProjectIteration iteration) {
-        Map<LocaleId, String> localeAliases = null;
+        Map<LocaleId, String> localeAliases;
         try {
             if (iteration.isOverrideLocales()) {
                 localeAliases = iteration.getLocaleAliases();
             } else {
                 localeAliases = iteration.getProject().getLocaleAliases();
             }
+            return localeAliases;
         }catch (NullPointerException e) {
             e.printStackTrace();
         }
-        return localeAliases;
+        return Maps.newHashMap();
     }
 
     @Inject

--- a/zanata-war/src/main/java/org/zanata/service/impl/LocaleServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/LocaleServiceImpl.java
@@ -89,11 +89,15 @@ public class LocaleServiceImpl implements LocaleService {
     }
 
     public static Map<LocaleId, String> getLocaleAliasesByIteration(HProjectIteration iteration) {
-        Map<LocaleId, String> localeAliases;
-        if (iteration.isOverrideLocales()) {
-            localeAliases = iteration.getLocaleAliases();
-        } else {
-            localeAliases = iteration.getProject().getLocaleAliases();
+        Map<LocaleId, String> localeAliases = null;
+        try {
+            if (iteration.isOverrideLocales()) {
+                localeAliases = iteration.getLocaleAliases();
+            } else {
+                localeAliases = iteration.getProject().getLocaleAliases();
+            }
+        }catch (NullPointerException e) {
+            e.printStackTrace();
         }
         return localeAliases;
     }


### PR DESCRIPTION
As it is written in jira ticket https://zanata.atlassian.net/browse/ZNTA-906, somehow  a NullPointerException is occurred when viewing an iteration of a project. It seems that it is caused by "getProject()" function returning null value at this case. 

There is also a possibility to be cause by the iteration which comes null somehow. 
Apparently, this is an "exception" which we may not encounter frequently. So I reckon putting try catch block is better than controlling the iteration and getProject() value are null or not.

Also, as I wrapped if-else statement with try catch, I initialized the local variable with **null** value which I am not enough happy with.

I am not completely sure about my solution. Is there any idea?