### PR TITLE
Get api .java files from 'sources' jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -687,6 +687,12 @@
         <artifactId>zanata-common-api</artifactId>
         <classifier>sources</classifier>
         <version>${zanata.api.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -682,6 +682,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.zanata</groupId>
+        <artifactId>zanata-common-api</artifactId>
+        <classifier>sources</classifier>
+        <version>${zanata.api.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.zanata</groupId>

--- a/zanata-war/pom.xml
+++ b/zanata-war/pom.xml
@@ -1410,14 +1410,18 @@
       <artifactId>zanata-common-api</artifactId>
       <exclusions>
         <exclusion>
-          <artifactId>
-            servlet-api
-          </artifactId>
-          <groupId>
-            javax.servlet
-          </groupId>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- For GWT compilation -->
+    <dependency>
+      <groupId>org.zanata</groupId>
+      <artifactId>zanata-common-api</artifactId>
+      <classifier>sources</classifier>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This will allow us to remove .java files from zanata-common-api.jar, which is causing problems for Enunciate 2.

See also https://github.com/zanata/zanata-api/pull/46

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-server/1283)
<!-- Reviewable:end -->
