### PR TITLE
chore(editor): avoid script execution to make npm install more secure

### DIFF
--- a/zanata-frontend/pom.xml
+++ b/zanata-frontend/pom.xml
@@ -144,6 +144,7 @@
                 <argument>install</argument>
                 <argument>--cache-min</argument>
                 <argument>${npm.cache.min}</argument>
+                <argument>--ignore-scripts</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zanata-frontend/src/editor/.npmrc
+++ b/zanata-frontend/src/editor/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/zanata-frontend/src/editor/makefile
+++ b/zanata-frontend/src/editor/makefile
@@ -1,6 +1,6 @@
 # Ensure all dependencies are present at appropriate versions.
 setup:
-	npm install
+	npm install --ignore-scripts
 
 # Save the current dependency versions, including transitive dependencies
 # This is to ensure the build will use consistent dependency versions.
@@ -16,7 +16,7 @@ fakeserver:
 # Run the app on a local development server, automatically rebuild and refresh
 # when the code changes (sprites are only built at the beginning).
 watch: processhtml
-	npm run watch
+	npm run watch --ignore-scripts=false
 
 # Run a local development server backed by a fake Zanata server
 watch-fakeserver:
@@ -24,11 +24,11 @@ watch-fakeserver:
 
 # Copy index.html into /dist
 processhtml:
-	npm run processhtml
+	npm run processhtml --ignore-scripts=false
 
 # Run react-storybook server for development and testing of React components.
 storybook:
-	npm run storybook
+	npm run storybook --ignore-scripts=false
 
 # Build a static version of the React component storybook
 #  - outputs to /storybook-static
@@ -37,15 +37,15 @@ storybook:
 #    it all (only needs icons.svg at this point). Not worth the extra complexity
 #    to prevent that.
 storybook-static:
-	npm run build-storybook
+	npm run build-storybook --ignore-scripts=false
 
 # Build the css and javascript bundles using webpack.
 # Files end up as app.css and bundle.js in /app/dist
 build: processhtml
-	npm run build
+	npm run build --ignore-scripts=false
 
 # Run the tests.
 test:
-	npm test
+	npm test --ignore-scripts=false
 
 .PHONY: test build


### PR DESCRIPTION
**Migrated to  https://github.com/zanata/zanata-platform/pull/27**


This aims to prevent running npm scripts for dependencies, because that is insecure, but allow our own npm scripts to run because they are needed at the moment to run our build and development tasks.

Our scripts are specified in the `"scripts"` section of package.json.

We can turn off npm script execution completely if we replace all our npm scripts with direct invocations of the relevant binaries (generally in the `node_modules/.bin` directory).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1272)

<!-- Reviewable:end -->
