### PR TITLE
fix(arq): Allow Java 8 to auto allocate heap size

### DIFF
--- a/zanata-war/src/test/resources/arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian.xml
@@ -31,7 +31,7 @@
   <container qualifier="wildfly81">
     <configuration>
       <!--<property name="jbossHome">${wildfly.home}</property>-->
-      <property name="javaVmArguments">-Dorg.jboss.as.logging.per-deployment=false</property>
+      <!-- <property name="javaVmArguments">-Dorg.jboss.as.logging.per-deployment=false</property> -->
       <!-- NB: don't put whitespace around the number -->
       <property name="managementPort">${jboss.management.http.port,env.JBOSS_MANAGEMENT_HTTP_PORT:10090}</property>
     </configuration>

--- a/zanata-war/src/test/resources/arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian.xml
@@ -18,10 +18,6 @@
       <!--
                   <property name="javaVmArguments">-Xms1536m -Xmx1536m -XX:MaxPermSize=256m -Dorg.jboss.as.logging.per-deployment=false -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787</property>
       -->
-      <property
-        name="javaVmArguments">-Xms1536m -Xmx1536m -XX:MaxPermSize=256m -Dorg.jboss.as.logging.per-deployment=false
-      </property>
-
       <!-- From JBOSS_HOME/standalone/configuration -->
       <property name="serverConfig">standalone-arquillian.xml</property>
       <!--<property name="allowConnectingToRunningServer">true</property>-->
@@ -34,9 +30,6 @@
   <container qualifier="wildfly81">
     <configuration>
       <!--<property name="jbossHome">${wildfly.home}</property>-->
-      <!--<property-->
-        <!--name="javaVmArguments">-Xms1536m -Xmx1536m -XX:MaxPermSize=256m -Dorg.jboss.as.logging.per-deployment=false-->
-      <!--</property>-->
 
       <!-- NB: don't put whitespace around the number -->
       <property name="managementPort">${jboss.management.http.port,env.JBOSS_MANAGEMENT_HTTP_PORT:10090}</property>

--- a/zanata-war/src/test/resources/arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian.xml
@@ -18,6 +18,7 @@
       <!--
                   <property name="javaVmArguments">-Xms1536m -Xmx1536m -XX:MaxPermSize=256m -Dorg.jboss.as.logging.per-deployment=false -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787</property>
       -->
+      <property name="javaVmArguments">-Dorg.jboss.as.logging.per-deployment=false</property>
       <!-- From JBOSS_HOME/standalone/configuration -->
       <property name="serverConfig">standalone-arquillian.xml</property>
       <!--<property name="allowConnectingToRunningServer">true</property>-->
@@ -30,7 +31,7 @@
   <container qualifier="wildfly81">
     <configuration>
       <!--<property name="jbossHome">${wildfly.home}</property>-->
-
+      <property name="javaVmArguments">-Dorg.jboss.as.logging.per-deployment=false</property>
       <!-- NB: don't put whitespace around the number -->
       <property name="managementPort">${jboss.management.http.port,env.JBOSS_MANAGEMENT_HTTP_PORT:10090}</property>
     </configuration>


### PR DESCRIPTION
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1234)

<!-- Reviewable:end -->
