### PR TITLE
fix(ZNTA-1132): Handle context and comment in Qt ts

### DIFF
--- a/zanata-war/src/main/java/org/zanata/file/SourceDocumentUpload.java
+++ b/zanata-war/src/main/java/org/zanata/file/SourceDocumentUpload.java
@@ -26,13 +26,13 @@ import static org.zanata.file.DocumentUploadUtil.isSinglePart;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.Collections;
 
 import javax.annotation.Nonnull;
 import javax.enterprise.context.Dependent;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.FilenameUtils;
@@ -58,6 +58,7 @@ import org.zanata.rest.StringSet;
 import org.zanata.rest.dto.ChunkUploadResponse;
 import org.zanata.rest.dto.extensions.ExtensionType;
 import org.zanata.rest.dto.extensions.comment.SimpleComment;
+import org.zanata.rest.dto.extensions.gettext.PotEntryHeader;
 import org.zanata.rest.dto.resource.Resource;
 import org.zanata.rest.service.VirusScanner;
 import org.zanata.security.ZanataIdentity;
@@ -297,7 +298,7 @@ public class SourceDocumentUpload {
             document =
                     documentServiceImpl.saveDocument(id.getProjectSlug(),
                             id.getVersionSlug(), doc,
-                            Collections.<String> emptySet(), false);
+                            Sets.newHashSet(PotEntryHeader.ID, SimpleComment.ID), false);
         } catch (SecurityException e) {
             throw new ChunkUploadException(Status.INTERNAL_SERVER_ERROR,
                     e.getMessage(), e);


### PR DESCRIPTION
File project document parsing wasn't handling context or comments in any way. This change enables that, and makes use of it for .ts files.
There didn't seem to be a way to get the comment 'part' of a TSFilter TextUnit directly, so an ISkeleton and regex sufficed.
https://zanata.atlassian.net/browse/ZNTA-1132

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1224)
<!-- Reviewable:end -->
