### PR TITLE
Re-enable sniffer for Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,7 @@
       Version of Java used for API compatibility checking. Should
       correspond with required.jvm.
     -->
-    <animal.sniffer.signature>java18</animal.sniffer.signature>
-
-    <!-- Not currently working for Java 1.8: https://github.com/mojohaus/animal-sniffer/issues/1 -->
-    <animal.sniffer.skip>true</animal.sniffer.skip>
+    <animal.sniffer.signature>org.codehaus.mojo.signature:java18:1.0</animal.sniffer.signature>
 
     <!--
     Not used yet.
@@ -1712,6 +1709,28 @@
             </container>
           </configuration>
         </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.15</version>
+        <executions>
+          <execution>
+            <id>animal-sniffer</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <ignores>
+            <!-- not part of java18 sig, but seems to be public API -->
+            <ignore>jdk.nashorn.api.*</ignore>
+          </ignores>
+        </configuration>
+      </plugin>
+
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${surefire.version}</version>


### PR DESCRIPTION
animal-sniffer-maven-plugin 1.15 expects animal.sniffer.signature to include the full GAV.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1264)
<!-- Reviewable:end -->