### PR TITLE
Set lucene query execution logs to debug

### DIFF
--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
@@ -617,8 +617,6 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
 
         log.debug("Executing Lucene query: {}", textQuery.toString());
 
-        log.debug("Executing Lucene query: {}", textQuery.toString());
-
         FullTextQuery ftQuery =
                 entityManager.createFullTextQuery(textQuery, entities);
 

--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
@@ -366,7 +366,7 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
                 calculateSimilarityPercentage(transMemoryQuery,
                     textFlowContents);
             if (percent < MINIMUM_SIMILARITY) {
-                log.info("Ignoring TM - {} with less than {}% matching.",
+                log.debug("Ignoring TM - {} with less than {}% matching.",
                     textFlowContents, MINIMUM_SIMILARITY);
                 return;
             }
@@ -385,7 +385,7 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
             double percent =
                 calculateSimilarityPercentage(transMemoryQuery, sourceContents);
             if (percent < MINIMUM_SIMILARITY) {
-                log.info("Ignoring TM - {} with less than {}% matching.",
+                log.debug("Ignoring TM - {} with less than {}% matching.",
                         sourceContents, MINIMUM_SIMILARITY);
                 return;
             }
@@ -615,9 +615,9 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
                 generateQuery(query, sourceLocale, targetLocale, textFlowTargetId, queryText,
                         multiQueryText, IndexFieldLabels.TF_CONTENT_FIELDS);
 
-        log.info("Executing Lucene query: {}", textQuery.toString());
+        log.debug("Executing Lucene query: {}", textQuery.toString());
 
-        log.info("Executing Lucene query: {}", textQuery.toString());
+        log.debug("Executing Lucene query: {}", textQuery.toString());
 
         FullTextQuery ftQuery =
                 entityManager.createFullTextQuery(textQuery, entities);

--- a/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
+++ b/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
@@ -615,7 +615,7 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
                 generateQuery(query, sourceLocale, targetLocale, textFlowTargetId, queryText,
                         multiQueryText, IndexFieldLabels.TF_CONTENT_FIELDS);
 
-        log.debug("Executing Lucene query: {}", textQuery.toString());
+        log.debug("Executing Lucene query: {}", textQuery);
 
         FullTextQuery ftQuery =
                 entityManager.createFullTextQuery(textQuery, entities);


### PR DESCRIPTION
TM entity ignored output is logged every time the user moves to
another textflow. The output is for debugging purposes and may
be excessive with large texts and many users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1193)
<!-- Reviewable:end -->
