### PR TITLE
Enable IDE to run Arquillian tests

### DIFF
--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1220,7 +1220,7 @@
                 </goals>
                 <configuration>
                   <target unless="skipArqTests">
-                    <copy overwrite="true" file="${project.basedir}/src/test/resources/arquillian/standalone-arquillian-wildfly.xml" tofile="${appserver.home}/standalone/configuration/standalone.xml" />
+                    <copy overwrite="true" file="${project.basedir}/src/test/resources/arquillian/standalone-arquillian-wildfly.xml" tofile="${appserver.home}/standalone/configuration/standalone-arquillian.xml" />
                   </target>
                 </configuration>
               </execution>
@@ -1232,7 +1232,7 @@
             <configuration>
               <systemPropertyVariables>
                 <!-- NB this is a container qualifier in arquillian.xml -->
-                <arquillian.launch>wildfly81</arquillian.launch>
+                <arquillian.launch>wildfly</arquillian.launch>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/zanata-war/src/test/resources/arquillian.xml
+++ b/zanata-war/src/test/resources/arquillian.xml
@@ -28,10 +28,13 @@
       <property name="managementPort">${jboss.management.native.port,env.JBOSS_MANAGEMENT_NATIVE_PORT:10099}</property>
     </configuration>
   </container>
-  <container qualifier="wildfly81">
+  <container qualifier="wildfly" default="true">
     <configuration>
-      <!--<property name="jbossHome">${wildfly.home}</property>-->
+      <property name="jbossHome">${jboss.home}</property>
       <!-- <property name="javaVmArguments">-Dorg.jboss.as.logging.per-deployment=false</property> -->
+
+      <!-- From JBOSS_HOME/standalone/configuration -->
+      <property name="serverConfig">standalone-arquillian.xml</property>
       <!-- NB: don't put whitespace around the number -->
       <property name="managementPort">${jboss.management.http.port,env.JBOSS_MANAGEMENT_HTTP_PORT:10090}</property>
     </configuration>


### PR DESCRIPTION
1. Install WildFly somewhere, eg /path/to/wildfly-10.0.0.Final.
   This is your ${jboss.home}.
2. Copy standalone-arquillian-wildfly.xml to
   ${jboss.home}/standalone/configuration/standalone-arquillian.xml
3. Create a launch profile for desired ITCase class
4. Set VM options:
   -Djboss.home=/path/to/wildfly-10.0.0.Final # Use your ${jboss.home}
   -Darquillian.launch=wildfly # Optional: wildfly container is default
5. IntelliJ IDEA only: make sure working dir is $MODULE_DIR$
6. Run the launch profile.

Not currently working:
- EAP
- Debugging of the wildfly process

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1257)
<!-- Reviewable:end -->
