### PR TITLE
Enable ocpsoft-rewrite to bridge to JBoss Logging

### DIFF
--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1759,6 +1759,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.ocpsoft.logging</groupId>
+      <artifactId>logging-adapter-jboss</artifactId>
+      <version>1.0.3.Final</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
     </dependency>


### PR DESCRIPTION
Without this bridge module, the ocpsoft code seems to use JDK logging, which doesn't seem to behave as expected in the JBoss/WildFly environment (eg ERRORs are reported as SEVERE).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1206)
<!-- Reviewable:end -->
