### PR TITLE
doc(admin guide): Move admin guide in the menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,6 @@ pages:
 - Getting Started:
   - Translator Guide: 'user-guide/translator-guide.md'
   - Project Maintainer Guide: 'user-guide/project-maintainer-guide.md'
-  - System admin guide: 'user-guide/system-admin/configuration/installation.md'
 # Accounts
 - Accounts:
   - Create new account: 'user-guide/account/account-sign-up.md'


### PR DESCRIPTION
Remove additional "admin guide" link in the menu

https://zanata.atlassian.net/browse/ZNTA-1107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1172)
<!-- Reviewable:end -->
