### PR TITLE
fix(ZNTA-1169): Use different default username and password

### DIFF
--- a/docs/user-guide/system-admin/configuration/installation.md
+++ b/docs/user-guide/system-admin/configuration/installation.md
@@ -16,16 +16,15 @@ The following packages are optional, but recommended:
 
  1. Download and install MySQL 5.5 from the [MySQL download page](http://dev.mysql.com/downloads/mysql/).
  Zanata has been thoroughly tested against MySQL 5.5 and the Zanata team therefore recommends that you install and use this version with Zanata.
- 
- 1. Create `zanata` user with the password `zanatapw`
- `CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'zanatapw'`
- 
- 1. Grant `zanata` user the permission
- `GRANT ALL ON zanata.* TO 'zanata'@'localhost'`
 
  1. Start MySQL service and create a database schema for Zanata.
  `CREATE DATABASE zanata /**!40100 DEFAULT CHARACTER SET utf8 **/`
- 
+
+ 1. Create `zanata` user with the password `zanatapw` and grant `zanata` user full permissions
+
+     CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'zanatapw'`
+     GRANT ALL ON zanata.* TO 'zanata'@'localhost'`
+
 
 ## Installing Zanata
 

--- a/docs/user-guide/system-admin/configuration/installation.md
+++ b/docs/user-guide/system-admin/configuration/installation.md
@@ -17,8 +17,8 @@ The following packages are optional, but recommended:
  1. Download and install MySQL 5.5 from the [MySQL download page](http://dev.mysql.com/downloads/mysql/).
  Zanata has been thoroughly tested against MySQL 5.5 and the Zanata team therefore recommends that you install and use this version with Zanata.
  
- 1. Create `zanata` user with the password `ChangeMe`
- `CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'ChangeMe'`
+ 1. Create `zanata` user with the password `zanatapw`
+ `CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'zanatapw'`
  
  1. Grant `zanata` user the permission
  `GRANT ALL ON zanata.* TO 'zanata'@'localhost'`

--- a/docs/user-guide/system-admin/configuration/installation.md
+++ b/docs/user-guide/system-admin/configuration/installation.md
@@ -18,13 +18,15 @@ The following packages are optional, but recommended:
  Zanata has been thoroughly tested against MySQL 5.5 and the Zanata team therefore recommends that you install and use this version with Zanata.
 
  1. Start MySQL service and create a database schema for Zanata.
- `CREATE DATABASE zanata /**!40100 DEFAULT CHARACTER SET utf8 **/`
+    ```sql
+    CREATE DATABASE zanata /**!40100 DEFAULT CHARACTER SET utf8 **/
+    ```
 
  1. Create `zanata` user with the password `zanatapw` and grant `zanata` user full permissions
-
-     CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'zanatapw'`
-     GRANT ALL ON zanata.* TO 'zanata'@'localhost'`
-
+    ```sql
+    CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'zanatapw'
+    GRANT ALL ON zanata.* TO 'zanata'@'localhost'
+    ```
 
 ## Installing Zanata
 

--- a/docs/user-guide/system-admin/configuration/installation.md
+++ b/docs/user-guide/system-admin/configuration/installation.md
@@ -16,9 +16,16 @@ The following packages are optional, but recommended:
 
  1. Download and install MySQL 5.5 from the [MySQL download page](http://dev.mysql.com/downloads/mysql/).
  Zanata has been thoroughly tested against MySQL 5.5 and the Zanata team therefore recommends that you install and use this version with Zanata.
+ 
+ 1. Create `zanata` user with the password `ChangeMe`
+ `CREATE USER 'zanata'@'localhost' IDENTIFIED BY 'ChangeMe'`
+ 
+ 1. Grant `zanata` user the permission
+ `GRANT ALL ON zanata.* TO 'zanata'@'localhost'`
 
  1. Start MySQL service and create a database schema for Zanata.
- `CREATE DATABASE zanata /**!40100 DEFAULT CHARACTER SET utf8 **/;`
+ `CREATE DATABASE zanata /**!40100 DEFAULT CHARACTER SET utf8 **/`
+ 
 
 ## Installing Zanata
 

--- a/zanata-overlay/common/standalone/configuration/zanata.properties
+++ b/zanata-overlay/common/standalone/configuration/zanata.properties
@@ -1,6 +1,6 @@
 # JDBC url for the Zanata database (includes host, port, schema name)
 zanata.db.url=jdbc:mysql://localhost:3306/zanata?characterEncoding=UTF-8
 # Database username
-zanata.db.username=root
+zanata.db.username=zanata
 # Database password
-zanata.db.password=
+zanata.db.password=ChangeMe

--- a/zanata-overlay/common/standalone/configuration/zanata.properties
+++ b/zanata-overlay/common/standalone/configuration/zanata.properties
@@ -3,4 +3,4 @@ zanata.db.url=jdbc:mysql://localhost:3306/zanata?characterEncoding=UTF-8
 # Database username
 zanata.db.username=zanata
 # Database password
-zanata.db.password=ChangeMe
+zanata.db.password=zanatapw


### PR DESCRIPTION
Change the zanata.properties and documentation, in order to provide an working zanata installation instruction for overlay users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1202)
<!-- Reviewable:end -->
